### PR TITLE
Fixing error in neighbors for comm plan input in tutorials

### DIFF
--- a/core/example/tutorial/12_migration/migration_example.cpp
+++ b/core/example/tutorial/12_migration/migration_example.cpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <iostream>
+#include <algorithm>
 
 #include <mpi.h>
 
@@ -85,6 +85,7 @@ void migrationExample()
     // First 10 go to the next rank. Note that this view will most often be
     // filled within a parallel_for but we do so in serial here for
     // demonstration purposes.
+    int previous_rank = ( comm_rank == 0 ) ? comm_size - 1 : comm_rank - 1;
     int next_rank = ( comm_rank == comm_size - 1 ) ? 0 : comm_rank + 1;
     for ( int i = 0; i < 10; ++i )
         export_ranks(i) = next_rank;
@@ -104,13 +105,16 @@ void migrationExample()
       from. In the second we know the topology of the communication plan
       (i.e. the ranks we send and receive from).
 
-      We know that we will only send/receive from this rank and the next rank
-      so use that information in this case because this substantially reduces
-      the amount of communication needed to compose the communication plan. If
-      this neighbor data were not supplied, extra global communication would
-      be needed to generate a list of neighbors.
+      We know that we will only send/receive from this rank and the
+      next/previous rank so use that information in this case because this
+      substantially reduces the amount of communication needed to compose the
+      communication plan. If this neighbor data were not supplied, extra
+      global communication would be needed to generate a list of neighbors.
      */
-    std::vector<int> neighbors = { comm_rank, next_rank };
+    std::vector<int> neighbors = { previous_rank, comm_rank, next_rank };
+    std::sort( neighbors.begin(), neighbors.end() );
+    auto unique_end = std::unique( neighbors.begin(), neighbors.end() );
+    neighbors.resize( std::distance(neighbors.begin(), unique_end) );
     Cabana::Distributor<MemorySpace> distributor(
         MPI_COMM_WORLD, export_ranks, neighbors );
 

--- a/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
+++ b/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <iostream>
+#include <algorithm>
 
 #include <mpi.h>
 
@@ -85,6 +85,7 @@ void haloExchangeExample()
     // Last 10 elements (elements 90-99) go to the next rank. Note that this
     // view will most often be filled within a parallel_for but we do so in
     // serial here for demonstration purposes.
+    int previous_rank = ( comm_rank == 0 ) ? comm_size - 1 : comm_rank - 1;
     int next_rank = ( comm_rank == comm_size - 1 ) ? 0 : comm_rank + 1;
     for ( int i = 0; i < local_num_send; ++i )
     {
@@ -98,13 +99,16 @@ void haloExchangeExample()
       the second we know the topology of the communication plan (i.e. the
       ranks we send and receive from).
 
-      We know that we will only send/receive from this rank and the next rank
-      so use that information in this case because this substantially reduces
-      the amount of communication needed to compose the communication plan. If
-      this neighbor data were not supplied, extra global communication would
-      be needed to generate a list of neighbors.
+      We know that we will only send/receive from this rank and the
+      next/previous rank so use that information in this case because this
+      substantially reduces the amount of communication needed to compose the
+      communication plan. If this neighbor data were not supplied, extra
+      global communication would be needed to generate a list of neighbors.
      */
-    std::vector<int> neighbors = { comm_rank, next_rank };
+    std::vector<int> neighbors = { previous_rank, comm_rank, next_rank };
+    std::sort( neighbors.begin(), neighbors.end() );
+    auto unique_end = std::unique( neighbors.begin(), neighbors.end() );
+    neighbors.resize( std::distance(neighbors.begin(), unique_end) );
     Cabana::Halo<MemorySpace> halo(
         MPI_COMM_WORLD, num_tuple, export_ids, export_ranks, neighbors );
 

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -196,7 +196,8 @@ class CommunicationPlan
 
       \param neighbor_ranks List of ranks this rank will send to and receive
       from. This list can include the calling rank. This is effectively a
-      description of the topology of the point-to-point communication plan.
+      description of the topology of the point-to-point communication
+      plan. The elements in this list must be unique.
 
       \note Calling this function completely updates the state of this object
       and invalidates the previous state.

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -85,7 +85,8 @@ class Distributor : public CommunicationPlan<MemorySpace>
 
       \param neighbor_ranks List of ranks this rank will send to and receive
       from. This list can include the calling rank. This is effectively a
-      description of the topology of the point-to-point communication plan.
+      description of the topology of the point-to-point communication
+      plan. The elements in this list must be unique.
 
       \param mpi_tag The MPI tag to use for non-blocking communication in the
       communication plan generation.

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -93,7 +93,8 @@ class Halo : public CommunicationPlan<MemorySpace>
 
       \param neighbor_ranks List of ranks this rank will send to and receive
       from. This list can include the calling rank. This is effectively a
-      description of the topology of the point-to-point communication plan.
+      description of the topology of the point-to-point communication
+      plan. The elements in this list must be unique.
 
       \param mpi_tag The MPI tag to use for non-blocking communication in the
       communication plan generation.


### PR DESCRIPTION
An incorrect neighbor set was generated for the communication plans in the halo and distributor tutorials. This was causing MPI hangs on some systems.