### PR TITLE
Remove Kokkos Aliases in Tutorials

### DIFF
--- a/core/example/tutorial/04_aosoa/aosoa_example.cpp
+++ b/core/example/tutorial/04_aosoa/aosoa_example.cpp
@@ -55,14 +55,14 @@ void aosoaExample()
       allocated. In this example we are writing basic loops that will execute
       on the CPU. The HostSpace allocates memory in standard CPU RAM.
 
-      Cabana also supports execution on NVIDIA GPUs. To create an AoSoA
-      allocated with CUDA Unified Virtual Memory (UVM) use
-      `Cabana::CudaUVMSpace` instead of `Cabana::HostSpace`. The CudaUVMSpace
+      Kokkos also supports execution on NVIDIA GPUs. For example, to create an
+      AoSoA allocated with CUDA Unified Virtual Memory (UVM) use
+      `Kokkos::CudaUVMSpace` instead of `Kokkos::HostSpace`. The CudaUVMSpace
       allocates memory in managed GPU memory via `cudaMallocManaged`. This
       memory is automatically paged between host and device depending on the
       context in which the memory is accessed.
     */
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA. We define how many tuples the aosoa will

--- a/core/example/tutorial/05_slice/slice_example.cpp
+++ b/core/example/tutorial/05_slice/slice_example.cpp
@@ -60,14 +60,14 @@ void sliceExample()
       allocated. In this example we are writing basic loops that will execute
       on the CPU. The HostSpace allocates memory in standard CPU RAM.
 
-      Cabana also supports execution on NVIDIA GPUs. To create an AoSoA
+      Kokkos also supports execution on NVIDIA GPUs. To create an AoSoA
       allocated with CUDA Unified Virtual Memory (UVM) use
-      `Cabana::CudaUVMSpace` instead of `Cabana::HostSpace`. The CudaUVMSpace
+      `Kokkos::CudaUVMSpace` instead of `Kokkos::HostSpace`. The CudaUVMSpace
       allocates memory in managed GPU memory via `cudaMallocManaged`. This
       memory is automatically paged between host and device depending on the
       context in which the memory is accessed.
     */
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA. We define how many tuples the aosoa will

--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -46,14 +46,14 @@ void deepCopyExample()
       AoSoA.
     */
     const int SrcVectorLength = 8;
-    using SrcMemorySpace = Cabana::HostSpace;
+    using SrcMemorySpace = Kokkos::HostSpace;
 
     /*
       Declare the vector length and memory space parameters of the destination
       AoSoA.
     */
     const int DstVectorLength = 32;
-    using DstMemorySpace = Cabana::CudaUVMSpace;
+    using DstMemorySpace = Kokkos::CudaUVMSpace;
 
     /*
        Create the source and destination AoSoAs.

--- a/core/example/tutorial/07_sorting/sorting.cpp
+++ b/core/example/tutorial/07_sorting/sorting.cpp
@@ -39,7 +39,7 @@ void sortingExample()
       and member type configurations are compatible with sorting.
     */
     const int VectorLength = 4;
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA.

--- a/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
+++ b/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
@@ -45,7 +45,7 @@ void linkedCellListExample()
       and member type configurations are compatible with sorting.
     */
     const int VectorLength = 8;
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA.

--- a/core/example/tutorial/09_verlet_list/verlet_list.cpp
+++ b/core/example/tutorial/09_verlet_list/verlet_list.cpp
@@ -39,7 +39,7 @@ void verletListExample()
       and member type configurations are compatible with sorting.
     */
     const int VectorLength = 8;
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA.

--- a/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
+++ b/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
@@ -47,7 +47,7 @@ void atomicSliceExample()
     */
     using DataTypes = Cabana::MemberTypes<double>;
     const int VectorLength = 32;
-    using MemorySpace = Cabana::CudaUVMSpace;
+    using MemorySpace = Kokkos::CudaUVMSpace;
 
     /*
        Create the AoSoA. Just put a single value to demonstrate the atomic.

--- a/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
+++ b/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
@@ -31,7 +31,7 @@ void atomicSliceExample()
     */
     using DataTypes = Cabana::MemberTypes<double>;
     const int VectorLength = 8;
-    using MemorySpace = Cabana::HostSpace;
+    using MemorySpace = Kokkos::HostSpace;
 
     /*
        Create the AoSoA. Just put a single value to demonstrate the atomic.


### PR DESCRIPTION
We want our users to not use our old aliases of Kokkos concepts. They are still there for now but changing them in the tutorial will signal to new users that they should use kokkos memory spaces.