### PR TITLE
AoSoA Mirror

### DIFF
--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -112,6 +112,32 @@ void deepCopyExample()
         std::cout << "Tuple " << t
                   << ", member 2: " << tp.get<2>() << std::endl;
     }
+
+    /*
+      In applications that utilize multiple memory spaces (e.g. those that use
+      heterogeneous architectures) we can also create an AoSoA that mirrors
+      another AoSoA. A mirror is a data structure that has an identical data
+      layout but may be allocated in another memory space. A good example of a
+      use for this type of capability is easily managing copies between a GPU
+      and a CPU.
+
+      Given that the AoSoA we created above is on the GPU we can easily create
+      another identical AoSoA containing the same contents but that is
+      allocated in a different mnemory space allowing for easy transfer back to
+      the device:
+     */
+    auto dst_aosoa_host = Cabana::Experimental::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), dst_aosoa );
+
+    /*
+       Note that this view is now in the provided host space. If we were to
+       use the same memory space as dst_aosoa in this function call we would
+       have received the same dst_aosoa back - no memory allocations or copies
+       would have occured. This is particularly useful for writing code that
+       will run on both heterogenous and homogenous architectures where the
+       heterogenous case requires an allocation and a copy while the
+       homogenous case does not.
+     */
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -134,10 +134,9 @@ namespace Experimental
   \brief Create a mirror view of the given AoSoA in the given memory
   space. Same space specialization returns the input AoSoA.
 
-  \note The semantics of using the word view in the name of this function
-  indicate that memory allocation will only occur if the requested mirror
-  memory space is different from that of the input AoSoA. If they are the
-  same, the original AoSoA (e.g. a view of that AoSoA) is returned.
+  \note Memory allocation will only occur if the requested mirror memory space
+  is different from that of the input AoSoA. If they are the same, the
+  original AoSoA (e.g. a view of that AoSoA) is returned.
  */
 template<class Space, class SrcAoSoA>
 inline
@@ -158,8 +157,7 @@ create_mirror_view_and_copy(
   space and deep copy the AoSoA into the mirror. Different space
   specialization allocates a new AoSoA and performs the deep copy.
 
-  \note The semantics of using the word view in the name of this function
-  indicate that memory allocation will only occur if the requested mirror
+  \note Memory allocation will only occur if the requested mirror
   memory space is different from that of the input AoSoA. If they are the
   same, the original AoSoA (e.g. a view of that AoSoA) is returned.
  */

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -127,6 +127,119 @@ inline void deep_copy(
 }
 
 //---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror of the given AoSoA in the given memory
+  space. Same space specialization returns the input AoSoA.
+ */
+template<class Space, class SrcAoSoA>
+SrcAoSoA
+create_mirror_aosoa(
+    const Space&,
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             std::is_same<typename SrcAoSoA::memory_space,
+                             typename Space::memory_space>::value)>::type* = 0 )
+{
+    return src;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror of the given AoSoA in the given memory
+  space. Different space specialization allocates a new AoSoA.
+ */
+template<class Space, class SrcAoSoA>
+AoSoA<typename SrcAoSoA::member_types,
+      typename Space::memory_space,
+      SrcAoSoA::vector_length>
+create_mirror_aosoa(
+    const Space&,
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             !std::is_same<typename SrcAoSoA::memory_space,
+                             typename Space::memory_space>::value)>::type* = 0 )
+{
+    return AoSoA<typename SrcAoSoA::member_types,
+                 typename Space::memory_space,
+                 SrcAoSoA::vector_length>( src.size() );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror on the host of the given AoSoA. Same space
+  specialization returns the input AoSoA.
+ */
+template<class SrcAoSoA>
+AoSoA<typename SrcAoSoA::member_types,
+      Kokkos::HostSpace,
+      SrcAoSoA::vector_length>
+create_mirror_aosoa(
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             std::is_same<typename SrcAoSoA::memory_space,
+                             Kokkos::HostSpace>::value)>::type* = 0 )
+{
+    return src;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror on the host of the given AoSoA. Different space
+  specialization allocates a new AoSoA.
+ */
+template<class SrcAoSoA>
+AoSoA<typename SrcAoSoA::member_types,
+      Kokkos::HostSpace,
+      SrcAoSoA::vector_length>
+create_mirror_aosoa(
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             !std::is_same<typename SrcAoSoA::memory_space,
+                             Kokkos::HostSpace>::value)>::type* = 0 )
+{
+    return create_mirror_aosoa( Kokkos::HostSpace(), src );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror of the given AoSoA in the given memory
+  space. Same space specialization returns the input AoSoA.
+ */
+template<class Space, class SrcAoSoA>
+SrcAoSoA
+create_mirror_aosoa_and_copy(
+    const Space&,
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             std::is_same<typename SrcAoSoA::memory_space,
+                             typename Space::memory_space>::value)>::type* = 0 )
+{
+    return src;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a mirror on the host of the given AoSoA in the given memory
+  space and deep copy the AoSoA into the mirror. Different space
+  specialization allocates a new AoSoA and performs the deep copy.
+ */
+template<class Space, class SrcAoSoA>
+AoSoA<typename SrcAoSoA::member_types,
+      typename Space::memory_space,
+      SrcAoSoA::vector_length>
+create_mirror_aosoa_and_copy(
+    const Space& space,
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
+                             !std::is_same<typename SrcAoSoA::memory_space,
+                             typename Space::memory_space>::value)>::type* = 0 )
+{
+    auto dst = create_mirror_aosoa( space, src );
+    deep_copy( dst, src );
+    return dst;
+}
+
+//---------------------------------------------------------------------------//
 
 } // end namespace Cabana
 

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -140,6 +140,7 @@ namespace Experimental
   same, the original AoSoA (e.g. a view of that AoSoA) is returned.
  */
 template<class Space, class SrcAoSoA>
