### PR TITLE
MPI Dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_script:
   - KOKKOS_OPTS=( --with-hwloc=/usr --gcc-toolchain=/usr )
   - for i in ${BACKENDS}; do KOKKOS_OPTS+=( --with-${i,,[A-Z]} ); done
     # LD_LIBRARY_PATH workaround for libomp: https://github.com/travis-ci/travis-ci/issues/8613
-  - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi 
+  - if [[ ${CC} = clang ]]; then export LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH; fi
   - git clone --depth=1 https://github.com/kokkos/kokkos.git &&
     pushd kokkos &&
     mkdir build &&
     pushd build &&
     ../generate_makefile.bash --prefix=$HOME/kokkos ${KOKKOS_OPTS[@]} &&
     make -j2 &&
-    make install && 
+    make install &&
     popd &&
     popd
   - for i in ${BACKENDS}; do CMAKE_OPTS+=( -DCabana_ENABLE_${i}=ON ); done
@@ -39,11 +39,14 @@ addons:
     packages:
       - doxygen
       - libhwloc-dev
+      - openmpi-bin
+      - libopenmpi-dev
 
 script:
   - mkdir build && pushd build &&
     cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCabana_ENABLE_Serial=OFF ${CMAKE_OPTS[@]}
+          -DCabana_ENABLE_MPI=ON
           -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON
           ${COVERAGE:+-DCabana_ENABLE_COVERAGE_BUILD=ON -DCOMPILER_SUPPORTS_MARCH=OFF} .. &&
     make -j2 VERBOSE=1 &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,17 @@ if(Doxygen_FOUND)
   doxygen_add_docs(doxygen core)
 endif()
 
+option(Cabana_ENABLE_MPI "Build Cabana with MPI support" OFF)
+if(Cabana_ENABLE_MPI)
+  find_package(MPI REQUIRED)
+endif()
+
 #------------------------------------------------------------------------------#
 # Architecture
 #------------------------------------------------------------------------------#
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
   set(Cabana_BUILD_MARCH "" CACHE STRING "Arch to use with -march= (if empty CMake will try to use 'native') in release build and only release build")
-  
+
   # Try -march first. On platforms that don't support it, GCC will issue
   # a hard error, so we'll know not to use it.
   if(Cabana_BUILD_MARCH)
@@ -77,7 +82,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
   else()
     set(INTERNAL_Cabana_BUILD_MARCH "native")
   endif()
-  
+
   include(CheckCXXCompilerFlag)
   check_cxx_compiler_flag("-march=${INTERNAL_Cabana_BUILD_MARCH}" COMPILER_SUPPORTS_MARCH)
   if(COMPILER_SUPPORTS_MARCH)
@@ -87,7 +92,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
   else()
     unset(INTERNAL_Cabana_BUILD_MARCH)
   endif()
-  
+
   option(Cabana_ENABLE_COVERAGE_BUILD "Do a coverage build" OFF)
   if(Cabana_ENABLE_COVERAGE_BUILD)
       message(STATUS "Enabling coverage build")

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -19,4 +19,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CabanaCore_config.hpp DESTINATION ${CM
 add_library(cabanacore ${SOURCES} ${SOURCES} ${SOURCES_IMPL})
 target_include_directories(cabanacore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(cabanacore Kokkos::kokkos)
+if(Cabana_ENABLE_MPI)
+  target_link_libraries(cabanacore MPI::MPI_CXX)
+endif()
 install(TARGETS cabanacore LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Adds an optional MPI dependency to the build and open-mpi to the Travis CI. This PR has no code that uses MPI - just adds the library and test infrastructure.