### PR TITLE
add binary dir to mpi tests

### DIFF
--- a/core/example/tutorial/12_migration/CMakeLists.txt
+++ b/core/example/tutorial/12_migration/CMakeLists.txt
@@ -1,4 +1,5 @@
   add_executable(Migration migration_example.cpp)
   target_link_libraries(Migration cabanacore)
-  add_test(NAME Core_tutorial_12 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} Migration)
+  add_test(NAME Core_tutorial_12 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
+    ${MPIEXEC_MAX_NUMPROCS} ${CMAKE_CURRENT_BINARY_DIR}/Migration)
   set_tests_properties(Core_tutorial_12 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/core/example/tutorial/13_halo_exchange/CMakeLists.txt
+++ b/core/example/tutorial/13_halo_exchange/CMakeLists.txt
@@ -1,4 +1,5 @@
   add_executable(HaloExchange halo_exchange_example.cpp)
   target_link_libraries(HaloExchange cabanacore)
-  add_test(NAME Core_tutorial_13 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} HaloExchange)
+  add_test(NAME Core_tutorial_13 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
+    ${MPIEXEC_MAX_NUMPROCS} ${CMAKE_CURRENT_BINARY_DIR}/HaloExchange)
   set_tests_properties(Core_tutorial_13 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -57,7 +57,8 @@ if(${Cabana_ENABLE_MPI})
         target_link_libraries(${_test}_test_${_device} cabanacore cabana_core_gtest)
         foreach(_np 1 ${MPIEXEC_MAX_NUMPROCS})
           add_test(NAME ${_test}_test_${_device}_${_np} COMMAND
-            ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np} ${_test}_test_${_device} --gtest_color=yes)
+            ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np}
+            ${CMAKE_CURRENT_BINARY_DIR}/${_test}_test_${_device} --gtest_color=yes)
         endforeach()
       endforeach()
     endif()


### PR DESCRIPTION
This PR prefixes the binaries that run under mpi with their directory.  Without this patch, my build with gcc 7.3 and mpich 3.2.1 on rhel7 failed the following ctest tests when mpiexec couldn't find the binaries.

```
71% tests passed, 20 tests failed out of 68

Total Test time (real) =  19.52 sec

The following tests FAILED:
         37 - CommunicationPlan_test_Serial_1 (Failed)
         38 - CommunicationPlan_test_Serial_4 (Failed)
         39 - Distributor_test_Serial_1 (Failed)
         40 - Distributor_test_Serial_4 (Failed)
         41 - Halo_test_Serial_1 (Failed)
         42 - Halo_test_Serial_4 (Failed)
         43 - CommunicationPlan_test_OpenMP_1 (Failed)
         44 - CommunicationPlan_test_OpenMP_4 (Failed)
         45 - Distributor_test_OpenMP_1 (Failed)
         46 - Distributor_test_OpenMP_4 (Failed)
         47 - Halo_test_OpenMP_1 (Failed)
         48 - Halo_test_OpenMP_4 (Failed)
         49 - CommunicationPlan_test_Cuda_1 (Failed)
         50 - CommunicationPlan_test_Cuda_4 (Failed)
         51 - Distributor_test_Cuda_1 (Failed)
         52 - Distributor_test_Cuda_4 (Failed)
         53 - Halo_test_Cuda_1 (Failed)
         54 - Halo_test_Cuda_4 (Failed)
         63 - Core_tutorial_12 (Failed)
         64 - Core_tutorial_13 (Failed)
Errors while running CTest
```

The mpiexec error was:

```
37/68 Testing: CommunicationPlan_test_Serial_1                                                                                                                                                                                                                
37/68 Test: CommunicationPlan_test_Serial_1                                                                                                                                                                                                                   
Command: "/opt/scorec/spack/install/linux-rhel7-x86_64/gcc-7.3.0/mpich-3.2.1-niuhmadq72otoeruzmhwp6f7b3rqe24y/bin/mpiexec" "-n" "1" "CommunicationPlan_test_Serial" "--gtest_color=yes"                                                                       
Directory: /lore/cwsmith/develop/build-cabana-cuda-blockade/core/unit_test                                                                                                                                                                                    
"CommunicationPlan_test_Serial_1" start time: Jan 29 15:15 EST                                                                                                                                                                                                
Output:                                                                                                                                                                                                                                                       
----------------------------------------------------------                                                                                                                                                                                                    
[proxy:0:0@blockade.scorec.rpi.edu] HYDU_create_process (utils/launch/launch.c:75): execvp error on file CommunicationPlan_test_Serial (No such file or directory)                                                                                            
<end of output>                                                                                                                                                                                                                                               
Test time =   0.01 sec                                                                                                                                                                                                                                        
----------------------------------------------------------                                                                                                                                                                                                    
Test Failed.                                                                                                                                                                                                                                                  
"CommunicationPlan_test_Serial_1" end time: Jan 29 15:15 EST                                                                                                                                                                                                  
"CommunicationPlan_test_Serial_1" time elapsed: 00:00:00                                                                                                                                                                                                      
----------------------------------------------------------                  
```

My cmake command is:

```
cmake /path/to/cabana/ \
-DCMAKE_BUILD_TYPE="Debug" \
-DCMAKE_CXX_COMPILER=mpicxx \
-DCabana_ENABLE_TESTING=ON \
-DCabana_ENABLE_EXAMPLES=ON \
-DCabana_ENABLE_Serial=ON \
-DCabana_ENABLE_OpenMP=ON \
-DCabana_ENABLE_Cuda:BOOL=ON \
-DCabana_ENABLE_MPI=ON \
-DCMAKE_INSTALL_PREFIX=$PWD/install 
```