+inline
 SrcAoSoA
 create_mirror_view_and_copy(
     const Space&,
@@ -163,6 +164,7 @@ create_mirror_view_and_copy(
   same, the original AoSoA (e.g. a view of that AoSoA) is returned.
  */
 template<class Space, class SrcAoSoA>
+inline
 AoSoA<typename SrcAoSoA::member_types,
       typename Space::memory_space,
       SrcAoSoA::vector_length>

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -127,87 +127,21 @@ inline void deep_copy(
 }
 
 //---------------------------------------------------------------------------//
+namespace Experimental
+{
+//---------------------------------------------------------------------------//
 /*!
-  \brief Create a mirror of the given AoSoA in the given memory
+  \brief Create a mirror view of the given AoSoA in the given memory
   space. Same space specialization returns the input AoSoA.
+
+  \note The semantics of using the word view in the name of this function
+  indicate that memory allocation will only occur if the requested mirror
+  memory space is different from that of the input AoSoA. If they are the
+  same, the original AoSoA (e.g. a view of that AoSoA) is returned.
  */
 template<class Space, class SrcAoSoA>
 SrcAoSoA
-create_mirror_aosoa(
-    const Space&,
-    const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             std::is_same<typename SrcAoSoA::memory_space,
-                             typename Space::memory_space>::value)>::type* = 0 )
-{
-    return src;
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Create a mirror of the given AoSoA in the given memory
-  space. Different space specialization allocates a new AoSoA.
- */
-template<class Space, class SrcAoSoA>
-AoSoA<typename SrcAoSoA::member_types,
-      typename Space::memory_space,
-      SrcAoSoA::vector_length>
-create_mirror_aosoa(
-    const Space&,
-    const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             !std::is_same<typename SrcAoSoA::memory_space,
-                             typename Space::memory_space>::value)>::type* = 0 )
-{
-    return AoSoA<typename SrcAoSoA::member_types,
-                 typename Space::memory_space,
-                 SrcAoSoA::vector_length>( src.size() );
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Create a mirror on the host of the given AoSoA. Same space
-  specialization returns the input AoSoA.
- */
-template<class SrcAoSoA>
-AoSoA<typename SrcAoSoA::member_types,
-      Kokkos::HostSpace,
-      SrcAoSoA::vector_length>
-create_mirror_aosoa(
-    const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             std::is_same<typename SrcAoSoA::memory_space,
-                             Kokkos::HostSpace>::value)>::type* = 0 )
-{
-    return src;
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Create a mirror on the host of the given AoSoA. Different space
-  specialization allocates a new AoSoA.
- */
-template<class SrcAoSoA>
-AoSoA<typename SrcAoSoA::member_types,
-      Kokkos::HostSpace,
-      SrcAoSoA::vector_length>
-create_mirror_aosoa(
-    const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             !std::is_same<typename SrcAoSoA::memory_space,
-                             Kokkos::HostSpace>::value)>::type* = 0 )
-{
-    return create_mirror_aosoa( Kokkos::HostSpace(), src );
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Create a mirror of the given AoSoA in the given memory
-  space. Same space specialization returns the input AoSoA.
- */
-template<class Space, class SrcAoSoA>
-SrcAoSoA
-create_mirror_aosoa_and_copy(
+create_mirror_view_and_copy(
     const Space&,
     const SrcAoSoA& src,
     typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
@@ -222,22 +156,33 @@ create_mirror_aosoa_and_copy(
   \brief Create a mirror on the host of the given AoSoA in the given memory
   space and deep copy the AoSoA into the mirror. Different space
   specialization allocates a new AoSoA and performs the deep copy.
+
+  \note The semantics of using the word view in the name of this function
+  indicate that memory allocation will only occur if the requested mirror
+  memory space is different from that of the input AoSoA. If they are the
+  same, the original AoSoA (e.g. a view of that AoSoA) is returned.
  */
 template<class Space, class SrcAoSoA>
 AoSoA<typename SrcAoSoA::member_types,
       typename Space::memory_space,
       SrcAoSoA::vector_length>
-create_mirror_aosoa_and_copy(
-    const Space& space,
+create_mirror_view_and_copy(
+    const Space&,
     const SrcAoSoA& src,
     typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
                              !std::is_same<typename SrcAoSoA::memory_space,
                              typename Space::memory_space>::value)>::type* = 0 )
 {
-    auto dst = create_mirror_aosoa( space, src );
+    auto dst = AoSoA<typename SrcAoSoA::member_types,
+                     typename Space::memory_space,
+                     SrcAoSoA::vector_length>( src.size() );
     deep_copy( dst, src );
     return dst;
 }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Experimental
 
 //---------------------------------------------------------------------------//
 

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -230,5 +230,11 @@ TEST_F( TEST_CATEGORY, deep_copy_from_host_different_layout_test )
 }
 
 //---------------------------------------------------------------------------//
+TEST_F( TEST_CATEGORY, mirror_test )
+{
+    testMirror();
+}
+
+//---------------------------------------------------------------------------//
 
 } // end namespace Test

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -168,55 +168,34 @@ void testMirror()
                 slice_3( idx, i, j ) = dval * (i+j);
     }
 
-    // Create a mirror with the same memory space.
-    auto same_space_mirror =
-        Cabana::create_mirror_aosoa( TEST_MEMSPACE(), aosoa );
-    EXPECT_EQ( same_space_mirror.size(), aosoa.size() );
-    bool ssm_same_ms =
-        std::is_same<TEST_MEMSPACE,
-                     decltype(same_space_mirror)::memory_space>::value;
-    EXPECT_TRUE( ssm_same_ms );
-    bool ssm_same_mt =
-        std::is_same<DataTypes,
-                     decltype(same_space_mirror)::member_types>::value;
-    EXPECT_TRUE( ssm_same_mt );
-
-    // Create a mirror on the host.
-    auto host_space_mirror =
-        Cabana::create_mirror_aosoa( Kokkos::HostSpace(), aosoa );
-    EXPECT_EQ( host_space_mirror.size(), aosoa.size() );
-    bool hsm_same_ms =
-        std::is_same<Kokkos::HostSpace,
-                     decltype(host_space_mirror)::memory_space>::value;
-    EXPECT_TRUE( hsm_same_ms );
-    bool hsm_same_mt =
-        std::is_same<DataTypes,
-                     decltype(host_space_mirror)::member_types>::value;
-    EXPECT_TRUE( hsm_same_mt );
-
-    // Create a second mirror on the host using a different API
-    auto host_space_mirror_2 =
-        Cabana::create_mirror_aosoa( aosoa );
-    EXPECT_EQ( host_space_mirror_2.size(), aosoa.size() );
-    bool hsm2_same_ms =
-        std::is_same<Kokkos::HostSpace,
-                     decltype(host_space_mirror_2)::memory_space>::value;
-    EXPECT_TRUE( hsm2_same_ms );
-    bool hsm2_same_mt =
-        std::is_same<DataTypes,
-                     decltype(host_space_mirror_2)::member_types>::value;
-    EXPECT_TRUE( hsm2_same_mt );
-
     // Create a mirror with the same memory space and copy.
-    auto same_space_copy = Cabana::create_mirror_aosoa_and_copy(
+    auto same_space_copy = Cabana::Experimental::create_mirror_view_and_copy(
         TEST_MEMSPACE(), aosoa );
+    EXPECT_EQ( same_space_copy.size(), aosoa.size() );
+    bool ssc_same_ms =
+        std::is_same<TEST_MEMSPACE,
+                     decltype(same_space_copy)::memory_space>::value;
+    EXPECT_TRUE( ssc_same_ms );
+    bool ssc_same_mt =
+        std::is_same<DataTypes,
+                     decltype(same_space_copy)::member_types>::value;
+    EXPECT_TRUE( ssc_same_mt );
 
     // Check values.
     checkDataMembers( same_space_copy, fval, dval, ival, dim_1, dim_2, dim_3 );
 
     // Create a mirror with the host space and copy.
-    auto host_space_copy = Cabana::create_mirror_aosoa_and_copy(
+    auto host_space_copy = Cabana::Experimental::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
+    EXPECT_EQ( host_space_copy.size(), aosoa.size() );
+    bool hsc_same_ms =
+        std::is_same<Kokkos::HostSpace,
+                     decltype(host_space_copy)::memory_space>::value;
+    EXPECT_TRUE( hsc_same_ms );
+    bool hsc_same_mt =
+        std::is_same<DataTypes,
+                     decltype(host_space_copy)::member_types>::value;
+    EXPECT_TRUE( hsc_same_mt );
 
     // Check values.
     checkDataMembers( host_space_copy, fval, dval, ival, dim_1, dim_2, dim_3 );

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -181,6 +181,10 @@ void testMirror()
                      decltype(same_space_copy)::member_types>::value;
     EXPECT_TRUE( ssc_same_mt );
 
+    // Check that the same memory space case didn't allocate any memory. They
+    // should have the same pointer.
+    EXPECT_EQ( aosoa.ptr(), same_space_copy.ptr() );
+
     // Check values.
     checkDataMembers( same_space_copy, fval, dval, ival, dim_1, dim_2, dim_3 );
 


### PR DESCRIPTION
This adds a mirror capability equivalent to that provided for `Kokkos::View`. This closes #90 and is intended to make the implementation of #88 easier.

Also note that this new capability will need to be updated when #92 is resolved.