### PR TITLE
Verlet List Update

### DIFF
--- a/core/example/benchmark/md_neighbor_perf_test.cpp
+++ b/core/example/benchmark/md_neighbor_perf_test.cpp
@@ -168,7 +168,7 @@ void perfTest( const double cutoff_ratio,
     Cabana::permute( linked_cell_list, aosoa );
 
     // Create the list once to get some statistics.
-    Cabana::VerletList<MemorySpace,NeighborListTag>
+    Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR>
         stat_list( aosoa.slice<Position>(), 0, aosoa.size(),
                    interaction_cutoff, cell_size_ratio, grid_min, grid_max );
     Kokkos::MinMaxScalar<int> result;
@@ -177,13 +177,13 @@ void perfTest( const double cutoff_ratio,
         "Cabana::countMinMax",
         Kokkos::RangePolicy<ExecutionSpace>(0,num_data),
         Kokkos::Impl::min_max_functor<Kokkos::View<int*,MemorySpace> >(
-            stat_list._counts ),
+            stat_list._data.counts ),
         reducer );
     Kokkos::fence();
     std::cout << std::endl;
     std::cout << "List min neighbors: " << result.min_val << std::endl;
     std::cout << "List max neighbors: " << result.max_val << std::endl;
-    double count_average = stat_list._neighbors.extent(0) / num_data;
+    double count_average = stat_list._data.neighbors.extent(0) / num_data;
     std::cout << "List avg neighbors: " << count_average << std::endl;
     std::cout << std::endl;
 
@@ -195,7 +195,7 @@ void perfTest( const double cutoff_ratio,
         std::cout << "Run t: " << t << std::endl;
         auto start_time = std::chrono::high_resolution_clock::now();
 
-        Cabana::VerletList<MemorySpace,NeighborListTag> list(
+        Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR> list(
             aosoa.slice<Position>(), 0, aosoa.size(),
             interaction_cutoff, cell_size_ratio, grid_min, grid_max );
 

--- a/core/example/tutorial/09_verlet_list/verlet_list.cpp
+++ b/core/example/tutorial/09_verlet_list/verlet_list.cpp
@@ -119,7 +119,7 @@ void verletListExample()
     double neighborhood_radius = 0.25;
     double cell_ratio = 1.0;
     using ListAlgorithm = Cabana::FullNeighborTag;
-    using ListType = Cabana::VerletList<MemorySpace,ListAlgorithm>;
+    using ListType = Cabana::VerletList<MemorySpace,ListAlgorithm,Cabana::VerletLayoutCSR>;
     ListType verlet_list( positions, 0, positions.size(),
                           neighborhood_radius, cell_ratio,
                           grid_min, grid_max );

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -405,6 +405,7 @@ void checkFullNeighborListPartialRange( const ListType& list,
 }
 
 //---------------------------------------------------------------------------//
+template<class LayoutTag>
 void testVerletListFull()
 {
     // Create the AoSoA and fill with random particle positions.
@@ -418,7 +419,7 @@ void testVerletListFull()
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
-    Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag>
+    Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>
         nlist( aosoa.slice<0>(), 0, aosoa.size(),
                test_radius, cell_size_ratio, grid_min, grid_max );
 
@@ -428,6 +429,7 @@ void testVerletListFull()
 }
 
 //---------------------------------------------------------------------------//
+template<class LayoutTag>
 void testVerletListHalf()
 {
     // Create the AoSoA and fill with random particle positions.
@@ -441,7 +443,7 @@ void testVerletListHalf()
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
-    Cabana::VerletList<TEST_MEMSPACE,Cabana::HalfNeighborTag>
+    Cabana::VerletList<TEST_MEMSPACE,Cabana::HalfNeighborTag,LayoutTag>
         nlist( aosoa.slice<0>(), 0, aosoa.size(),
                test_radius, cell_size_ratio, grid_min, grid_max );
 
@@ -451,6 +453,7 @@ void testVerletListHalf()
 }
 
 //---------------------------------------------------------------------------//
+template<class LayoutTag>
 void testNeighborParallelFor()
 {
     // Create the AoSoA and fill with random particle positions.
@@ -462,11 +465,11 @@ void testNeighborParallelFor()
     auto aosoa = createParticles( num_particle, box_min, box_max );
 
     // Create the neighbor list.
+    using ListType = Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>;
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
-    Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag>
-        nlist( aosoa.slice<0>(), 0, aosoa.size(),
-               test_radius, cell_size_ratio, grid_min, grid_max );
+    ListType nlist( aosoa.slice<0>(), 0, aosoa.size(),
+                    test_radius, cell_size_ratio, grid_min, grid_max );
 
     // Create Kokkos views for the write operation.
     using memory_space = typename TEST_MEMSPACE::memory_space;
@@ -492,7 +495,7 @@ void testNeighborParallelFor()
     auto test_list_copy = createTestListHostCopy( test_list );
     for ( int p = 0; p < num_particle; ++p )
         for ( int n = 0; n < test_list_copy.counts(p); ++n )
-            test_result(p) += test_list_copy.neighbors( p, n );
+            test_result(p) += test_list_copy.neighbors(p,n);
 
     // Check the result.
     auto serial_mirror = Kokkos::create_mirror_view_and_copy(
@@ -507,6 +510,7 @@ void testNeighborParallelFor()
 }
 
 //---------------------------------------------------------------------------//
+template<class LayoutTag>
 void testVerletListFullPartialRange()
 {
     // Create the AoSoA and fill with random particle positions.
@@ -521,7 +525,7 @@ void testVerletListFullPartialRange()
     // Create the neighbor list.
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
-    Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag>
+    Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>
         nlist( aosoa.slice<0>(), 0, num_ignore,
                test_radius, cell_size_ratio, grid_min, grid_max );
 
@@ -541,25 +545,29 @@ TEST( TEST_CATEGORY, linked_cell_stencil_test )
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, linked_cell_list_full_test )
 {
-    testVerletListFull();
+    testVerletListFull<Cabana::VerletLayoutCSR>();
+    testVerletListFull<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, linked_cell_list_half_test )
 {
-    testVerletListHalf();
+    testVerletListHalf<Cabana::VerletLayoutCSR>();
+    testVerletListHalf<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, linked_cell_list_full_range_test )
 {
-    testVerletListFullPartialRange();
+    testVerletListFullPartialRange<Cabana::VerletLayoutCSR>();
+    testVerletListFullPartialRange<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, parallel_for_test )
 {
-    testNeighborParallelFor();
+    testNeighborParallelFor<Cabana::VerletLayoutCSR>();
+    testNeighborParallelFor<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
* Adds 2D Verlet list storage in addition to the existing CSR storage. These are created by a new layout template parameter on the Verlet list. Closes #71 
* ~~Allows for the reuse of a `LinkedCellList` when constructing the Verlet list. This should save a lot of time for those cases where a `LinkedCellList` is constructed and used elsewhere.~~ (will not do per discussion in #75) Closes #75 