### PR TITLE
Deep Copy Additions

### DIFF
--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -138,6 +138,40 @@ void deepCopyExample()
        heterogenous case requires an allocation and a copy while the
        homogenous case does not.
      */
+
+    /*
+      Deep copy can also be performed on a slice-by-slice basis.
+     */
+    auto src_slice_0 = src_aosoa.slice<0>();
+    auto dst_slice_0 = dst_aosoa.slice<0>();
+    Cabana::deep_copy( dst_slice_0, src_slice_0 );
+    auto src_slice_1 = src_aosoa.slice<1>();
+    auto dst_slice_1 = dst_aosoa.slice<1>();
+    Cabana::deep_copy( dst_slice_1, src_slice_1 );
+    auto src_slice_2 = src_aosoa.slice<2>();
+    auto dst_slice_2 = dst_aosoa.slice<2>();
+    Cabana::deep_copy( dst_slice_2, src_slice_2 );
+
+    /*
+      One can also assign scalar values to every element in a slice. The slice
+      can be in any memory space.
+     */
+    Cabana::deep_copy( src_slice_0, 3.4 );
+    Cabana::deep_copy( src_slice_1, 2.22 );
+    Cabana::deep_copy( src_slice_2, 12 );
+
+    /*
+      Or one can initialize each tuple in an AoSoA with the values of a given
+      tuple. The AoSoA can be in any memory space.
+     */
+    Cabana::Tuple<DataTypes> tp;
+    for ( int i = 0; i < 3; ++i )
+        for ( int j = 0; j < 3; ++j )
+            tp.get<0>(i,j) = 1.0;
+    for ( int i = 0; i < 4; ++i )
+        tp.get<1>(i) = 3.23;
+    tp.get<2>() = 39;
+    Cabana::deep_copy( dst_aosoa, tp );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -13,6 +13,7 @@
 #define CABANA_DEEPCOPY_HPP
 
 #include <Cabana_AoSoA.hpp>
