### PR TITLE
Adding labels to the aosoa and slice

### DIFF
--- a/core/example/benchmark/Cabana_peakflops.cpp
+++ b/core/example/benchmark/Cabana_peakflops.cpp
@@ -204,18 +204,18 @@ void run()
     int num_particle = num_struct*array_size;
 
     // Create the particle lists.
-    ParticleList a_( num_particle );
-    ParticleList x_( num_particle );
-    ParticleList c_( num_particle );
-    ParticleList x1_( num_particle );
-    ParticleList x2_( num_particle );
-    ParticleList x3_( num_particle );
-    ParticleList x4_( num_particle );
-    ParticleList x5_( num_particle );
-    ParticleList x6_( num_particle );
-    ParticleList x7_( num_particle );
-    ParticleList x8_( num_particle );
-    ParticleList x9_( num_particle );
+    ParticleList a_( "a", num_particle );
+    ParticleList x_( "x", num_particle );
+    ParticleList c_( "c", num_particle );
+    ParticleList x1_( "x1", num_particle );
+    ParticleList x2_( "x2", num_particle );
+    ParticleList x3_( "x3", num_particle );
+    ParticleList x4_( "x4", num_particle );
+    ParticleList x5_( "x5", num_particle );
+    ParticleList x6_( "x6", num_particle );
+    ParticleList x7_( "x7", num_particle );
+    ParticleList x8_( "x8", num_particle );
+    ParticleList x9_( "x9", num_particle );
 
     // Get a slice of the x position field from each particle list.
     auto ma = a_.slice<PositionX>();

