### PR TITLE
Fix gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,5 +14,5 @@ test:default:
       popd
     - mkdir build && cd build &&
       cmake -DCMAKE_PREFIX_PATH=$HOME/kokkos -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON .. &&
-      make -j2 VERBOSE=1 &&
+      make -k -O -j2 VERBOSE=1 &&
       make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ test:default:
   image: ubuntu
   script:
     - apt-get update
-    - apt-get install -y gcovr gfortran cmake g++ git
+    - apt-get install -y gcovr gfortran cmake g++ git bc
     - git clone --depth=1 https://github.com/kokkos/kokkos.git && 
       pushd kokkos &&
       mkdir build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
           -DCabana_ENABLE_MPI=ON
           -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON
           ${COVERAGE:+-DCabana_ENABLE_COVERAGE_BUILD=ON -DCOMPILER_SUPPORTS_MARCH=OFF} .. &&
-    make -j2 VERBOSE=1 &&
+    make -k -j2 VERBOSE=1 &&
     make test CTEST_OUTPUT_ON_FAILURE=1 &&
     make doxygen &&
     make install DESTDIR=${PWD}/install && rm -rf ${PWD}/install/usr/local && rmdir ${PWD}/install/usr &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,10 @@ after_success:
      fi;
    fi
 
+branches:
+  only:
+  - master
+
 cache:
   - ccache
 


### PR DESCRIPTION
Gitlab CI has not MPI installed and triggers error for all the tutorials, which depend on mpi indirectly.