### PR TITLE
cleaning warnings from -Wall and -Wextra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: cpp
 sudo: required
 
 env:
+  global:
+    - CCACHE_CPP2=yes # for clang
   matrix:
     - BACKENDS="OpenMP" WERROR=ON
     - BACKENDS="Serial" WERROR=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: cpp
 sudo: required
 
 env:
-  global:
-    - CXXFLAGS="-Wall -Wextra -Werror -pedantic"
   matrix:
     - BACKENDS="OpenMP"
     - BACKENDS="Serial"
@@ -45,6 +43,7 @@ addons:
       - libopenmpi-dev
 
 script:
+  - export CXXFLAGS="-Wall -Wextra -Werror -pedantic"
   - mkdir build && pushd build &&
     cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCabana_ENABLE_Serial=OFF ${CMAKE_OPTS[@]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: cpp
 sudo: required
 
 env:
+  global:
+    - CXXFLAGS="-Wall -Wextra -Werror -pedantic"
   matrix:
     - BACKENDS="OpenMP"
     - BACKENDS="Serial"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
       - libopenmpi-dev
 
 script:
-  - export CXXFLAGS="-Wall -Wextra -pedantic ${COVERAGE+:-Werror}"
+  - export CXXFLAGS="-Wall -Wextra -pedantic ${COVERAGE:+-Werror}"
   - mkdir build && pushd build &&
     cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCabana_ENABLE_Serial=OFF ${CMAKE_OPTS[@]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
       - libopenmpi-dev
 
 script:
-  - export CXXFLAGS="-Wall -Wextra -Werror -pedantic"
+  - export CXXFLAGS="-Wall -Wextra -pedantic ${COVERAGE+:-Werror}"
   - mkdir build && pushd build &&
     cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCabana_ENABLE_Serial=OFF ${CMAKE_OPTS[@]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ sudo: required
 
 env:
   matrix:
-    - BACKENDS="OpenMP"
-    - BACKENDS="Serial"
-    - BACKENDS="Pthread"
-    - BACKENDS="Serial OpenMP"
-    - BACKENDS="Serial Pthread"
+    - BACKENDS="OpenMP" WERROR=ON
+    - BACKENDS="Serial" WERROR=ON
+    - BACKENDS="Pthread" WERROR=ON
+    - BACKENDS="Serial OpenMP" WERROR=ON
+    - BACKENDS="Serial Pthread" WERROR=ON
     - BACKENDS="OpenMP" COVERAGE=ON
     - BACKENDS="Serial" COVERAGE=ON
     - BACKENDS="Pthread" COVERAGE=ON
@@ -43,7 +43,7 @@ addons:
       - libopenmpi-dev
 
 script:
-  - export CXXFLAGS="-Wall -Wextra -pedantic ${COVERAGE:+-Werror}"
+  - export CXXFLAGS="-Wall -Wextra -pedantic ${WERROR:+-Werror}"
   - mkdir build && pushd build &&
     cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos
           -DCabana_ENABLE_Serial=OFF ${CMAKE_OPTS[@]}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,14 +93,14 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
   else()
     unset(INTERNAL_Cabana_BUILD_MARCH)
   endif()
+endif()
 
-  option(Cabana_ENABLE_COVERAGE_BUILD "Do a coverage build" OFF)
-  if(Cabana_ENABLE_COVERAGE_BUILD)
+option(Cabana_ENABLE_COVERAGE_BUILD "Do a coverage build" OFF)
+if(Cabana_ENABLE_COVERAGE_BUILD)
       message(STATUS "Enabling coverage build")
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -O0")
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
       set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
-  endif()
 endif()
 
 ##---------------------------------------------------------------------------##

--- a/core/example/tutorial/04_aosoa/aosoa_example.cpp
+++ b/core/example/tutorial/04_aosoa/aosoa_example.cpp
@@ -90,7 +90,7 @@ void aosoaExample()
       2-dimensional tuple indices. Start by looping over the SoA's. The SoA
       index is the first tuple index:
     */
-    for ( int s = 0; s < aosoa.numSoA(); ++s )
+    for ( std::size_t s = 0; s < aosoa.numSoA(); ++s )
     {
         /*
            Get a reference the SoA we are working on. The aosoa access()

--- a/core/example/tutorial/05_slice/slice_example.cpp
+++ b/core/example/tutorial/05_slice/slice_example.cpp
@@ -98,7 +98,7 @@ void sliceExample()
       accessing the total number of tuples in the data structure and the array
       sizes.
     */
-    for ( int s = 0; s < slice_0.numSoA(); ++s )
+    for ( std::size_t s = 0; s < slice_0.numSoA(); ++s )
     {
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )

--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -65,7 +65,7 @@ void deepCopyExample()
     /*
       Put some data in the source AoSoA.
     */
-    for ( int s = 0; s < src_aosoa.numSoA(); ++s )
+    for ( std::size_t s = 0; s < src_aosoa.numSoA(); ++s )
     {
         auto& soa = src_aosoa.access(s);
 

--- a/core/example/tutorial/07_sorting/sorting.cpp
+++ b/core/example/tutorial/07_sorting/sorting.cpp
@@ -54,7 +54,7 @@ void sortingExample()
     */
     int forward_index_counter = 0;
     int reverse_index_counter = 100;
-    for ( int s = 0; s < aosoa.numSoA(); ++s )
+    for ( std::size_t s = 0; s < aosoa.numSoA(); ++s )
     {
         auto& soa = aosoa.access(s);
 

--- a/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
+++ b/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
@@ -66,7 +66,7 @@ void linkedCellListExample()
       Create the particle ids.
     */
     auto ids = aosoa.slice<1>();
-    for ( int i = 0; i < aosoa.size(); ++i )
+    for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
     /*
       Create the particle coordinates. We will put 2 particles in the center
@@ -117,7 +117,7 @@ void linkedCellListExample()
        still valid as long as we haven't resized, changes the capacity, or
        otherwise changed the memory associated with the AoSoA.
      */
-    for ( int i = 0; i < aosoa.size(); ++i )
+    for ( std::size_t i = 0; i < aosoa.size(); ++i )
         std::cout << "Particle: id = " << ids(i)
                   << ", coords (" << positions(i,0) << ","
                   << positions(i,1) << "," << positions(i,2) << ")"

--- a/core/example/tutorial/09_verlet_list/verlet_list.cpp
+++ b/core/example/tutorial/09_verlet_list/verlet_list.cpp
@@ -60,7 +60,7 @@ void verletListExample()
       Create the particle ids.
     */
     auto ids = aosoa.slice<1>();
-    for ( int i = 0; i < aosoa.size(); ++i )
+    for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
     /*
       Create the particle coordinates. We will put 3 particles in the center
@@ -130,7 +130,7 @@ void verletListExample()
       memory space of the neighbor list. Each particle should have 2
       neighbors.
      */
-    for ( int i = 0; i < aosoa.size(); ++i )
+    for ( std::size_t i = 0; i < aosoa.size(); ++i )
     {
         int num_n = Cabana::NeighborList<ListType>::numNeighbor(verlet_list,i);
         std::cout << "Particle " << i << " # neighbor = " << num_n << std::endl;

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -65,7 +65,7 @@ class LinkedCellList
                  grid_max[0], grid_max[1], grid_max[2],
                  grid_delta[0], grid_delta[1], grid_delta[2] )
     {
-        build( positions, 0, positions.size(), grid_delta, grid_min, grid_max );
+        build( positions, 0, positions.size() );
     }
 
     /*!
@@ -98,7 +98,7 @@ class LinkedCellList
                  grid_max[0], grid_max[1], grid_max[2],
                  grid_delta[0], grid_delta[1], grid_delta[2] )
     {
-        build( positions, begin, end, grid_delta, grid_min, grid_max );
+        build( positions, begin, end );
     }
 
     /*!
@@ -208,10 +208,7 @@ class LinkedCellList
     template<class SliceType>
     void build( SliceType positions,
                 const std::size_t begin,
-                const std::size_t end,
-                const typename SliceType::value_type grid_delta[3],
-                const typename SliceType::value_type grid_min[3],
-                const typename SliceType::value_type grid_max[3] )
+                const std::size_t end )
     {
         // Allocate the binning data. Note that the permutation vector spans
         // only the length of begin-end;

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -269,10 +269,9 @@ struct ViewOffset<Dimension,Kokkos::LayoutCabanaSlice<LayoutDims...>,void>
     template< class DimRHS , class LayoutRHS >
     KOKKOS_INLINE_FUNCTION
     constexpr ViewOffset
-    ( const ViewOffset< DimRHS , LayoutRHS , void > & rhs
+    ( const ViewOffset< DimRHS , LayoutRHS , void > &
       , const SubviewExtents< DimRHS::rank , dimension_type::rank > & sub
         )
-        // range_extent(r) returns 0 when dimension_type::rank <= r
         : m_dim( sub.range_extent(0)
                  , sub.range_extent(1)
                  , sub.range_extent(2)

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -172,7 +172,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     */
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    constexpr int rank() const
+    constexpr unsigned rank() const
     {
         return std::rank<member_data_type<M> >::value;
     }
@@ -188,7 +188,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     */
     template<std::size_t M, std::size_t D>
     KOKKOS_FORCEINLINE_FUNCTION
-    constexpr int extent() const
+    constexpr std::size_t extent() const
     {
         return std::extent<member_data_type<M>,D>::value;
     }

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -159,8 +159,8 @@ struct VerletListBuilder
     // Constructor.
     VerletListBuilder(
         PositionSlice slice,
-        const std::size_t begin,
-        const std::size_t end,
+        const std::size_t, // begin - FIXME (see GitHub issue #54),
+        const std::size_t, // end - FIXME (see GitHub issue #54),
         const PositionValueType neighborhood_radius,
         const PositionValueType cell_size_ratio,
         const PositionValueType grid_min[3],

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -38,9 +38,9 @@ class NeighborDiscriminator<FullNeighborTag>
     // "p" is not the same as the neighbor index "n").
     KOKKOS_INLINE_FUNCTION
     static bool isValid( const std::size_t p,
-                         const double xp, const double yp, const double zp,
+                         const double, const double, const double,
                          const std::size_t n,
-                         const double xn, const double yn, const double zn )
+                         const double, const double, const double )
     {
         return ( p != n );
     }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -6,8 +6,13 @@ endif()
 set(GTEST_SOURCE_DIR ${CMAKE_SOURCE_DIR}/gtest)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_PTHREAD=0")
 
-include_directories(SYSTEM ${GTEST_SOURCE_DIR})
+include_directories(${GTEST_SOURCE_DIR})
 add_library(cabana_core_gtest ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc)
+set_target_properties(cabana_core_gtest PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+    )
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 set(GTEST_SOURCE_DIR ${CMAKE_SOURCE_DIR}/gtest)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_PTHREAD=0")
 
-include_directories(${GTEST_SOURCE_DIR})
+include_directories(SYSTEM ${GTEST_SOURCE_DIR})
 add_library(cabana_core_gtest ${GTEST_SOURCE_DIR}/gtest/gtest-all.cc)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/core/unit_test/tstCommunicationPlan.hpp
+++ b/core/unit_test/tstCommunicationPlan.hpp
@@ -296,7 +296,7 @@ void test4( const bool use_topology )
 
     // self sends - we don't know which order the self sends are in but we
     // know they are the first 2.
-    if ( my_rank == host_steering(0) )
+    if ( my_rank == (int) host_steering(0) )
     {
         EXPECT_EQ( host_steering(0), my_rank );
         EXPECT_EQ( host_steering(1), my_rank + my_size );
@@ -327,7 +327,7 @@ void test4( const bool use_topology )
         }
         else
         {
-            if ( n == host_steering(2*n) )
+            if ( n == (int) host_steering(2*n) )
             {
                 EXPECT_EQ( host_steering(2*n), n );
                 EXPECT_EQ( host_steering(2*n+1), n + my_size );

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -540,7 +540,7 @@ void test6( const bool use_topology )
     auto steering = distributor->getExportSteering();
     auto host_steering = Kokkos::create_mirror_view_and_copy(
         Kokkos::HostSpace(), steering );
-    for ( int i = 0; i < distributor->totalNumImport(); ++i )
+    for ( std::size_t i = 0; i < distributor->totalNumImport(); ++i )
     {
         EXPECT_EQ( slice_int_host(i), distributor->neighborRank(i) );
         EXPECT_EQ( slice_dbl_host(i,0), distributor->neighborRank(i) );

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -117,16 +117,13 @@ struct TestNeighborList
 // Create particles.
 Cabana::AoSoA<Cabana::MemberTypes<double[3]>,TEST_MEMSPACE>
 createParticles( const int num_particle,
-                 const double neighborhood_radius,
                  const double box_min,
                  const double box_max )
 {
-    // Create the AoSoA with (100x100x100) particles.
     using DataTypes = Cabana::MemberTypes<double[3]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t aosoa( num_particle );
 
-    // Create particles within a region sized (10x10x10) neighborhood radii.
     auto position = aosoa.slice<0>();
     using PoolType = Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE>;
     using RandomType = Kokkos::Random_XorShift64<TEST_EXECSPACE>;
@@ -313,8 +310,7 @@ void testVerletListFull()
     double cell_size_ratio = 0.5;
     double box_min = -5.3 * test_radius;
     double box_max = 4.7 * test_radius;
-    auto aosoa =
-        createParticles( num_particle, test_radius, box_min, box_max );
+    auto aosoa = createParticles( num_particle, box_min, box_max );
 
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };
@@ -337,8 +333,7 @@ void testVerletListHalf()
     double cell_size_ratio = 0.5;
     double box_min = -5.3 * test_radius;
     double box_max = 4.7 * test_radius;
-    auto aosoa =
-        createParticles( num_particle, test_radius, box_min, box_max );
+    auto aosoa = createParticles( num_particle, box_min, box_max );
 
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };
@@ -361,9 +356,7 @@ void testNeighborParallelFor()
     double cell_size_ratio = 0.5;
     double box_min = -5.3 * test_radius;
     double box_max = 4.7 * test_radius;
-    auto aosoa =
-        createParticles( num_particle, test_radius, box_min, box_max );
-    using aosoa_t = decltype(aosoa);
+    auto aosoa = createParticles( num_particle, box_min, box_max );
 
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -31,7 +31,7 @@ void checkDataMembers(
     auto slice_2 = aosoa.template slice<2>();
     auto slice_3 = aosoa.template slice<3>();
 
-    for ( std::size_t idx = begin; idx != end; ++idx )
+    for ( int idx = begin; idx != end; ++idx )
     {
         // Member 0.
         for ( int i = 0; i < dim_1; ++i )

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -320,7 +320,7 @@ void atomicAccessTest()
     // Have every thread increment all elements of the slice. This should
     // create contention in parallel without the atomic.
     auto increment_op =
-        KOKKOS_LAMBDA( const int i )
+        KOKKOS_LAMBDA( const int )
         {
             for ( int j = 0; j < num_data; ++j ) atomic_slice( j ) += 1;
         };


### PR DESCRIPTION
Just a note that the following warning was fixed by commenting out the 2 variable names:
```
/Users/uy7/software/Cabana/core/src/Cabana_VerletList.hpp:163:27: warning: unused parameter 'begin' [-Wunused-parameter]
        const std::size_t begin,
                          ^
/Users/uy7/software/Cabana/core/src/Cabana_VerletList.hpp:164:27: warning: unused parameter 'end' [-Wunused-parameter]
        const std::size_t end,
                          ^
2 warnings generated.
```
this is directly related to #54.

Also adding stronger warnings and warnings as errors to the CI build.