### PR TITLE
Remove use of Kokkos macro aliases

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -16,7 +16,6 @@
 #include <Cabana_Slice.hpp>
 #include <Cabana_Tuple.hpp>
 #include <Cabana_Types.hpp>
-#include <Cabana_Macros.hpp>
 #include <Cabana_SoA.hpp>
 #include <impl/Cabana_Index.hpp>
 #include <impl/Cabana_PerformanceTraits.hpp>
@@ -147,7 +146,7 @@ class AoSoA
       This is the number of actual objects held in the container, which is not
       necessarily equal to its storage capacity.
     */
-    CABANA_FUNCTION
+    KOKKOS_FUNCTION
     std::size_t size() const { return _size; }
 
     /*!
@@ -167,7 +166,7 @@ class AoSoA
       The capacity of a container can be explicitly altered by calling member
       reserve.
     */
-    CABANA_FUNCTION
+    KOKKOS_FUNCTION
     std::size_t capacity() const { return _capacity; }
 
     /*!
@@ -236,7 +235,7 @@ class AoSoA
 
       \return The number of structs-of-arrays in the container.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t numSoA() const { return _num_soa; }
 
     /*!
@@ -247,7 +246,7 @@ class AoSoA
       \return The size of the array at the given struct index.
     */
     template<typename S>
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     typename std::enable_if<std::is_integral<S>::value,int>::type
     arraySize( const S& s ) const
     {
@@ -263,7 +262,7 @@ class AoSoA
       \return The SoA reference at the given index.
     */
     template<typename S>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<std::is_integral<S>::value,soa_type&>::type
     access( const S& s ) const
     { return _data(s); }
@@ -276,7 +275,7 @@ class AoSoA
       \return A tuple containing a deep copy of the data at the given index.
     */
     template<typename I>
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     typename std::enable_if<std::is_integral<I>::value,tuple_type>::type
     getTuple( const I& i ) const
     {
@@ -293,7 +292,7 @@ class AoSoA
       \param tuple The tuple to get the data from.
     */
     template<typename I>
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     typename std::enable_if<std::is_integral<I>::value,void>::type
     setTuple( const I& i,
               const tuple_type& tpl ) const

--- a/core/src/Cabana_ExecutionPolicy.hpp
+++ b/core/src/Cabana_ExecutionPolicy.hpp
@@ -12,7 +12,6 @@
 #ifndef CABANA_EXECUTIONPOLICY_HPP
 #define CABANA_EXECUTIONPOLICY_HPP
 
-#include <Cabana_Macros.hpp>
 #include <impl/Cabana_Index.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -14,7 +14,6 @@
 
 #include <Cabana_Sort.hpp>
 #include <Cabana_Slice.hpp>
-#include <Cabana_Macros.hpp>
 #include <impl/Cabana_CartesianGrid.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -106,7 +105,7 @@ class LinkedCellList
       \brief Get the total number of bins.
       \return the total number of bins.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     int totalBins() const
     { return _grid.totalNumCells(); }
 
@@ -115,7 +114,7 @@ class LinkedCellList
       \param dim The dimension to get the number of bins for.
       \return The number of bins.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     int numBin( const int dim ) const
     { return _grid.numBin(dim); }
 
@@ -129,7 +128,7 @@ class LinkedCellList
       Note that the Kokkos sort orders the bins such that the i index moves
       the slowest and the k index mvoes the fastest.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     size_type cardinalBinIndex( const int i, const int j, const int k ) const
     { return _grid.cardinalCellIndex(i,j,k); }
 
@@ -143,7 +142,7 @@ class LinkedCellList
       Note that the Kokkos sort orders the bins such that the i index moves
       the slowest and the k index mvoes the fastest.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     void ijkBinIndex( const int cardinal, int& i, int& j, int& k ) const
     {
         _grid.ijkBinIndex( cardinal, i, j, k );
@@ -156,7 +155,7 @@ class LinkedCellList
       \param k The k bin index (z).
       \return The number of particles in the bin.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     int binSize( const int i, const int j, const int k ) const
     { return _bin_data.binSize(cardinalBinIndex(i,j,k)); }
 
@@ -167,7 +166,7 @@ class LinkedCellList
       \param k The k bin index (z).
       \return The starting particle index of the bin.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     size_type binOffset( const int i, const int j, const int k ) const
     { return _bin_data.binOffset(cardinalBinIndex(i,j,k)); }
 
@@ -177,21 +176,21 @@ class LinkedCellList
       \param particle_id The id of the particle in the binned layout.
       \return The particle id in the old (unbinned) layout.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     size_type permutation( const int particle_id ) const
     { return _bin_data.permutation(particle_id); }
 
     /*!
       \brief The beginning particle index binned by the linked cell list.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t rangeBegin() const
     { return _bin_data.rangeBegin(); }
 
     /*!
       \brief The ending particle index binned by the linked cell list.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t rangeEnd() const
     { return _bin_data.rangeEnd(); }
 

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -12,8 +12,6 @@
 #ifndef CABANA_NEIGHBORLIST_HPP
 #define CABANA_NEIGHBORLIST_HPP
 
-#include <Cabana_Macros.hpp>
-
 #include <Kokkos_Core.hpp>
 
 namespace Cabana
@@ -59,13 +57,13 @@ class NeighborList
     using TypeTag = typename NeighborListType::TypeTag;
 
     // Get the number of neighbors for a given particle index.
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     static int numNeighbor( const NeighborListType& list,
                             const std::size_t particle_index );
 
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     static int getNeighbor( const NeighborListType& list,
                             const std::size_t particle_index,
                             const int neighbor_index );

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -13,7 +13,6 @@
 #define CABANA_SLICE_HPP
 
 #include <Cabana_Types.hpp>
-#include <Cabana_Macros.hpp>
 #include <impl/Cabana_Index.hpp>
 #include <impl/Cabana_TypeTraits.hpp>
 
@@ -540,7 +539,7 @@ class Slice
       \brief Returns the total number tuples in the slice.
       \return The number of tuples in the slice.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t size() const
     { return _size; }
 
@@ -548,7 +547,7 @@ class Slice
       \brief Get the number of structs-of-arrays in the container.
       \return The number of structs-of-arrays in the container.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t numSoA() const { return _view.extent(0); }
 
     /*!
@@ -557,7 +556,7 @@ class Slice
       \return The size of the array at the given struct index.
     */
     template<typename S>
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     typename std::enable_if<std::is_integral<S>::value,int>::type
     arraySize( const S& s ) const
     {
@@ -572,7 +571,7 @@ class Slice
     template<typename S,
              typename A,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(0==std::rank<U>::value &&
                              std::is_integral<S>::value &&
                              std::is_integral<A>::value &&
@@ -587,7 +586,7 @@ class Slice
              typename A,
              typename D0,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(1==std::rank<U>::value &&
                              std::is_integral<S>::value &&
                              std::is_integral<A>::value &&
@@ -605,7 +604,7 @@ class Slice
              typename D0,
              typename D1,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(2==std::rank<U>::value &&
                              std::is_integral<S>::value &&
                              std::is_integral<A>::value &&
@@ -626,7 +625,7 @@ class Slice
              typename D1,
              typename D2,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(3==std::rank<U>::value &&
                              std::is_integral<S>::value &&
                              std::is_integral<A>::value &&
@@ -648,7 +647,7 @@ class Slice
     // Rank 0
     template<typename I,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(0==std::rank<U>::value &&
                              std::is_integral<I>::value &&
                              std::is_same<U,DataType>::value),
@@ -660,7 +659,7 @@ class Slice
     template<typename I,
              typename D0,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(1==std::rank<U>::value &&
                              std::is_integral<I>::value &&
                              std::is_integral<D0>::value &&
@@ -675,7 +674,7 @@ class Slice
              typename D0,
              typename D1,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(2==std::rank<U>::value &&
                              std::is_integral<I>::value &&
                              std::is_integral<D0>::value &&
@@ -693,7 +692,7 @@ class Slice
              typename D1,
              typename D2,
              typename U = DataType>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(3==std::rank<U>::value &&
                              std::is_integral<I>::value &&
                              std::is_integral<D0>::value &&
@@ -714,7 +713,7 @@ class Slice
       \brief Get a raw pointer to the data for this member
       \return A raw pointer to the data for this slice.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     pointer_type data() const
     { return _view.data(); }
 
@@ -724,7 +723,7 @@ class Slice
       dimensions.
       \return The rank of the data for this slice.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     constexpr int rank() const
     { return _view.Rank; }
 
@@ -735,7 +734,7 @@ class Slice
       \param d The member data dimension to get the extent for.
       \return The extent of the given member data dimension.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t extent( const std::size_t d ) const
     { return _view.extent(d); }
 
@@ -745,7 +744,7 @@ class Slice
       \param d The member data dimension to get the stride for.
       \return The stride of the given member data dimension.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t stride( const std::size_t d ) const
     { return _view.stride(d); }
 

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -12,7 +12,6 @@
 #ifndef CABANA_SOA_HPP
 #define CABANA_SOA_HPP
 
-#include <Cabana_Macros.hpp>
 #include <impl/Cabana_IndexSequence.hpp>
 #include <Cabana_MemberTypes.hpp>
 
@@ -172,7 +171,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
       \return The rank of the given member index data.
     */
     template<std::size_t M>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     constexpr int rank() const
     {
         return std::rank<member_data_type<M> >::value;
@@ -188,7 +187,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
       \return The extent of the dimension.
     */
     template<std::size_t M, std::size_t D>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     constexpr int extent() const
     {
         return std::extent<member_data_type<M>,D>::value;
@@ -200,7 +199,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     // Rank 0
     template<std::size_t M,
              typename A>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(0==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value),
                             member_reference_type<M> >::type
@@ -212,7 +211,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
 
     template<std::size_t M,
              typename A>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(0==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value),
                             member_value_type<M> >::type
@@ -226,7 +225,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     template<std::size_t M,
              typename A,
              typename D0>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(1==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value),
@@ -241,7 +240,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     template<std::size_t M,
              typename A,
              typename D0>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(1==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value),
@@ -258,7 +257,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
              typename A,
              typename D0,
              typename D1>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(2==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value &&
@@ -276,7 +275,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
              typename A,
              typename D0,
              typename D1>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(2==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value &&
@@ -296,7 +295,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
              typename D0,
              typename D1,
              typename D2>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(3==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value &&
@@ -317,7 +316,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
              typename D0,
              typename D1,
              typename D2>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<(3==std::rank<member_data_type<M> >::value &&
                              std::is_integral<A>::value &&
                              std::is_integral<D0>::value &&

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -15,7 +15,6 @@
 #include <Cabana_AoSoA.hpp>
 #include <Cabana_Slice.hpp>
 #include <Cabana_DeepCopy.hpp>
-#include <Cabana_Macros.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp>
@@ -62,7 +61,7 @@ class BinningData
       \brief Get the number of bins.
       \return The number of bins.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     int numBin() const
     { return _nbin; }
 
@@ -71,7 +70,7 @@ class BinningData
       \param bin_id The bin id.
       \return The number of tuples in the bin.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     int binSize( const size_type bin_id ) const
     { return _counts( bin_id ); }
 
@@ -80,7 +79,7 @@ class BinningData
       \param bin_id The bin id.
       \return The starting tuple index of the bin.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     size_type binOffset( const size_type bin_id ) const
     { return _offsets( bin_id ); }
 
@@ -88,21 +87,21 @@ class BinningData
       \brief Given a local tuple id in the binned layout, get the id of the
       tuple in the old (unbinned) layout.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     size_type permutation( const size_type tuple_id ) const
     { return _permute_vector(tuple_id); }
 
     /*!
       \brief The beginning tuple index in the binning.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t rangeBegin() const
     { return _begin; }
 
     /*!
       \brief The ending tuple index in the binning.
     */
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     std::size_t rangeEnd() const
     { return _end; }
 

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -14,7 +14,6 @@
 
 #include <Cabana_SoA.hpp>
 #include <Cabana_MemberTypes.hpp>
-#include <Cabana_Macros.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -39,7 +38,7 @@ struct Tuple<MemberTypes<Types...> >
 
     // Rank 0
     template<std::size_t M>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (0==std::rank<typename base::template member_data_type<M> >::value),
         typename base::template member_reference_type<M> >::type
@@ -50,7 +49,7 @@ struct Tuple<MemberTypes<Types...> >
     }
 
     template<std::size_t M>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (0==std::rank<typename base::template member_data_type<M> >::value),
         typename base::template member_value_type<M> >::type
@@ -63,7 +62,7 @@ struct Tuple<MemberTypes<Types...> >
     // Rank 1
     template<std::size_t M,
              typename D0>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (1==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value),
@@ -76,7 +75,7 @@ struct Tuple<MemberTypes<Types...> >
 
     template<std::size_t M,
              typename D0>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (1==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value),
@@ -91,7 +90,7 @@ struct Tuple<MemberTypes<Types...> >
     template<std::size_t M,
              typename D0,
              typename D1>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (2==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value &&
@@ -107,7 +106,7 @@ struct Tuple<MemberTypes<Types...> >
     template<std::size_t M,
              typename D0,
              typename D1>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (2==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value &&
@@ -125,7 +124,7 @@ struct Tuple<MemberTypes<Types...> >
              typename D0,
              typename D1,
              typename D2>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (3==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value &&
@@ -144,7 +143,7 @@ struct Tuple<MemberTypes<Types...> >
              typename D0,
              typename D1,
              typename D2>
-    CABANA_FORCEINLINE_FUNCTION
+    KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
         (3==std::rank<typename base::template member_data_type<M> >::value &&
          std::is_integral<D0>::value &&

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -14,7 +14,6 @@
 
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_LinkedCellList.hpp>
-#include <Cabana_Macros.hpp>
 #include <impl/Cabana_CartesianGrid.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -526,7 +525,7 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag> >
     using TypeTag = AlgorithmTag;
 
     // Get the number of neighbors for a given particle index.
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     static int numNeighbor( const list_type& list,
                             const std::size_t particle_index )
     {
@@ -535,7 +534,7 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag> >
 
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
-    CABANA_INLINE_FUNCTION
+    KOKKOS_INLINE_FUNCTION
     static int getNeighbor( const list_type& list,
                             const std::size_t particle_index,
                             const int neighbor_index )


### PR DESCRIPTION
We are in the process of deprecating the macros in `Cabana_Macros.hpp` with the goal of that file eventually being removed. This PR removes the use of those macros in the library implementation.