### PR TITLE
finding kokkos from within a trilinos install

### DIFF
--- a/cmake/FindKOKKOS.cmake
+++ b/cmake/FindKOKKOS.cmake
@@ -13,7 +13,7 @@ pkg_check_modules(PC_KOKKOS kokkos QUIET)
 find_path(KOKKOS_SETTINGS_DIR kokkos_generated_settings.cmake HINTS ${PC_KOKKOS_PREFIX})
 
 find_path(KOKKOS_INCLUDE_DIR Kokkos_Core.hpp HINTS ${PC_KOKKOS_INCLUDE_DIRS})
-find_library(KOKKOS_LIBRARY NAMES kokkos HINTS ${PC_KOKKOS_LIBRARY_DIRS})
+find_library(KOKKOS_LIBRARY NAMES kokkos kokkoscore HINTS ${PC_KOKKOS_LIBRARY_DIRS})
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set KOKKOS_FOUND to TRUE


### PR DESCRIPTION
The trilinos-based install of kokkos creates a 'kokkoscore' lib but no 'kokkos' lib.

With this change I successfully built cabana against the trilinos-based kokkos install and the stand alone kokkos install.