+#include <Cabana_Slice.hpp>
 #include <impl/Cabana_TypeTraits.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -24,109 +25,7 @@
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
-/*!
-  \brief Deep copy data between compatible AoSoA objects.
 
-  \param dst The destination for the copied data.
-
-  \param src The source of the copied data.
-
-  Only AoSoA objects with the same set of member data types and size may be
-  copied.
-*/
-template<class DstAoSoA, class SrcAoSoA>
-inline void deep_copy(
-    DstAoSoA& dst,
-    const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<DstAoSoA>::value &&
-                             is_aosoa<SrcAoSoA>::value)>::type *  = 0 )
-{
-    using dst_type = DstAoSoA;
-    using src_type = SrcAoSoA;
-    using dst_memory_space = typename dst_type::memory_space;
-    using src_memory_space = typename src_type::memory_space;
-    using dst_soa_type = typename dst_type::soa_type;
-    using src_soa_type = typename src_type::soa_type;
-
-    // Check that the data types are the same.
-    static_assert(
-        std::is_same<typename dst_type::member_types,
-        typename src_type::member_types>::value,
-        "Attempted to deep copy AoSoA objects of different member types" );
-
-    // Check for the same number of values.
-    if ( dst.size() != src.size() )
-    {
-        throw std::runtime_error(
-            "Attempted to deep copy AoSoA objects of different sizes" );
-    }
-
-    // Get the pointers to the beginning of the data blocks.
-    void* dst_data = dst.ptr();
-    const void* src_data = src.ptr();
-
-    // Return if both pointers are null.
-    if ( dst_data == nullptr && src_data == nullptr )
-    {
-        return;
-    }
-
-    // Get the number of SoA's in each object.
-    auto dst_num_soa = dst.numSoA();
-    auto src_num_soa = src.numSoA();
-
-    // Return if the AoSoA memory occupies the same space.
-    if ( (dst_data == src_data) &&
-         (dst_num_soa * sizeof(dst_soa_type) ==
-          src_num_soa * sizeof(src_soa_type)) )
-    {
-        return;
-    }
-
-    // If the inner array size is the same and both AoSoAs have the same number
-    // of values then we can do a byte-wise copy directly.
-    if ( std::is_same<dst_soa_type,src_soa_type>::value &&
-         ( dst_type::vector_length == src_type::vector_length ) )
-    {
-        Kokkos::Impl::DeepCopy<dst_memory_space,src_memory_space>(
-            dst_data, src_data, dst_num_soa * sizeof(dst_soa_type) );
-    }
-
-    // Otherwise copy the data element-by-element because the data layout is
-    // different.
-    else
-    {
-        // Define a AoSoA type in the destination space with the same data
-        // layout as the source.
-        using src_mirror_type = AoSoA<typename src_type::member_types,
-                                      typename dst_type::memory_space,
-                                      src_type::vector_length>;
-        static_assert(
-            std::is_same<src_soa_type,typename src_mirror_type::soa_type>::value,
-            "Incompatible source mirror type in destination space" );
-
-        // Create an AoSoA in the destination space with the same data layout
-        // as the source.
-        src_mirror_type src_copy_on_dst( src.size() );
-
-        // Copy the source to the destination space.
-        Kokkos::Impl::DeepCopy<dst_memory_space,src_memory_space>(
-            src_copy_on_dst.ptr(),
-            src_data,
-            src_num_soa * sizeof(src_soa_type) );
-
-        // Copy via tuples.
-        auto copy_func =
-            KOKKOS_LAMBDA( const std::size_t i )
-            { dst.setTuple( i, src_copy_on_dst.getTuple(i) ); };
-        Kokkos::RangePolicy<typename dst_memory_space::execution_space>
-            exec_policy( 0, dst.size() );
-        Kokkos::parallel_for( "Cabana::deep_copy", exec_policy, copy_func );
-        Kokkos::fence();
-    }
-}
-
-//---------------------------------------------------------------------------//
 namespace Experimental
 {
 //---------------------------------------------------------------------------//
@@ -196,10 +95,11 @@ SrcAoSoA
 create_mirror_view_and_copy(
     const Space&,
     const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             std::is_same<typename SrcAoSoA::memory_space,
+    typename std::enable_if<(std::is_same<typename SrcAoSoA::memory_space,
                              typename Space::memory_space>::value)>::type* = 0 )
 {
+    static_assert( is_aosoa<SrcAoSoA>::value,
+                   "create_mirror_view_and_copy() requires an AoSoA" );
     return src;
 }
 
@@ -221,20 +121,277 @@ AoSoA<typename SrcAoSoA::member_types,
 create_mirror_view_and_copy(
     const Space&,
     const SrcAoSoA& src,
-    typename std::enable_if<(is_aosoa<SrcAoSoA>::value &&
-                             !std::is_same<typename SrcAoSoA::memory_space,
+    typename std::enable_if<(!std::is_same<typename SrcAoSoA::memory_space,
                              typename Space::memory_space>::value)>::type* = 0 )
 {
+    static_assert( is_aosoa<SrcAoSoA>::value,
+                   "create_mirror_view_and_copy() requires an AoSoA" );
+
     auto dst = AoSoA<typename SrcAoSoA::member_types,
                      typename Space::memory_space,
                      SrcAoSoA::vector_length>( src.size() );
-    deep_copy( dst, src );
+
+    Kokkos::Impl::DeepCopy<
+        typename Space::memory_space,typename SrcAoSoA::memory_space>(
+            dst.ptr(),
+            src.ptr(),
+            src.numSoA() * sizeof(typename SrcAoSoA::soa_type) );
+
     return dst;
 }
 
 //---------------------------------------------------------------------------//
 
 } // end namespace Experimental
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Deep copy data between compatible AoSoA objects.
+
+  \param dst The destination for the copied data.
+
+  \param src The source of the copied data.
+
+  Only AoSoA objects with the same set of member data types and size may be
+  copied.
+*/
+template<class DstAoSoA, class SrcAoSoA>
+inline void deep_copy(
+    DstAoSoA& dst,
+    const SrcAoSoA& src,
+    typename std::enable_if<(is_aosoa<DstAoSoA>::value &&
+                             is_aosoa<SrcAoSoA>::value)>::type *  = 0 )
+{
+    using dst_type = DstAoSoA;
+    using src_type = SrcAoSoA;
+    using dst_memory_space = typename dst_type::memory_space;
+    using src_memory_space = typename src_type::memory_space;
+    using dst_soa_type = typename dst_type::soa_type;
+    using src_soa_type = typename src_type::soa_type;
+
+    // Check that the data types are the same.
+    static_assert(
+        std::is_same<typename dst_type::member_types,
+        typename src_type::member_types>::value,
+        "Attempted to deep copy AoSoA objects of different member types" );
+
+    // Check for the same number of values.
+    if ( dst.size() != src.size() )
+    {
+        throw std::runtime_error(
+            "Attempted to deep copy AoSoA objects of different sizes" );
+    }
+
+    // Get the pointers to the beginning of the data blocks.
+    void* dst_data = dst.ptr();
+    const void* src_data = src.ptr();
+
+    // Return if both pointers are null.
+    if ( dst_data == nullptr && src_data == nullptr )
+    {
+        return;
+    }
+
+    // Get the number of SoA's in each object.
+    auto dst_num_soa = dst.numSoA();
+    auto src_num_soa = src.numSoA();
+
+    // Return if the AoSoA memory occupies the same space.
+    if ( (dst_data == src_data) &&
+         (dst_num_soa * sizeof(dst_soa_type) ==
+          src_num_soa * sizeof(src_soa_type)) )
+    {
+        return;
+    }
+
+    // If the inner array size is the same and both AoSoAs have the same number
+    // of values then we can do a byte-wise copy directly.
+    if ( std::is_same<dst_soa_type,src_soa_type>::value )
+    {
+        Kokkos::Impl::DeepCopy<dst_memory_space,src_memory_space>(
+            dst_data, src_data, dst_num_soa * sizeof(dst_soa_type) );
+    }
+
+    // Otherwise copy the data element-by-element because the data layout is
+    // different.
+    else
+    {
+        // Create an AoSoA in the destination space with the same data layout
+        // as the source.
+        auto src_copy_on_dst =
+            Experimental::create_mirror_view_and_copy(
+                typename dst_type::memory_space(), src );
+
+        // Copy via tuples.
+        auto copy_func =
+            KOKKOS_LAMBDA( const std::size_t i )
+            { dst.setTuple( i, src_copy_on_dst.getTuple(i) ); };
+        Kokkos::RangePolicy<typename dst_memory_space::execution_space>
+            exec_policy( 0, dst.size() );
+        Kokkos::parallel_for( "Cabana::deep_copy", exec_policy, copy_func );
+        Kokkos::fence();
+    }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Fill an AoSoA with a tuple.
+
+  \param slice The AoSoA to fill.
+
+  \param src The tuple to assign. All AoSoA elements will be assigned this
+  value.
+*/
+template<class AoSoA_t>
+inline void deep_copy( AoSoA_t& aosoa,
+                       const typename AoSoA_t::tuple_type& tuple )
+{
+    static_assert( is_aosoa<AoSoA_t>::value,
+                   "Only AoSoAs can be assigned tuples" );
+    auto assign_func =
+        KOKKOS_LAMBDA( const std::size_t i )
+        { aosoa.setTuple( i, tuple ); };
+    Kokkos::RangePolicy<typename AoSoA_t::memory_space::execution_space>
+        exec_policy( 0, aosoa.size() );
+    Kokkos::parallel_for( "Cabana::deep_copy", exec_policy, assign_func );
+    Kokkos::fence();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Deep copy data between compatible Slice objects.
+
+  \param dst The destination for the copied data.
+
+  \param src The source of the copied data.
+
+  Only Slice objects with the same set of member data types and size may be
+  copied.
+*/
+template<class DstSlice, class SrcSlice>
+inline void deep_copy(
+    DstSlice& dst,
+    const SrcSlice& src,
+    typename std::enable_if<(is_slice<DstSlice>::value &&
+                             is_slice<SrcSlice>::value)>::type *  = 0 )
+{
+    using dst_type = DstSlice;
+    using src_type = SrcSlice;
+
+    // Check that the data types are the same.
+    static_assert(
+        std::is_same<typename dst_type::value_type,
+        typename src_type::value_type>::value,
+        "Attempted to deep copy Slice objects of different value types" );
+
+    // Check that the element dimensions are the same.
+    static_assert( SrcSlice::view_layout::D0 == SrcSlice::view_layout::D0,
+                   "Slice dimension 0 is different" );
+    static_assert( SrcSlice::view_layout::D1 == SrcSlice::view_layout::D1,
+                   "Slice dimension 1 is different" );
+    static_assert( SrcSlice::view_layout::D2 == SrcSlice::view_layout::D2,
+                   "Slice dimension 2 is different" );
+    static_assert( SrcSlice::view_layout::D3 == SrcSlice::view_layout::D3,
+                   "Slice dimension 3 is different" );
+    static_assert( SrcSlice::view_layout::D4 == SrcSlice::view_layout::D4,
+                   "Slice dimension 4 is different" );
+    static_assert( SrcSlice::view_layout::D5 == SrcSlice::view_layout::D5,
+                   "Slice dimension 5 is different" );
+
+    // Check for the same number of elements.
+    if ( dst.size() != src.size() )
+    {
+        throw std::runtime_error(
+            "Attempted to deep copy Slice objects of different sizes" );
+    }
+
+    // Get the pointers to the beginning of the data blocks.
+    auto dst_data = dst.data();
+    auto src_data = src.data();
+
+    // Return if both pointers are null.
+    if ( dst_data == nullptr && src_data == nullptr )
+    {
+        return;
+    }
+
+    // Get the number of SoA's in each object.
+    auto dst_num_soa = dst.numSoA();
+    auto src_num_soa = src.numSoA();
+
+    // Return if the slice memory occupies the same space.
+    if ( (dst_data == src_data) &&
+         (dst_num_soa * dst.stride(0) == src_num_soa * src.stride(0)) )
+    {
+        return;
+    }
+
+    // Get the number of components in each slice element.
+    int num_comp = 1;
+    for ( int d = 2; d < dst.rank(); ++d )
+        num_comp *= dst.extent(d);
+
+    // Gather the slice data in a flat view in the source space and copy it to
+    // the destination space.
+    Kokkos::View<typename dst_type::value_type*,typename dst_type::memory_space>
+        gather_dst( "gather_dst", num_comp * dst.size() );
+    {
+        Kokkos::View<typename src_type::value_type*,
+                     typename src_type::memory_space>
+            gather_src( "gather_src", num_comp * src.size() );
+        auto gather_func =
+            KOKKOS_LAMBDA( const std::size_t i )
+            {
+                auto src_offset =
+                SrcSlice::index_type::s(i) * src.stride(0) +
+                SrcSlice::index_type::a(i);
+                for ( int n = 0; n < num_comp; ++n )
+                    gather_src( i * num_comp + n ) =
+                        src_data[ src_offset + SrcSlice::vector_length * n ];
+            };
+        Kokkos::RangePolicy<typename src_type::memory_space::execution_space>
+            gather_policy( 0, src.size() );
+        Kokkos::parallel_for(
+            "Cabana::deep_copy::gather", gather_policy, gather_func );
+        Kokkos::fence();
+        Kokkos::deep_copy( gather_dst, gather_src );
+    }
+
+    // Scatter back into the destination slice from the gathered slice.
+    auto scatter_func =
+        KOKKOS_LAMBDA( const std::size_t i )
+        {
+            auto dst_offset =
+            DstSlice::index_type::s(i) * dst.stride(0) +
+            DstSlice::index_type::a(i);
+            for ( int n = 0; n < num_comp; ++n )
+                dst_data[ dst_offset + DstSlice::vector_length * n ] =
+                    gather_dst( i * num_comp + n );
+        };
+    Kokkos::RangePolicy<typename dst_type::memory_space::execution_space>
+        scatter_policy( 0, dst.size() );
+    Kokkos::parallel_for(
+        "Cabana::deep_copy::scatter", scatter_policy, scatter_func );
+    Kokkos::fence();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Fill a slice with a scalar.
+
+  \param slice The slice to fill.
+
+  \param src The scalar to assign. All slice elements will be assigned this
+  value.
+*/
+template<class Slice_t>
+inline void deep_copy( Slice_t& slice,
+                       const typename Slice_t::value_type scalar )
+{
+    static_assert( is_slice<Slice_t>::value,
+                   "Only slices can be assigned scalars" );
+    Kokkos::deep_copy( slice.view(), scalar );
+}
 
 //---------------------------------------------------------------------------//
 

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -38,7 +38,7 @@ struct LayoutCabanaSlice
 {
     typedef LayoutCabanaSlice array_layout;
 
-    enum { is_extent_constructible = false };
+    enum { is_extent_constructible = true };
 
     static constexpr int Stride = SOASTRIDE;
     static constexpr int VectorLength = VLEN;
@@ -58,8 +58,15 @@ struct LayoutCabanaSlice
 
     KOKKOS_INLINE_FUNCTION
     explicit constexpr
-    LayoutCabanaSlice( size_t num_soa )
-        : dimension { num_soa, VectorLength, D0, D1, D2, D3, D4, D5 }
+    LayoutCabanaSlice( size_t num_soa = 0,
+                       size_t vector_length = VectorLength,
+                       size_t d0 = D0,
+                       size_t d1 = D1,
+                       size_t d2 = D2,
+                       size_t d3 = D3,
+                       size_t d4 = D4,
+                       size_t d5 = D5 )
+        : dimension { num_soa, vector_length, d0, d1, d2, d3, d4, d5 }
     {}
 };
 
@@ -463,6 +470,7 @@ class Slice
     using pointer_type = typename kokkos_view::pointer_type;
     using execution_space = typename kokkos_view::execution_space;
     using device_type = typename kokkos_view::device_type;
+    using view_layout = typename kokkos_view::array_layout;
 
     // Compatible memory access slice types.
     using default_access_slice =
@@ -746,6 +754,13 @@ class Slice
     KOKKOS_INLINE_FUNCTION
     std::size_t stride( const std::size_t d ) const
     { return _view.stride(d); }
+
+    /*!
+      \brief Get the underlying Kokkos View managing the slice data.
+    */
+    KOKKOS_INLINE_FUNCTION
+    kokkos_view view() const
+    { return _view; }
 
   private:
 


### PR DESCRIPTION
This PR adds a number of user-requested features for Deep Copy:

- The ability to deep copy between two slices. The slices must have the same element types for this to work. This is checked at compile time.
- The ability to assign a scalar value to all elements of a slice. Good for initialization or reinitialization. This is identical to the Kokkos view scalar assignment capability.
- The ability to assign a tuple to each element of an AoSoA. This is the analog to slice scalar assignment.

The tutorial has also been updated to include these features. I did some slight cleaning so the new create mirror view code can be used to simplify the deep copy implementations.