--- a/core/example/benchmark/md_neighbor_perf_test.cpp
+++ b/core/example/benchmark/md_neighbor_perf_test.cpp
@@ -56,10 +56,10 @@ void perfTest( const double cutoff_ratio,
     using AoSoA_t = Cabana::AoSoA<DataTypes,MemorySpace,vector_length>;
 
     // Create an Array-of-Structs-of-Arrays.
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Get the particle postions.
-    auto x = aosoa.slice<Position>();
+    auto x = aosoa.slice<Position>("position");
 
     // Build particles.
     std::cout << std::endl;
@@ -163,13 +163,13 @@ void perfTest( const double cutoff_ratio,
     double sort_delta[3] =
         { interaction_cutoff, interaction_cutoff, interaction_cutoff };
     Cabana::LinkedCellList<MemorySpace>
-        linked_cell_list( aosoa.slice<Position>(),
+        linked_cell_list( aosoa.slice<Position>("position"),
                           sort_delta, grid_min, grid_max );
     Cabana::permute( linked_cell_list, aosoa );
 
     // Create the list once to get some statistics.
     Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR>
-        stat_list( aosoa.slice<Position>(), 0, aosoa.size(),
+        stat_list( aosoa.slice<Position>("position"), 0, aosoa.size(),
                    interaction_cutoff, cell_size_ratio, grid_min, grid_max );
     Kokkos::MinMaxScalar<int> result;
     Kokkos::MinMax<int> reducer(result);
@@ -196,7 +196,7 @@ void perfTest( const double cutoff_ratio,
         auto start_time = std::chrono::high_resolution_clock::now();
 
         Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR> list(
-            aosoa.slice<Position>(), 0, aosoa.size(),
+            aosoa.slice<Position>("position"), 0, aosoa.size(),
             interaction_cutoff, cell_size_ratio, grid_min, grid_max );
 
         auto end_time = std::chrono::high_resolution_clock::now();

--- a/core/example/longrange/directsum_example.cpp
+++ b/core/example/longrange/directsum_example.cpp
@@ -26,14 +26,14 @@ int main(int argc, char** argv)
   const int n_particles = c_size * c_size * c_size;
   //Number of periodic shells
   const int periodic_shells = 3;
-  
+
   //Create an empty list of all the particles
-  ParticleList *particles = new ParticleList( n_particles );
+  ParticleList *particles = new ParticleList( "particles", n_particles );
 
   std::cout << std::setprecision(12);
 
   //Initialize the particles
-  //Currently particles are initialized as alternating charges 
+  //Currently particles are initialized as alternating charges
   //in uniform cubic grid pattern like NaCl
   initializeParticles( *particles, c_size );
 
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
   timer.reset();
 
   auto elapsed_time = tune_time + exec_time;
-  
+
   //Print out the timings and accuracy
   std::cout << "Time for initialization in Direct Sum solver: " << (tune_time) << " s." << std::endl;
   std::cout << "Time for computation in Direct Sum solver:        " << (exec_time) << " s." << std::endl;
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
   std::cout << "total potential energy (Direct Sum): " << total_energy << std::endl;
   std::cout << "absolute error (energy): " << (n_particles * MADELUNG_NACL)-total_energy << std::endl;
   std::cout << "relative error (energy): " << 1.0 - (n_particles * MADELUNG_NACL)/total_energy << std::endl;
-  
+
   //delete particles;
   //Kokkos::fence();
   Kokkos::finalize();

--- a/core/example/longrange/spme_example.cpp
+++ b/core/example/longrange/spme_example.cpp
@@ -16,24 +16,24 @@ int main(int argc, char** argv)
   const double width = 1.0;
   //Number of mesh points in each direction for SPME
   const int n_meshpoints = 4096;//16*16*16;
-  //Declare alpha and rmax, but just let the tuner select their values later  
+  //Declare alpha and rmax, but just let the tuner select their values later
   //double alpha, r_max;
   //Number of particles, 3D
   const int n_particles = c_size * c_size * c_size;
- 
+
   //Create an empty list of all the particles
-  ParticleList *particles = new ParticleList( n_particles );
+  ParticleList *particles = new ParticleList( "particles", n_particles );
   //Create an empty list of all the mesh points
-  ParticleList *mesh = new ParticleList( n_meshpoints );
+  ParticleList *mesh = new ParticleList( "mesh", n_meshpoints );
 
   std::cout << std::setprecision(12);
 
   //Initialize the particles and mesh
-  //Currently particles are initialized as alternating charges 
+  //Currently particles are initialized as alternating charges
   //in uniform cubic grid pattern like NaCl
   initializeParticles( *particles, c_size );
   //Mesh is by default cubic and uniform
-  initializeMesh( *mesh, width );  
+  initializeMesh( *mesh, width );
 
   //Create a Kokkos timer to measure performance
   Kokkos::Timer timer;
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
   timer.reset();
 
   auto elapsed_time = tune_time + exec_time;
-  
+
   //Print out the timings and accuracy
   std::cout << "Time for init+tuning parameters in SPME solver: " << (tune_time) << " s." << std::endl;
   std::cout << "Time for computation in SPME solver:        " << (exec_time) << " s." << std::endl;
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
   std::cout << "total potential energy (SPME): " << total_energy << std::endl;
   std::cout << "absolute error (energy): " << (n_particles * MADELUNG_NACL)-total_energy << std::endl;
   std::cout << "relative error (energy): " << 1.0 - (n_particles * MADELUNG_NACL)/total_energy << std::endl;
-  
+
   //Clean up
   delete mesh;
   delete particles;

--- a/core/example/scafacos/scafacos_example.cpp
+++ b/core/example/scafacos/scafacos_example.cpp
@@ -105,14 +105,14 @@ void initializeParticles( ParticleList& particles,
                           double gap_space,
                           parallel_info& info )
 {
-    auto p_x = particles.slice<PositionX>();
-    auto p_y = particles.slice<PositionY>();
-    auto p_z = particles.slice<PositionZ>();
-    auto v = particles.slice<Velocity>();
-    auto q = particles.slice<Charge>();
-    auto pot = particles.slice<Potential>();
-    auto field = particles.slice<Field>();
-    auto indx = particles.slice<Index>();
+    auto p_x = particles.slice<PositionX>("position_x");
+    auto p_y = particles.slice<PositionY>("position_y");
+    auto p_z = particles.slice<PositionZ>("position_z");
+    auto v = particles.slice<Velocity>("velocity");
+    auto q = particles.slice<Charge>("charge");
+    auto pot = particles.slice<Potential>("potential");
+    auto field = particles.slice<Field>("field");
+    auto indx = particles.slice<Index>("index");
 
     int offset;
 
@@ -157,14 +157,14 @@ void printParticles( const ParticleList particles, parallel_info& info )
 {
 
     // get slices for the corresponding particle data
-    auto p_x = particles.slice<PositionX>();
-    auto p_y = particles.slice<PositionY>();
-    auto p_z = particles.slice<PositionZ>();
-    auto v = particles.slice<Velocity>();
-    auto q = particles.slice<Charge>();
-    auto pot = particles.slice<Potential>();
-    auto field = particles.slice<Field>();
-    auto indx = particles.slice<Index>();
+    auto p_x = particles.slice<PositionX>("position_x");
+    auto p_y = particles.slice<PositionY>("position_y");
+    auto p_z = particles.slice<PositionZ>("position_z");
+    auto v = particles.slice<Velocity>("velocity");
+    auto q = particles.slice<Charge>("charge");
+    auto pot = particles.slice<Potential>("potential");
+    auto field = particles.slice<Field>("field");
+    auto indx = particles.slice<Index>("index");
 
     std::cout << "Rank: "
               << info.rank
@@ -223,7 +223,7 @@ void exampleMain(int num_particle,
 
 
     // Create the particle list.
-    ParticleList particles( info.n_local_particles );
+    ParticleList particles( "particles", info.n_local_particles );
 
     // Initialize particles.
     initializeParticles( particles,
@@ -256,10 +256,10 @@ void exampleMain(int num_particle,
     std::vector<double> f(3*info.n_local_particles);
     std::vector<double> pot(info.n_local_particles);
 
-    auto p_x = particles.slice<PositionX>();
-    auto p_y = particles.slice<PositionY>();
-    auto p_z = particles.slice<PositionZ>();
-    auto qp = particles.slice<Charge>();
+    auto p_x = particles.slice<PositionX>("x_position");
+    auto p_y = particles.slice<PositionY>("y_position");
+    auto p_z = particles.slice<PositionZ>("z_position");
+    auto qp = particles.slice<Charge>("charge");
 
     for (int i = 0; i < info.n_local_particles; ++i)
     {

--- a/core/example/tutorial/04_aosoa/aosoa_example.cpp
+++ b/core/example/tutorial/04_aosoa/aosoa_example.cpp
@@ -68,16 +68,20 @@ void aosoaExample()
        Create the AoSoA. We define how many tuples the aosoa will
        contain. Note that if the number of tuples is not evenly divisible by
        the vector length then the last SoA in the AoSoA will not be entirely
-       full (although its memory will still be allocated).
+       full (although its memory will still be allocated). The AoSoA label
+       allows one to track the managed memory in an AoSoA through the Kokkos
+       allocation tracker.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "my_aosoa", num_tuple );
 
     /*
-       Print size data. In this case we have created an AoSoA with 5
-       tuples. Because a vector length of 4 is used, a total memory capacity
-       for 8 tuples will be allocated in 2 SoAs.
+       Print the label and size data. In this case we have created an AoSoA
+       with 5 tuples. Because a vector length of 4 is used, a total memory
+       capacity for 8 tuples will be allocated in 2 SoAs.
     */
+    std::cout << "aosoa.label() = " << aosoa.label() << std::endl;
     std::cout << "aosoa.size() = " << aosoa.size() << std::endl;
     std::cout << "aosoa.capacity() = " << aosoa.capacity() << std::endl;
     std::cout << "aosoa.numSoA() = " << aosoa.numSoA() << std::endl;

--- a/core/example/tutorial/05_slice/slice_example.cpp
+++ b/core/example/tutorial/05_slice/slice_example.cpp
@@ -76,18 +76,22 @@ void sliceExample()
        full (although its memory will still be allocated).
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "my_aosoa", num_tuple );
 
     /*
       Create a slice over each tuple member in the AoSoA. An integer template
       parameter is used to indicate which member to slice. A slice object
       simply wraps the data associated with an AoSoA member in a more
       conventient accessor structure. A slice therefore has the same memory
-      space as the AoSoA from which it was derived.
-     */
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
-    auto slice_2 = aosoa.slice<2>();
+      space as the AoSoA from which it was derived. Slices may optionally be
+      assigned a label. This label is not included in the memory tracker
+      because slices are unmanaged memory but may still be used for diagnostic
+      purposes.
+    */
+    auto slice_0 = aosoa.slice<0>( "my_slice_0" );
+    auto slice_1 = aosoa.slice<1>( "my_slice_1" );
+    auto slice_2 = aosoa.slice<2>( "my_slice_2" );
 
     /*
       Let's initialize the data using the 2D indexing scheme. Slice data can

--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -59,8 +59,10 @@ void deepCopyExample()
        Create the source and destination AoSoAs.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes,SrcMemorySpace,SrcVectorLength> src_aosoa( num_tuple );
-    Cabana::AoSoA<DataTypes,DstMemorySpace,DstVectorLength> dst_aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,SrcMemorySpace,SrcVectorLength>
+        src_aosoa( "src", num_tuple );
+    Cabana::AoSoA<DataTypes,DstMemorySpace,DstVectorLength>
+        dst_aosoa( "dst", num_tuple );
 
     /*
       Put some data in the source AoSoA.

--- a/core/example/tutorial/07_sorting/sorting.cpp
+++ b/core/example/tutorial/07_sorting/sorting.cpp
@@ -45,7 +45,8 @@ void sortingExample()
        Create the AoSoA.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "my_aosoa", num_tuple );
 
     /*
       Fill the AoSoA with data. The integer member of the AoSoA will be

--- a/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
+++ b/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
@@ -51,7 +51,8 @@ void linkedCellListExample()
        Create the AoSoA.
     */
     int num_tuple = 54;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "A", num_tuple );
 
     /*
       Define the parameters of the Cartesian grid over which we will build the
@@ -68,6 +69,7 @@ void linkedCellListExample()
     auto ids = aosoa.slice<1>();
     for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
+
     /*
       Create the particle coordinates. We will put 2 particles in the center
       of each cell. We are ordering this such that each consecutive particle

--- a/core/example/tutorial/09_verlet_list/verlet_list.cpp
+++ b/core/example/tutorial/09_verlet_list/verlet_list.cpp
@@ -45,7 +45,7 @@ void verletListExample()
        Create the AoSoA.
     */
     int num_tuple = 81;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( "A", num_tuple );
 
     /*
       Define the parameters of the Cartesian grid over which we will build the
@@ -62,6 +62,7 @@ void verletListExample()
     auto ids = aosoa.slice<1>();
     for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
+
     /*
       Create the particle coordinates. We will put 3 particles in the center
       of each cell. We will set the Verlet list parameters such that each

--- a/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
+++ b/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
@@ -53,7 +53,7 @@ void atomicSliceExample()
        Create the AoSoA. Just put a single value to demonstrate the atomic.
     */
     int num_tuple = 1;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( "A", num_tuple );
 
     /*
       Create a slice over the single value and assign it to zero.

--- a/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
+++ b/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
@@ -37,7 +37,7 @@ void atomicSliceExample()
        Create the AoSoA. Just put a single value to demonstrate the atomic.
     */
     int num_tuple = 1;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( "X", num_tuple );
 
     /*
       Create a slice over the single value and assign it to zero.

--- a/core/example/tutorial/11_parallel_for/parallel_for_example.cpp
+++ b/core/example/tutorial/11_parallel_for/parallel_for_example.cpp
@@ -60,7 +60,8 @@ void parallelForExample()
        Create the AoSoA.
     */
     const int num_tuple = 100;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "my_aosoa", num_tuple );
 
     /*
       Create slices and assign some data. One might consider using a parallel

--- a/core/example/tutorial/12_migration/migration_example.cpp
+++ b/core/example/tutorial/12_migration/migration_example.cpp
@@ -58,7 +58,7 @@ void migrationExample()
        Create the AoSoA.
     */
     int num_tuple = 100;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( "A", num_tuple );
 
     /*
       Create slices and assign data. The data values are equal to id of this

--- a/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
+++ b/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
@@ -62,7 +62,8 @@ void haloExchangeExample()
        Create the AoSoA.
     */
     int num_tuple = 100;
-    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( num_tuple );
+    Cabana::AoSoA<DataTypes,MemorySpace,VectorLength>
+        aosoa( "my_aosoa", num_tuple );
 
     /*
       Create slices and assign data.

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <type_traits>
+#include <string>
 
 //---------------------------------------------------------------------------//
 namespace Kokkos
@@ -504,12 +505,15 @@ class Slice
       \param soa_stride The number of elements in the slice's value type between starting
       elements of a struct.
       \param num_soa The number of structs in the slice.
+      \param label An optional label for the slice.
     */
     Slice( const pointer_type data,
            const std::size_t size,
-           const std::size_t num_soa )
+           const std::size_t num_soa,
+           const std::string& label = "" )
         : _view( data, view_wrapper::createLayout(num_soa) )
         , _size( size )
+        , _label( label )
     {}
 
     /*!
@@ -523,6 +527,7 @@ class Slice
     Slice( const Slice<DataType,MemorySpace,MAT,VectorLength,Stride>& rhs )
         : _view( rhs._view )
         , _size( rhs._size )
+        , _label( rhs._label )
     {}
 
     /*!
@@ -539,8 +544,17 @@ class Slice
     {
         _view = rhs._view;
         _size = rhs._size;
+        _label = rhs._label;
         return *this;
     }
+
+    /*!
+      \brief Returns the data structure label.
+
+      \return A string identifying the data structure.
+    */
+    std::string label() const
+    { return std::string(_label); }
 
     /*!
       \brief Returns the total number tuples in the slice.
@@ -770,6 +784,9 @@ class Slice
 
     // Number of tuples in the slice.
     std::size_t _size;
+
+    // Slice label.
+    std::string _label;
 };
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -339,7 +339,7 @@ void testTuple()
     // Create an AoSoA.
     int num_data = 453;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "label", num_data );
 
     // Create a slice of tuples with the same data types.
     Kokkos::View<Tuple_t*,typename AoSoA_t::memory_space>
@@ -451,7 +451,7 @@ void testAccess()
 
     // Create an AoSoA.
     int num_data = 453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "label", num_data );
 
     // Initialize data with the SoA accessor
     float fval = 3.4;

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -87,13 +87,26 @@ void testAoSoA()
     EXPECT_TRUE( Cabana::is_aosoa<AoSoA_t>::value );
 
     // Create an AoSoA.
-    AoSoA_t aosoa;
+    std::string label = "test_aosoa";
+    AoSoA_t aosoa( label );
+    EXPECT_EQ( aosoa.label(), label );
 
     // Get field slices.
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
-    auto slice_2 = aosoa.slice<2>();
-    auto slice_3 = aosoa.slice<3>();
+    std::string s0_label = "slice_0";
+    auto slice_0 = aosoa.slice<0>( s0_label );
+    EXPECT_EQ( slice_0.label(), s0_label );
+
+    std::string s1_label = "slice_1";
+    auto slice_1 = aosoa.slice<1>( s1_label );
+    EXPECT_EQ( slice_1.label(), s1_label );
+
+    std::string s2_label = "slice_2";
+    auto slice_2 = aosoa.slice<2>( s2_label );
+    EXPECT_EQ( slice_2.label(), s2_label );
+
+    std::string s3_label = "slice_3";
+    auto slice_3 = aosoa.slice<3>( s3_label );
+    EXPECT_EQ( slice_3.label(), s3_label );
 
     // Check sizes.
     EXPECT_EQ( aosoa.size(), int(0) );
@@ -219,7 +232,9 @@ void testRawData()
 
     // Create an AoSoA using the default constructor.
     int num_data = 350;
-    AoSoA_t aosoa( num_data );
+    std::string label = "test_aosoa";
+    AoSoA_t aosoa( label, num_data );
+    EXPECT_EQ( aosoa.label(), label );
 
     // Get slices of fields.
     auto slice_0 = aosoa.slice<0>();

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -83,8 +83,8 @@ void testDeepCopy()
 
     // Create AoSoAs.
     int num_data = 357;
-    DstAoSoA_t dst_aosoa( num_data );
-    SrcAoSoA_t src_aosoa( num_data );
+    DstAoSoA_t dst_aosoa( "dst", num_data );
+    SrcAoSoA_t src_aosoa( "src", num_data );
 
     // Initialize data with the rank accessors.
     float fval = 3.4;
@@ -157,7 +157,7 @@ void testMirror()
 
     // Create an AoSoA in the test memory space.
     int num_data = 423;
-    Cabana::AoSoA<DataTypes,TEST_MEMSPACE> aosoa( num_data );
+    Cabana::AoSoA<DataTypes,TEST_MEMSPACE> aosoa( "label", num_data );
 
     // Initialize data.
     float fval = 3.4;
@@ -252,7 +252,7 @@ void testAssign()
 
     // Create an AoSoA in the test memory space.
     int num_data = 423;
-    Cabana::AoSoA<DataTypes,TEST_MEMSPACE> aosoa( num_data );
+    Cabana::AoSoA<DataTypes,TEST_MEMSPACE> aosoa( "label", num_data );
 
     // Assign every tuple in the AoSoA to the same value.
     float fval = 3.2;

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -55,7 +55,7 @@ void test1( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data_src( num_data );
+    AoSoA_t data_src( "src", num_data );
     auto slice_int_src = data_src.slice<0>();
     auto slice_dbl_src = data_src.slice<1>();
 
@@ -72,7 +72,7 @@ void test1( const bool use_topology )
     Kokkos::fence();
 
     // Create a second set of data to which we will migrate.
-    AoSoA_t data_dst( num_data );
+    AoSoA_t data_dst( "dst", num_data );
     auto slice_int_dst = data_dst.slice<0>();
     auto slice_dbl_dst = data_dst.slice<1>();
 
@@ -80,7 +80,8 @@ void test1( const bool use_topology )
     Cabana::migrate( *distributor, data_src, data_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_dst_host( num_data );
+    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_dst_host(
+        "data_dst_host", num_data );
     auto slice_int_dst_host = data_dst_host.slice<0>();
     auto slice_dbl_dst_host = data_dst_host.slice<1>();
     Cabana::deep_copy( data_dst_host, data_dst );
@@ -126,7 +127,7 @@ void test2( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data( num_data );
+    AoSoA_t data( "data", num_data );
     auto slice_int = data.slice<0>();
     auto slice_dbl = data.slice<1>();
 
@@ -147,7 +148,8 @@ void test2( const bool use_topology )
     Cabana::migrate( *distributor, data );
 
     // Get host copies of the migrated data.
-    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host( num_data / 2 );
+    Cabana::AoSoA<DataTypes,Cabana::HostSpace>
+        data_host( "data_host", num_data / 2 );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data );
@@ -201,7 +203,7 @@ void test3( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data_src( num_data );
+    AoSoA_t data_src( "data_src", num_data );
     auto slice_int_src = data_src.slice<0>();
     auto slice_dbl_src = data_src.slice<1>();
 
@@ -219,7 +221,7 @@ void test3( const bool use_topology )
     Kokkos::fence();
 
     // Create a second set of data to which we will migrate.
-    AoSoA_t data_dst( num_data );
+    AoSoA_t data_dst( "data_dst", num_data );
     auto slice_int_dst = data_dst.slice<0>();
     auto slice_dbl_dst = data_dst.slice<1>();
 
@@ -247,7 +249,8 @@ void test3( const bool use_topology )
         Kokkos::HostSpace(), inverse_steering );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_dst_host( num_data );
+    Cabana::AoSoA<DataTypes,Cabana::HostSpace>
+        data_dst_host( "data_dst_host", num_data );
     Cabana::deep_copy( data_dst_host, data_dst );
     auto slice_int_dst_host = data_dst_host.slice<0>();
     auto slice_dbl_dst_host = data_dst_host.slice<1>();
@@ -298,7 +301,7 @@ void test4( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data_src( num_data );
+    AoSoA_t data_src( "data_src", num_data );
     auto slice_int_src = data_src.slice<0>();
     auto slice_dbl_src = data_src.slice<1>();
 
@@ -316,7 +319,7 @@ void test4( const bool use_topology )
     Kokkos::fence();
 
     // Create a second set of data to which we will migrate.
-    AoSoA_t data_dst( num_data );
+    AoSoA_t data_dst( "data_dst", num_data );
     auto slice_int_dst = data_dst.slice<0>();
     auto slice_dbl_dst = data_dst.slice<1>();
 
@@ -324,7 +327,8 @@ void test4( const bool use_topology )
     Cabana::migrate( *distributor, data_src, data_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_dst_host( num_data );
+    Cabana::AoSoA<DataTypes,Cabana::HostSpace>
+        data_dst_host( "data_dst_host", num_data );
     auto slice_int_dst_host = data_dst_host.slice<0>();
     auto slice_dbl_dst_host = data_dst_host.slice<1>();
     Cabana::deep_copy( data_dst_host, data_dst );
@@ -404,7 +408,7 @@ void test5( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data_src( num_data );
+    AoSoA_t data_src( "data_src", num_data );
     auto slice_int_src = data_src.slice<0>();
     auto slice_dbl_src = data_src.slice<1>();
 
@@ -422,7 +426,7 @@ void test5( const bool use_topology )
     Kokkos::fence();
 
     // Create a second set of data to which we will migrate.
-    AoSoA_t data_dst( my_size );
+    AoSoA_t data_dst( "data_dst", my_size );
     auto slice_int_dst = data_dst.slice<0>();
     auto slice_dbl_dst = data_dst.slice<1>();
 
@@ -431,7 +435,8 @@ void test5( const bool use_topology )
     Cabana::migrate( *distributor, slice_dbl_src, slice_dbl_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host( my_size );
+    Cabana::AoSoA<DataTypes,Cabana::HostSpace>
+        data_host( "data_host", my_size );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data_dst );
@@ -500,7 +505,7 @@ void test6( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data( num_data );
+    AoSoA_t data( "data", num_data );
     auto slice_int = data.slice<0>();
     auto slice_dbl = data.slice<1>();
 
@@ -527,7 +532,7 @@ void test6( const bool use_topology )
 
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
-        data_host( distributor->totalNumImport() );
+        data_host( "data_host", distributor->totalNumImport() );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data );
@@ -588,7 +593,7 @@ void test7( const bool use_topology )
     // Make some data to migrate.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data( num_data );
+    AoSoA_t data( "data", num_data );
     auto slice_int = data.slice<0>();
     auto slice_dbl = data.slice<1>();
 
@@ -611,7 +616,7 @@ void test7( const bool use_topology )
 
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
-        data_host( distributor->totalNumImport() );
+        data_host( "data_host", distributor->totalNumImport() );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data );

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -76,7 +76,7 @@ void test1( const bool use_topology )
     // Create an AoSoA of local data with space allocated for local data.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data( halo->numLocal() + halo->numGhost() );
+    AoSoA_t data( "data", halo->numLocal() + halo->numGhost() );
     auto slice_int = data.slice<0>();
     auto slice_dbl = data.slice<1>();
 
@@ -98,7 +98,7 @@ void test1( const bool use_topology )
 
     // Check the results of the gather.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host(
-        halo->numLocal() + halo->numGhost() );
+        "data_host", halo->numLocal() + halo->numGhost() );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data );
@@ -275,7 +275,7 @@ void test2( const bool use_topology )
     // Create an AoSoA of local data with space allocated for local data.
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t data( halo->numLocal() + halo->numGhost() );
+    AoSoA_t data( "data", halo->numLocal() + halo->numGhost() );
     auto slice_int = data.slice<0>();
     auto slice_dbl = data.slice<1>();
 
@@ -297,7 +297,7 @@ void test2( const bool use_topology )
 
     // Check the results of the gather.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host(
-        halo->numLocal() + halo->numGhost() );
+        "data_host", halo->numLocal() + halo->numGhost() );
     auto slice_int_host = data_host.slice<0>();
     auto slice_dbl_host = data_host.slice<1>();
     Cabana::deep_copy( data_host, data );

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -26,7 +26,7 @@ void testLinkedList()
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     using size_type = typename AoSoA_t::memory_space::size_type;
     int num_p = 1000;
-    AoSoA_t aosoa( num_p );
+    AoSoA_t aosoa( "aosoa", num_p );
 
     // Set the problem so each particle lives in the center of a cell on a
     // regular grid of cell size 1 and total size 10x10x10. We are making them
@@ -245,7 +245,7 @@ void testLinkedListSlice()
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     using size_type = typename AoSoA_t::memory_space::size_type;
     int num_p = 1000;
-    AoSoA_t aosoa( num_p );
+    AoSoA_t aosoa( "aosoa", num_p );
 
     // Set the problem so each particle lives in the center of a cell on a
     // regular grid of cell size 1 and total size 10x10x10. We are making them

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -162,7 +162,7 @@ createParticles( const int num_particle,
 {
     using DataTypes = Cabana::MemberTypes<double[3]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
-    AoSoA_t aosoa( num_particle );
+    AoSoA_t aosoa( "aosoa", num_particle );
 
     auto position = aosoa.slice<0>();
     using PoolType = Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE>;

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -172,7 +172,7 @@ void runTest2d()
 
     // Create an AoSoA.
     int num_data = 155;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a vectorized execution policy using the begin and end of the
     // AoSoA.

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -118,7 +118,7 @@ void apiTest()
     // Create an AoSoA.
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE,vector_length>;
     int num_data = 35;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create some slices.
     auto slice_0 = aosoa.slice<0>();
@@ -249,7 +249,7 @@ void randomAccessTest()
     // Create an AoSoA.
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE,vector_length>;
     int num_data = 35;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Initialize data.
     float fval = 3.4;
@@ -270,7 +270,7 @@ void randomAccessTest()
     decltype(da_slice_3)::random_access_slice ra_slice_3 = da_slice_3;
 
     // Create a second aosoa.
-    AoSoA_t aosoa_2( num_data );
+    AoSoA_t aosoa_2( "aosoa_2", num_data );
 
     // Get normal slices of the data.
     auto slice_0 = aosoa_2.slice<0>();
@@ -319,7 +319,7 @@ void atomicAccessTest()
     // Create an AoSoA.
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE,vector_length>;
     int num_data = 35;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Get a slice of the data.
     auto slice = aosoa.slice<0>();

--- a/core/unit_test/tstSort.hpp
+++ b/core/unit_test/tstSort.hpp
@@ -35,7 +35,7 @@ void testSortByKey()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
     using KeyViewType = Kokkos::View<int*,typename AoSoA_t::memory_space>;
@@ -121,7 +121,7 @@ void testBinByKey()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
     using KeyViewType = Kokkos::View<int*,typename AoSoA_t::memory_space>;
@@ -223,7 +223,7 @@ void testSortBySlice()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
@@ -305,7 +305,7 @@ void testSortBySliceDataOnly()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
@@ -387,7 +387,7 @@ void testBinBySlice()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
@@ -483,7 +483,7 @@ void testBinBySliceDataOnly()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
@@ -580,7 +580,7 @@ void testSortByKeySlice()
 
     // Create an AoSoA.
     int num_data = 3453;
-    AoSoA_t aosoa( num_data );
+    AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
     using KeyViewType = Kokkos::View<int*,typename AoSoA_t::memory_space>;


### PR DESCRIPTION
Adds labels to the AoSoA and Slice for profiling and debugging purposes. The AoSoA label will also end up in the Kokkos View managing that memory and therefore be present in the Kokkos allocation tracker. The slice label is only assigned to the slice because there is no allocation tracker associated with unmanaged views. However, these labels can still be used to compose output messages and other information. The mirror creation is also updated to add a mirror suffix to labels of newly create AoSoA data structures.

Closes #92 