### PR TITLE
Fixing slice construction for uninitialized AoSoAs

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -319,15 +319,18 @@ class AoSoA
             0 == sizeof(soa_type) % sizeof(member_value_type<M>),
             "Slice stride cannot be calculated for misaligned memory!" );
 
+        member_pointer_type<M> data_ptr =
+            ( _data.size() > 0 )
+            ? static_cast<member_pointer_type<M> >(_data(0).template ptr<M>())
+            : nullptr;
+
         return
             Slice<member_data_type<M>,
                   memory_space,
                   DefaultAccessMemory,
                   vector_length,
-                  sizeof(soa_type) / sizeof(member_value_type<M>)>
-            ( static_cast<member_pointer_type<M> >(_data(0).template ptr<M>()),
-              _size,
-              _num_soa );
+                  sizeof(soa_type) / sizeof(member_value_type<M>)>(
+                      data_ptr, _size, _num_soa );
     }
 
     /*!


### PR DESCRIPTION
A bug was discovered in #79 where slices created from uninitialized AoSoAs would try to dereference the first value of the AoSoA data. Now we check to see if there is any data. If there is we dereference it. Otherwise we build the slice on a raw pointer. This is valid because the slice is given a corresponding size of 0. A user should not dereference data in a slice of size 0.