### PR TITLE
Use MPIEXEC_PREFLAGS instead of tuning Open MPI run-time

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -77,7 +77,7 @@ if(${Cabana_ENABLE_MPI})
         foreach(_np ${TEST_MPIEXEC_NUMPROCS})
           add_test(NAME ${_target}_${_np} COMMAND
             ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np} ${MPIEXEC_PREFLAGS}
-            ${_target} --gtest_color=yes)
+            ${_target} ${MPIEXEC_POSTFLAGS} --gtest_color=yes)
         endforeach()
       endforeach()
     endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -17,13 +17,15 @@ set_target_properties(cabana_core_gtest PROPERTIES
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+set(gtest_args --gtest_color=yes)
+
 ##--------------------------------------------------------------------------##
 ## General tests.
 ##--------------------------------------------------------------------------##
 foreach(_test Version Index CartesianGrid SoA)
   add_executable(${_test}_test tst${_test}.cpp unit_test_main.cpp)
   target_link_libraries(${_test}_test cabanacore cabana_core_gtest)
-  add_test(NAME ${_test}_test COMMAND ${_test}_test --gtest_color=yes)
+  add_test(NAME ${_test}_test COMMAND ${_test}_test ${gtest_args})
 endforeach()
 
 ##--------------------------------------------------------------------------##
@@ -47,7 +49,7 @@ foreach(_device ${CABANA_SUPPORTED_DEVICES})
             ${_target} --gtest_color=yes --kokkos-threads=${_thread})
         endforeach()
       else()
-        add_test(NAME ${_target} COMMAND ${_target} --gtest_color=yes)
+        add_test(NAME ${_target} COMMAND ${_target} ${gtest_args})
       endif()
     endforeach()
   endif()
@@ -77,7 +79,7 @@ if(${Cabana_ENABLE_MPI})
         foreach(_np ${TEST_MPIEXEC_NUMPROCS})
           add_test(NAME ${_target}_${_np} COMMAND
             ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np} ${MPIEXEC_PREFLAGS}
-            ${_target} ${MPIEXEC_POSTFLAGS} --gtest_color=yes)
+            ${_target} ${MPIEXEC_POSTFLAGS} ${gtest_args})
         endforeach()
       endforeach()
     endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -76,7 +76,7 @@ if(${Cabana_ENABLE_MPI})
         endif()
         foreach(_np ${TEST_MPIEXEC_NUMPROCS})
           add_test(NAME ${_target}_${_np} COMMAND
-            ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np}
+            ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${_np} ${MPIEXEC_PREFLAGS}
             ${_target} --gtest_color=yes)
         endforeach()
       endforeach()

--- a/scripts/jenkins/Dockerfile
+++ b/scripts/jenkins/Dockerfile
@@ -51,11 +51,4 @@ RUN export OPENMPI_VERSION=4.0.0 && \
     cd ${OPENMPI_SOURCE_DIR} && mkdir build && cd build && \
     ../configure --prefix=${OPENMPI_INSTALL_PREFIX} --with-cuda && \
     make -j8 install && \
-    echo "btl_smcuda_use_cuda_ipc = 0" >> ${OPENMPI_INSTALL_PREFIX}/etc/openmpi-mca-params.conf && \
     rm -rf ${OPENMPI_ARCHIVE} ${OPENMPI_SOURCE_DIR}
-
-# Allow running mpiexec as root
-RUN echo '#!/usr/bin/env bash' > /usr/local/bin/mpiexec && \
-    echo '/usr/bin/mpiexec --allow-run-as-root "$@"' >> /usr/local/bin/mpiexec && \
-    chmod +x /usr/local/bin/mpiexec && \
-    mpiexec --version

--- a/scripts/jenkins/build.sh
+++ b/scripts/jenkins/build.sh
@@ -7,6 +7,7 @@ cmake \
   -D CMAKE_CXX_COMPILER=$KOKKOS_DIR/bin/nvcc_wrapper \
   -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic" \
   -D CMAKE_PREFIX_PATH=$KOKKOS_DIR \
+  -D MPIEXEC_PREFLAGS="--allow-run-as-root;--mca;btl_smcuda_use_cuda_ipc;0" \
   -D Cabana_ENABLE_MPI=ON \
   -D Cabana_ENABLE_Cuda=ON \
   -D Cabana_ENABLE_Serial=OFF \

--- a/scripts/jenkins/docker-compose.yml
+++ b/scripts/jenkins/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ci:
-    image: dalg24/cabana-base:19.03.3
+    image: dalg24/cabana-base:19.03.4
     volumes:
       - jenkins_data:$WORKSPACE/../..:rw
     command: bash -xe $WORKSPACE/scripts/jenkins/build.sh


### PR DESCRIPTION
As suggested by Christoph [here](https://github.com/ECP-copa/Cabana/pull/100#discussion_r268220180) prefer `MPIEXEC_PREFLAGS` to other shenanigans.