### PR TITLE
Turn off CUDA Inter-Process Communication (IPC) in Docker image

### DIFF
--- a/scripts/jenkins/Dockerfile
+++ b/scripts/jenkins/Dockerfile
@@ -43,13 +43,15 @@ RUN export OPENMPI_VERSION=4.0.0 && \
     export OPENMPI_URL=https://www.open-mpi.org/software/ompi/v${OPENMPI_VERSION_SHORT}/downloads/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_ARCHIVE=openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_SOURCE_DIR=openmpi-${OPENMPI_VERSION} && \
+    export OPENMPI_INSTALL_PREFIX=/usr && \
     wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
     echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
     mkdir -p ${OPENMPI_SOURCE_DIR} && \
     tar -xf ${OPENMPI_ARCHIVE} -C ${OPENMPI_SOURCE_DIR} --strip-components=1 && \
     cd ${OPENMPI_SOURCE_DIR} && mkdir build && cd build && \
-    ../configure --prefix=/usr --with-cuda && \
+    ../configure --prefix=${OPENMPI_INSTALL_PREFIX} --with-cuda && \
     make -j8 install && \
+    echo "btl_smcuda_use_cuda_ipc = 0" >> ${OPENMPI_INSTALL_PREFIX}/etc/openmpi-mca-params.conf && \
     rm -rf ${OPENMPI_ARCHIVE} ${OPENMPI_SOURCE_DIR}
 
 # Allow running mpiexec as root

--- a/scripts/jenkins/docker-compose.yml
+++ b/scripts/jenkins/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ci:
-    image: dalg24/cabana-base:19.03.2
+    image: dalg24/cabana-base:19.03.3
     volumes:
       - jenkins_data:$WORKSPACE/../..:rw
     command: bash -xe $WORKSPACE/scripts/jenkins/build.sh


### PR DESCRIPTION
Stuart reported [here](https://github.com/ECP-copa/Cabana/pull/88#issuecomment-475280973) he was able to get rid of these errors we see for `Distributor_test_Cuda_<N>` and `Halo_test_Cuda_<N>` [on Jenkins](https://cloud.cees.ornl.gov/jenkins-ci/job/Cabana/53/#showFailuresLink) by passing `--mca btl_smcuda_use_cuda_ipc 0` to `mpirun`.  This turns off the CUDA IPC.
I tagged a new image `dalg24/cabana_base:19.03.3` and pushed it to Docker Hub.