### PR TITLE
Template helpers

### DIFF
--- a/core/example/benchmark/Cabana_peakflops.cpp
+++ b/core/example/benchmark/Cabana_peakflops.cpp
@@ -218,18 +218,18 @@ void run()
     ParticleList x9_( "x9", num_particle );
 
     // Get a slice of the x position field from each particle list.
-    auto ma = a_.slice<PositionX>();
-    auto mc = c_.slice<PositionX>();
-    auto m0 = x_.slice<PositionX>();
-    auto m1 = x1_.slice<PositionX>();
-    auto m2 = x2_.slice<PositionX>();
-    auto m3 = x3_.slice<PositionX>();
-    auto m4 = x4_.slice<PositionX>();
-    auto m5 = x5_.slice<PositionX>();
-    auto m6 = x6_.slice<PositionX>();
-    auto m7 = x7_.slice<PositionX>();
-    auto m8 = x8_.slice<PositionX>();
-    auto m9 = x9_.slice<PositionX>();
+    auto ma = Cabana::slice<PositionX>(a_);
+    auto mc = Cabana::slice<PositionX>(c_);
+    auto m0 = Cabana::slice<PositionX>(x_);
+    auto m1 = Cabana::slice<PositionX>(x1_);
+    auto m2 = Cabana::slice<PositionX>(x2_);
+    auto m3 = Cabana::slice<PositionX>(x3_);
+    auto m4 = Cabana::slice<PositionX>(x4_);
+    auto m5 = Cabana::slice<PositionX>(x5_);
+    auto m6 = Cabana::slice<PositionX>(x6_);
+    auto m7 = Cabana::slice<PositionX>(x7_);
+    auto m8 = Cabana::slice<PositionX>(x8_);
+    auto m9 = Cabana::slice<PositionX>(x9_);
 
     // Initialize particle data.
     long seed = 76843802738543;

--- a/core/example/benchmark/Cabana_peakflops.cpp
+++ b/core/example/benchmark/Cabana_peakflops.cpp
@@ -253,18 +253,18 @@ void run()
     }
 
     // Cast particle data to an explicit array-of-struct-of-arrays.
-    auto* pa = (data_t*)(a_.ptr());
-    auto* px = (data_t*)(x_.ptr());
-    auto* pc = (data_t*)(c_.ptr());
-    auto* px1 = (data_t*)(x1_.ptr());
-    auto* px2 = (data_t*)(x2_.ptr());
-    auto* px3 = (data_t*)(x3_.ptr());
-    auto* px4 = (data_t*)(x4_.ptr());
-    auto* px5 = (data_t*)(x5_.ptr());
-    auto* px6 = (data_t*)(x6_.ptr());
-    auto* px7 = (data_t*)(x7_.ptr());
-    auto* px8 = (data_t*)(x8_.ptr());
-    auto* px9 = (data_t*)(x9_.ptr());
+    auto* pa = (data_t*)(a_.data());
+    auto* px = (data_t*)(x_.data());
+    auto* pc = (data_t*)(c_.data());
+    auto* px1 = (data_t*)(x1_.data());
+    auto* px2 = (data_t*)(x2_.data());
+    auto* px3 = (data_t*)(x3_.data());
+    auto* px4 = (data_t*)(x4_.data());
+    auto* px5 = (data_t*)(x5_.data());
+    auto* px6 = (data_t*)(x6_.data());
+    auto* px7 = (data_t*)(x7_.data());
+    auto* px8 = (data_t*)(x8_.data());
+    auto* px9 = (data_t*)(x9_.data());
 
     // Print initial conditions.
     for (int idx = 0; idx < array_size; ++idx)

--- a/core/example/benchmark/md_neighbor_perf_test.cpp
+++ b/core/example/benchmark/md_neighbor_perf_test.cpp
@@ -59,7 +59,7 @@ void perfTest( const double cutoff_ratio,
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Get the particle postions.
-    auto x = aosoa.slice<Position>("position");
+    auto x = Cabana::slice<Position>(aosoa, "position");
 
     // Build particles.
     std::cout << std::endl;
@@ -163,13 +163,13 @@ void perfTest( const double cutoff_ratio,
     double sort_delta[3] =
         { interaction_cutoff, interaction_cutoff, interaction_cutoff };
     Cabana::LinkedCellList<MemorySpace>
-        linked_cell_list( aosoa.slice<Position>("position"),
+        linked_cell_list( Cabana::slice<Position>(aosoa,"position"),
                           sort_delta, grid_min, grid_max );
     Cabana::permute( linked_cell_list, aosoa );
 
     // Create the list once to get some statistics.
     Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR>
-        stat_list( aosoa.slice<Position>("position"), 0, aosoa.size(),
+        stat_list( Cabana::slice<Position>(aosoa,"position"), 0, aosoa.size(),
                    interaction_cutoff, cell_size_ratio, grid_min, grid_max );
     Kokkos::MinMaxScalar<int> result;
     Kokkos::MinMax<int> reducer(result);
@@ -196,7 +196,7 @@ void perfTest( const double cutoff_ratio,
         auto start_time = std::chrono::high_resolution_clock::now();
 
         Cabana::VerletList<MemorySpace,NeighborListTag,Cabana::VerletLayoutCSR> list(
-            aosoa.slice<Position>("position"), 0, aosoa.size(),
+            Cabana::slice<Position>(aosoa,"position"), 0, aosoa.size(),
             interaction_cutoff, cell_size_ratio, grid_min, grid_max );
 
         auto end_time = std::chrono::high_resolution_clock::now();

--- a/core/example/longrange/direct.cpp
+++ b/core/example/longrange/direct.cpp
@@ -21,10 +21,10 @@ TDS::TDS(int periodic)
 double TDS::compute(ParticleList& particles, double lx, double ly, double lz)
 {
   // Create slices
-  auto r = particles.slice<Position>();
-  auto f = particles.slice<Force>();
-  auto p = particles.slice<Potential>();
-  auto q = particles.slice<Charge>();
+  auto r = Cabana::slice<Position>(particles);
+  auto f = Cabana::slice<Force>(particles);
+  auto p = Cabana::slice<Potential>(particles);
+  auto q = Cabana::slice<Charge>(particles);
 
   int n_max = particles.size();
   int periodic_shells = _periodic_shells;
@@ -39,15 +39,15 @@ double TDS::compute(ParticleList& particles, double lx, double ly, double lz)
     p( idx ) = 0.0;//set potential to zero
 
     //For each particle, we'll find the potential by summing
-    //the electrostatic interaction between it and every other 
-    //particle in the cell, as well as every particle in the 
+    //the electrostatic interaction between it and every other
+    //particle in the cell, as well as every particle in the
     //surrounding periodic spherical shells
     for (auto i = 0; i < n_max; ++i)
     {
       for (int kx = -periodic_shells; kx <= periodic_shells; ++kx)
       {
         //x-dist shift for particles in periodic cells
-        shift[0] = (double)kx * lx; 
+        shift[0] = (double)kx * lx;
         for (int ky = -periodic_shells; ky <= periodic_shells; ++ky)
         {
           //y-dist shift for particles in periodic cells
@@ -89,7 +89,7 @@ double TDS::compute(ParticleList& particles, double lx, double ly, double lz)
 
   Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>(0,n_max), work_func );
   Kokkos::fence();
-  
+
   //Compute total energy of particles
   double total_energy = 0.0;
   Kokkos::parallel_reduce( "Sum", Kokkos::RangePolicy<ExecutionSpace>(0,n_max), KOKKOS_LAMBDA(int idx, double& energy)
@@ -98,6 +98,6 @@ double TDS::compute(ParticleList& particles, double lx, double ly, double lz)
     },
     total_energy);
   Kokkos::fence();
-  
+
   return total_energy;
 }

--- a/core/example/longrange/particles.cpp
+++ b/core/example/longrange/particles.cpp
@@ -16,18 +16,18 @@
 // function to initialize particles as a NaCl crystal of length crystal_size
 void initializeParticles(ParticleList particles, int crystal_size)
 {
-  auto x = particles.slice<Position>();
-  auto v = particles.slice<Velocity>();
-  auto f = particles.slice<Force>();
-  auto q = particles.slice<Charge>();
-  auto u = particles.slice<Potential>();
-  auto i = particles.slice<Index>();
+  auto x = Cabana::slice<Position>(particles);
+  auto v = Cabana::slice<Velocity>(particles);
+  auto f = Cabana::slice<Force>(particles);
+  auto q = Cabana::slice<Charge>(particles);
+  auto u = Cabana::slice<Potential>(particles);
+  auto i = Cabana::slice<Index>(particles);
   auto init_parts = KOKKOS_LAMBDA(const int idx)
   {
     // Calculate location of particle in crystal
     int idx_x = idx % crystal_size;
     int idx_y = (idx / crystal_size) % crystal_size;
-    int idx_z = idx / (crystal_size * crystal_size);	
+    int idx_z = idx / (crystal_size * crystal_size);
 
     // Initialize position.
     x(idx,0) = ((double)idx_x * 0.5);
@@ -44,7 +44,7 @@ void initializeParticles(ParticleList particles, int crystal_size)
 
     // Create alternating charge
     q(idx) = (((idx_x + idx_y + idx_z)%2)?1.0:-1.0)*COULOMB_PREFACTOR_INV;
-    
+
     // Set potential
     u(idx) = 0.0;
 
@@ -59,18 +59,18 @@ void initializeParticles(ParticleList particles, int crystal_size)
 void initializeMesh(ParticleList mesh, int width)
 {
   int ptsx = std::round(std::pow(mesh.size(),1.0/3.0));//number of points in each dimension
-  auto x = mesh.slice<Position>();
-  auto v = mesh.slice<Velocity>();
-  auto f = mesh.slice<Force>();
-  auto q = mesh.slice<Charge>();
-  auto u = mesh.slice<Potential>();
-  auto i = mesh.slice<Index>();
-  auto init_mesh = KOKKOS_LAMBDA( const int idx ) 
+  auto x = Cabana::slice<Position>(mesh);
+  auto v = Cabana::slice<Velocity>(mesh);
+  auto f = Cabana::slice<Force>(mesh);
+  auto q = Cabana::slice<Charge>(mesh);
+  auto u = Cabana::slice<Potential>(mesh);
+  auto i = Cabana::slice<Index>(mesh);
+  auto init_mesh = KOKKOS_LAMBDA( const int idx )
   {
     // Calculate location of particle in crystal
     int idx_x = idx % ptsx;
     int idx_y = (idx / ptsx) % ptsx;
-    int idx_z = idx / (ptsx * ptsx);	
+    int idx_z = idx / (ptsx * ptsx);
 
     // Initialize position.
     x(idx,0) = ((double)idx_x * width / (ptsx));
@@ -97,4 +97,3 @@ void initializeMesh(ParticleList mesh, int width)
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,mesh.size()),init_mesh);
   Kokkos::fence();
 }
-

--- a/core/example/scafacos/scafacos_example.cpp
+++ b/core/example/scafacos/scafacos_example.cpp
@@ -105,14 +105,14 @@ void initializeParticles( ParticleList& particles,
                           double gap_space,
                           parallel_info& info )
 {
-    auto p_x = particles.slice<PositionX>("position_x");
-    auto p_y = particles.slice<PositionY>("position_y");
-    auto p_z = particles.slice<PositionZ>("position_z");
-    auto v = particles.slice<Velocity>("velocity");
-    auto q = particles.slice<Charge>("charge");
-    auto pot = particles.slice<Potential>("potential");
-    auto field = particles.slice<Field>("field");
-    auto indx = particles.slice<Index>("index");
+    auto p_x = Cabana::slice<PositionX>(particles,"position_x");
+    auto p_y = Cabana::slice<PositionY>(particles,"position_y");
+    auto p_z = Cabana::slice<PositionZ>(particles,"position_z");
+    auto v = Cabana::slice<Velocity>(particles,"velocity");
+    auto q = Cabana::slice<Charge>(particles,"charge");
+    auto pot = Cabana::slice<Potential>(particles,"potential");
+    auto field = Cabana::slice<Field>(particles,"field");
+    auto indx = Cabana::slice<Index>(particles,"index");
 
     int offset;
 
@@ -157,14 +157,14 @@ void printParticles( const ParticleList particles, parallel_info& info )
 {
 
     // get slices for the corresponding particle data
-    auto p_x = particles.slice<PositionX>("position_x");
-    auto p_y = particles.slice<PositionY>("position_y");
-    auto p_z = particles.slice<PositionZ>("position_z");
-    auto v = particles.slice<Velocity>("velocity");
-    auto q = particles.slice<Charge>("charge");
-    auto pot = particles.slice<Potential>("potential");
-    auto field = particles.slice<Field>("field");
-    auto indx = particles.slice<Index>("index");
+    auto p_x = Cabana::slice<PositionX>(particles,"position_x");
+    auto p_y = Cabana::slice<PositionY>(particles,"position_y");
+    auto p_z = Cabana::slice<PositionZ>(particles,"position_z");
+    auto v = Cabana::slice<Velocity>(particles,"velocity");
+    auto q = Cabana::slice<Charge>(particles,"charge");
+    auto pot = Cabana::slice<Potential>(particles,"potential");
+    auto field = Cabana::slice<Field>(particles,"field");
+    auto indx = Cabana::slice<Index>(particles,"index");
 
     std::cout << "Rank: "
               << info.rank
@@ -256,10 +256,10 @@ void exampleMain(int num_particle,
     std::vector<double> f(3*info.n_local_particles);
     std::vector<double> pot(info.n_local_particles);
 
-    auto p_x = particles.slice<PositionX>("x_position");
-    auto p_y = particles.slice<PositionY>("y_position");
-    auto p_z = particles.slice<PositionZ>("z_position");
-    auto qp = particles.slice<Charge>("charge");
+    auto p_x = Cabana::slice<PositionX>(particles,"x_position");
+    auto p_y = Cabana::slice<PositionY>(particles,"y_position");
+    auto p_z = Cabana::slice<PositionZ>(particles,"z_position");
+    auto qp = Cabana::slice<Charge>(particles,"charge");
 
     for (int i = 0; i < info.n_local_particles; ++i)
     {
@@ -306,8 +306,8 @@ void exampleMain(int num_particle,
     result = fcs_run(fcs,info.n_local_particles,pos.data(),q.data(),f.data(),pot.data());
     if (!check_result(result,info.rank)) return;
 
-    auto field = particles.slice<Field>();
-    auto poten = particles.slice<Potential>();
+    auto field = Cabana::slice<Field>(particles,"Field");
+    auto poten = Cabana::slice<Potential>(particles,"Potential");
 
     double check[4];
     for (int i = 0; i < 4; ++i)

--- a/core/example/tutorial/02_tuple/tuple_example.cpp
+++ b/core/example/tutorial/02_tuple/tuple_example.cpp
@@ -95,24 +95,24 @@ void tupleExample()
     */
     for ( int i = 0; i < 3; ++i )
         for ( int j = 0; j < 3; ++j )
-            tp.get<0>(i,j) = 1.0 * (i + j);
+            Cabana::get<0>(tp,i,j) = 1.0 * (i + j);
 
     for ( int i = 0; i < 4; ++i )
-        tp.get<1>(i) = 1.0 * i;
+        Cabana::get<1>(tp,i) = 1.0 * i;
 
-    tp.get<2>() = 1234;
+    Cabana::get<2>(tp) = 1234;
 
     /* Read back the tuple data using the same multidimensional accessors */
     for ( int i = 0; i < 3; ++i )
         for ( int j = 0; j < 3; ++j )
             std::cout << "Tuple member 0 element (" << i << "," << j << "): "
-                      << tp.get<0>(i,j) << std::endl;
+                      << Cabana::get<0>(tp,i,j) << std::endl;
 
     for ( int i = 0; i < 4; ++i )
         std::cout << "Tuple member 1 element (" << i << "): "
-                  << tp.get<1>(i) << std::endl;
+                  << Cabana::get<1>(tp,i) << std::endl;
 
-    std::cout << "Tuple member 2: " << tp.get<2>() << std::endl;
+    std::cout << "Tuple member 2: " << Cabana::get<2>(tp) << std::endl;
 }
 
 //---------------------------------------------------------------------------//

--- a/core/example/tutorial/03_struct_of_arrays/soa_example.cpp
+++ b/core/example/tutorial/03_struct_of_arrays/soa_example.cpp
@@ -96,14 +96,14 @@ void soaExample()
     for ( int i = 0; i < 3; ++i )
         for ( int j = 0; j < 3; ++j )
             for ( int a = 0; a < VectorLength; ++a )
-                  soa.get<0>(a,i,j) = 1.0 * (a + i + j);
+                  Cabana::get<0>(soa,a,i,j) = 1.0 * (a + i + j);
 
     for ( int i = 0; i < 4; ++i )
         for ( int a = 0; a < VectorLength; ++a )
-              soa.get<1>(a,i) = 1.0 * (a + i);
+              Cabana::get<1>(soa,a,i) = 1.0 * (a + i);
 
     for ( int a = 0; a < VectorLength; ++a )
-        soa.get<2>(a) = a + 1234;
+        Cabana::get<2>(soa,a) = a + 1234;
 
     /* Read back the tuple data using the same multidimensional accessors */
     for ( int i = 0; i < 3; ++i )
@@ -111,17 +111,17 @@ void soaExample()
             for ( int a = 0; a < VectorLength; ++a )
                 std::cout << "Tuple member 0, tuple index "
                           << a << ", element (" << i << "," << j << "): "
-                          << soa.get<0>(a,i,j) << std::endl;
+                          << Cabana::get<0>(soa,a,i,j) << std::endl;
 
     for ( int i = 0; i < 4; ++i )
         for ( int a = 0; a < VectorLength; ++a )
             std::cout << "Tuple member 1, tuple index " << a
                       << ", element (" << i << "): "
-                      << soa.get<1>(a,i) << std::endl;
+                      << Cabana::get<1>(soa,a,i) << std::endl;
 
     for ( int a = 0; a < VectorLength; ++a )
         std::cout << "Tuple member 2, tuple index " << a
-                  << ": " << soa.get<2>(a) << std::endl;
+                  << ": " << Cabana::get<2>(soa,a) << std::endl;
 }
 
 //---------------------------------------------------------------------------//

--- a/core/example/tutorial/04_aosoa/aosoa_example.cpp
+++ b/core/example/tutorial/04_aosoa/aosoa_example.cpp
@@ -117,14 +117,14 @@ void aosoaExample()
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )
                 for ( int a = 0; a < aosoa.arraySize(s); ++a )
-                    soa.get<0>(a,i,j) = 1.0 * (a + i + j);
+                    Cabana::get<0>(soa,a,i,j) = 1.0 * (a + i + j);
 
         for ( int i = 0; i < 4; ++i )
             for ( int a = 0; a < aosoa.arraySize(s); ++a )
-                soa.get<1>(a,i) = 1.0 * (a + i);
+                Cabana::get<1>(soa,a,i) = 1.0 * (a + i);
 
         for ( int a = 0; a < aosoa.arraySize(s); ++a )
-            soa.get<2>(a) = a + 1234;
+            Cabana::get<2>(soa,a) = a + 1234;
     }
 
     /*
@@ -153,15 +153,15 @@ void aosoaExample()
             for ( int j = 0; j < 3; ++j )
                 std::cout << "Tuple " << t
                           << ", member 0 element (" << i << "," << j << "): "
-                          << tp.get<0>(i,j) << std::endl;
+                          << Cabana::get<0>(tp,i,j) << std::endl;
 
         for ( int i = 0; i < 4; ++i )
             std::cout << "Tuple " << t
                       << ", member 1 element (" << i << "): "
-                      << tp.get<1>(i) << std::endl;
+                      << Cabana::get<1>(tp,i) << std::endl;
 
         std::cout << "Tuple " << t
-                  << ", member 2: " << tp.get<2>() << std::endl;
+                  << ", member 2: " << Cabana::get<2>(tp) << std::endl;
     }
 
     /*
@@ -172,12 +172,12 @@ void aosoaExample()
 
     for ( int i = 0; i < 3; ++i )
         for ( int j = 0; j < 3; ++j )
-            foo.get<0>(i,j) = 1.1;
+            Cabana::get<0>(foo,i,j) = 1.1;
 
     for ( int i = 0; i < 4; ++i )
-        foo.get<1>(i) = 2.2;
+        Cabana::get<1>(foo,i) = 2.2;
 
-    foo.get<2>() = 3;
+    Cabana::get<2>(foo) = 3;
 
     /* Now assign it's data by copying it to the AoSoA at 1D index 3. */
     aosoa.setTuple( 3, foo );
@@ -190,14 +190,14 @@ void aosoaExample()
         for ( int j = 0; j < 3; ++j )
             std::cout << "Updated tuple member 0 element ("
                       << i << "," << j << "): "
-                      << aosoa.access(0).get<0>(3,i,j) << std::endl;
+                      << Cabana::get<0>(aosoa.access(0),3,i,j) << std::endl;
 
     for ( int i = 0; i < 4; ++i )
         std::cout << "Update tuple member 1 (" << i << "): "
-                  << aosoa.access(0).get<1>(3,i) << std::endl;
+                  << Cabana::get<1>(aosoa.access(0),3,i) << std::endl;
 
     std::cout << "Updated tuple member 2: "
-              << aosoa.access(0).get<2>(3) << std::endl;
+              << Cabana::get<2>(aosoa.access(0),3) << std::endl;
 }
 
 //---------------------------------------------------------------------------//

--- a/core/example/tutorial/05_slice/slice_example.cpp
+++ b/core/example/tutorial/05_slice/slice_example.cpp
@@ -89,9 +89,9 @@ void sliceExample()
       because slices are unmanaged memory but may still be used for diagnostic
       purposes.
     */
-    auto slice_0 = aosoa.slice<0>( "my_slice_0" );
-    auto slice_1 = aosoa.slice<1>( "my_slice_1" );
-    auto slice_2 = aosoa.slice<2>( "my_slice_2" );
+    auto slice_0 = Cabana::slice<0>( aosoa, "my_slice_0" );
+    auto slice_1 = Cabana::slice<1>( aosoa, "my_slice_1" );
+    auto slice_2 = Cabana::slice<2>( aosoa, "my_slice_2" );
 
     /*
       Let's initialize the data using the 2D indexing scheme. Slice data can

--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -74,14 +74,14 @@ void deepCopyExample()
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )
                 for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
-                    soa.get<0>(a,i,j) = 1.0 * (a + i + j);
+                    Cabana::get<0>(soa,a,i,j) = 1.0 * (a + i + j);
 
         for ( int i = 0; i < 4; ++i )
             for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
-                soa.get<1>(a,i) = 1.0 * (a + i);
+                Cabana::get<1>(soa,a,i) = 1.0 * (a + i);
 
         for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
-            soa.get<2>(a) = a + 1234;
+            Cabana::get<2>(soa,a) = a + 1234;
     }
 
     /*
@@ -104,15 +104,15 @@ void deepCopyExample()
             for ( int j = 0; j < 3; ++j )
                 std::cout << "Tuple " << t
                           << ", member 0 element (" << i << "," << j << "): "
-                          << tp.get<0>(i,j) << std::endl;
+                          << Cabana::get<0>(tp,i,j) << std::endl;
 
         for ( int i = 0; i < 4; ++i )
             std::cout << "Tuple " << t
                       << ", member 1 element (" << i << "): "
-                      << tp.get<1>(i) << std::endl;
+                      << Cabana::get<1>(tp,i) << std::endl;
 
         std::cout << "Tuple " << t
-                  << ", member 2: " << tp.get<2>() << std::endl;
+                  << ", member 2: " << Cabana::get<2>(tp) << std::endl;
     }
 
     /*
@@ -144,14 +144,14 @@ void deepCopyExample()
     /*
       Deep copy can also be performed on a slice-by-slice basis.
      */
-    auto src_slice_0 = src_aosoa.slice<0>();
-    auto dst_slice_0 = dst_aosoa.slice<0>();
+    auto src_slice_0 = Cabana::slice<0>( src_aosoa );
+    auto dst_slice_0 = Cabana::slice<0>( dst_aosoa );
     Cabana::deep_copy( dst_slice_0, src_slice_0 );
-    auto src_slice_1 = src_aosoa.slice<1>();
-    auto dst_slice_1 = dst_aosoa.slice<1>();
+    auto src_slice_1 = Cabana::slice<1>( src_aosoa );
+    auto dst_slice_1 = Cabana::slice<1>( dst_aosoa );
     Cabana::deep_copy( dst_slice_1, src_slice_1 );
-    auto src_slice_2 = src_aosoa.slice<2>();
-    auto dst_slice_2 = dst_aosoa.slice<2>();
+    auto src_slice_2 = Cabana::slice<2>( src_aosoa );
+    auto dst_slice_2 = Cabana::slice<2>( dst_aosoa );
     Cabana::deep_copy( dst_slice_2, src_slice_2 );
 
     /*
@@ -169,10 +169,10 @@ void deepCopyExample()
     Cabana::Tuple<DataTypes> tp;
     for ( int i = 0; i < 3; ++i )
         for ( int j = 0; j < 3; ++j )
-            tp.get<0>(i,j) = 1.0;
+            Cabana::get<0>(tp,i,j) = 1.0;
     for ( int i = 0; i < 4; ++i )
-        tp.get<1>(i) = 3.23;
-    tp.get<2>() = 39;
+        Cabana::get<1>(tp,i) = 3.23;
+    Cabana::get<2>(tp) = 39;
     Cabana::deep_copy( dst_aosoa, tp );
 }
 

--- a/core/example/tutorial/07_sorting/sorting.cpp
+++ b/core/example/tutorial/07_sorting/sorting.cpp
@@ -62,14 +62,14 @@ void sortingExample()
         // ASCENDING ORDER!
         for ( int a = 0; a < aosoa.arraySize(s); ++a )
         {
-            soa.get<0>(a) = forward_index_counter;
+            Cabana::get<0>(soa,a) = forward_index_counter;
             ++forward_index_counter;
         }
 
         // DESCENDING ORDER!
         for ( int a = 0; a < aosoa.arraySize(s); ++a )
         {
-            soa.get<1>(a) = reverse_index_counter;
+            Cabana::get<1>(soa,a) = reverse_index_counter;
             --reverse_index_counter;
         }
     }
@@ -87,7 +87,7 @@ void sortingExample()
       that the binning data is templated on a memory space as it creates and
       stores data in the same memory space as the AoSoA.
      */
-    auto keys = aosoa.slice<1>();
+    auto keys = Cabana::slice<1>( aosoa );
     auto sort_data = Cabana::sortByKey( keys );
 
     /*
@@ -107,11 +107,11 @@ void sortingExample()
 
         // Should now be in DESCENDING ORDER!
         std::cout << "Tuple " << t
-                  << ", member 0: " << tp.get<0>() << std::endl;
+                  << ", member 0: " << Cabana::get<0>(tp) << std::endl;
 
         // Should now be in ASCENDING ORDER!
         std::cout << "Tuple " << t
-                  << ", member 1: " << tp.get<1>() << std::endl;
+                  << ", member 1: " << Cabana::get<1>(tp) << std::endl;
     }
     std::cout << std::endl;
 
@@ -158,10 +158,10 @@ void sortingExample()
         auto tp = aosoa.getTuple( t );
 
         std::cout << "Tuple " << t
-                  << ", member 0: " << tp.get<0>() << std::endl;
+                  << ", member 0: " << Cabana::get<0>(tp) << std::endl;
 
         std::cout << "Tuple " << t
-                  << ", member 1: " << tp.get<1>() << std::endl;
+                  << ", member 1: " << Cabana::get<1>(tp) << std::endl;
     }
     std::cout << std::endl;
 

--- a/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
+++ b/core/example/tutorial/08_linked_cell_list/linked_cell_list.cpp
@@ -66,7 +66,7 @@ void linkedCellListExample()
     /*
       Create the particle ids.
     */
-    auto ids = aosoa.slice<1>();
+    auto ids = Cabana::slice<1>( aosoa );
     for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
 
@@ -76,7 +76,7 @@ void linkedCellListExample()
       is in a different cell. When we use cell list to permute the particles
       later in the example, they will be regrouped by cell.
     */
-    auto positions = aosoa.slice<0>();
+    auto positions = Cabana::slice<0>( aosoa );
     int ppc = 2;
     int particle_counter = 0;
     for ( int p = 0; p < ppc; ++p )

--- a/core/example/tutorial/09_verlet_list/verlet_list.cpp
+++ b/core/example/tutorial/09_verlet_list/verlet_list.cpp
@@ -59,7 +59,7 @@ void verletListExample()
     /*
       Create the particle ids.
     */
-    auto ids = aosoa.slice<1>();
+    auto ids = Cabana::slice<1>( aosoa );
     for ( std::size_t i = 0; i < aosoa.size(); ++i )
         ids(i) = i;
 
@@ -68,7 +68,7 @@ void verletListExample()
       of each cell. We will set the Verlet list parameters such that each
       particle should only neighbor the other particle it shares a cell with.
     */
-    auto positions = aosoa.slice<0>();
+    auto positions = Cabana::slice<0>( aosoa );
     int ppc = 3;
     int particle_counter = 0;
     for ( int p = 0; p < ppc; ++p )

--- a/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
+++ b/core/example/tutorial/10_advanced_slice_cuda/advanced_slice_cuda.cpp
@@ -58,7 +58,7 @@ void atomicSliceExample()
     /*
       Create a slice over the single value and assign it to zero.
      */
-    auto slice = aosoa.slice<0>();
+    auto slice = Cabana::slice<0>( aosoa );
     slice(0) = 0.0;
 
     /*

--- a/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
+++ b/core/example/tutorial/10_advanced_slice_openmp/advanced_slice_openmp.cpp
@@ -42,7 +42,7 @@ void atomicSliceExample()
     /*
       Create a slice over the single value and assign it to zero.
      */
-    auto slice = aosoa.slice<0>();
+    auto slice = Cabana::slice<0>( aosoa );
     slice(0) = 0.0;
 
     /*

--- a/core/example/tutorial/11_parallel_for/parallel_for_example.cpp
+++ b/core/example/tutorial/11_parallel_for/parallel_for_example.cpp
@@ -68,8 +68,8 @@ void parallelForExample()
       for loop in this case - especially when the code being written is for an
       arbitrary memory space.
      */
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
+    auto slice_0 = Cabana::slice<0>( aosoa );
+    auto slice_1 = Cabana::slice<1>( aosoa );
     for ( int i = 0; i < num_tuple; ++i )
     {
         slice_0(i) = 1.0;

--- a/core/example/tutorial/12_migration/migration_example.cpp
+++ b/core/example/tutorial/12_migration/migration_example.cpp
@@ -66,8 +66,8 @@ void migrationExample()
       parallel for loop in this case - especially when the code being written
       is for an arbitrary memory space.
      */
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
+    auto slice_0 = Cabana::slice<0>( aosoa );
+    auto slice_1 = Cabana::slice<1>( aosoa );
     for ( int i = 0; i < num_tuple; ++i )
     {
         slice_0(i) = comm_rank;
@@ -148,8 +148,8 @@ void migrationExample()
       We can migrate each slice individually as well. This is useful when not
       all data in an AoSoA needs to be moved to a new decomposition.
      */
-    auto slice_0_dst = destination.slice<0>();
-    auto slice_1_dst = destination.slice<1>();
+    auto slice_0_dst = Cabana::slice<0>( destination );
+    auto slice_1_dst = Cabana::slice<1>( destination );
     Cabana::migrate( distributor, slice_0, slice_0_dst );
     Cabana::migrate( distributor, slice_1, slice_1_dst );
 

--- a/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
+++ b/core/example/tutorial/13_halo_exchange/halo_exchange_example.cpp
@@ -68,8 +68,8 @@ void haloExchangeExample()
     /*
       Create slices and assign data.
      */
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
+    auto slice_0 = Cabana::slice<0>( aosoa );
+    auto slice_1 = Cabana::slice<1>( aosoa );
     for ( int i = 0; i < num_tuple; ++i )
     {
         slice_0(i) = 1.0;
@@ -131,8 +131,8 @@ void haloExchangeExample()
     /*
       Get new slices after resizing.
      */
-    slice_0 = aosoa.slice<0>();
-    slice_1 = aosoa.slice<1>();
+    slice_0 = Cabana::slice<0>( aosoa );
+    slice_1 = Cabana::slice<1>( aosoa );
 
     /*
       Gather data for the ghosts on this rank from our neighbors that own

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -445,6 +445,7 @@ class AoSoA
       \brief Get an un-typed raw pointer to the entire data block.
       \return An un-typed raw-pointer to the entire data block.
     */
+    CABANA_DEPRECATED
     void* ptr() const
     { return _data.data(); }
 

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -31,6 +31,50 @@
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
+// AoSoA forward declaration.
+template<class DataTypes,
+         class MemorySpace,
+         int VectorLength,
+         class MemoryTraits>
+class AoSoA;
+
+//---------------------------------------------------------------------------//
+// Static type checker.
+template<class >
+struct is_aosoa : public std::false_type {};
+
+template<class DataTypes,
+         class MemorySpace,
+         int VectorLength,
+         class MemoryTraits>
+struct is_aosoa<AoSoA<DataTypes,MemorySpace,VectorLength,MemoryTraits> >
+    : public std::true_type {};
+
+template<class DataTypes,
+         class MemorySpace,
+         int VectorLength,
+         class MemoryTraits>
+struct is_aosoa<const AoSoA<DataTypes,MemorySpace,VectorLength,MemoryTraits> >
+    : public std::true_type {};
+
+//---------------------------------------------------------------------------//
+// Slice template helper.
+template<std::size_t M, class AoSoA_t>
+typename AoSoA_t::template member_slice_type<M>
+slice( const AoSoA_t& aosoa, const std::string& slice_label = "" )
+{
+    static_assert(
+        0 == sizeof(typename AoSoA_t::soa_type) %
+        sizeof(typename AoSoA_t::template member_value_type<M>),
+        "Slice stride cannot be calculated for misaligned memory!" );
+
+    return typename AoSoA_t::template member_slice_type<M>(
+        static_cast<typename AoSoA_t::template member_pointer_type<M> >(
+            AoSoA_t::soa_type::template staticPtr<M>(aosoa.data()) ),
+        aosoa.size(), aosoa.numSoA(), slice_label );
+}
+
+//---------------------------------------------------------------------------//
 /*!
   \class AoSoA
 
@@ -56,8 +100,8 @@ namespace Cabana
   the AoSoA. If not specified, this defaults to the preferred layout for the
   <tt>MemorySpace</tt>.
 
-  \tparam MemoryTraits Memory traits for the AoSoA data. Can be used to
-  indicate managed memory, unmanaged memory, etc.
+  \tparam MemoryTraits (optional) Memory traits for the AoSoA data. Can be
+  used to indicate managed memory, unmanaged memory, etc.
  */
 template<class DataTypes,
          class MemorySpace,
@@ -161,8 +205,9 @@ class AoSoA
         , _capacity( 0 )
         , _num_soa( 0 )
     {
-        static_assert( !memory_traits::Unmanaged,
-                       "Construction by allocation cannot use unmanaged memory" );
+        static_assert(
+            !memory_traits::Unmanaged,
+            "Construction by allocation cannot use unmanaged memory" );
         resize( _size );
     }
 
@@ -389,17 +434,11 @@ class AoSoA
       \param slice_label An optional label to assign to the slice.
       \return The member slice.
     */
+    CABANA_DEPRECATED
     template<std::size_t M>
     member_slice_type<M> slice( const std::string& slice_label = "" ) const
     {
-        static_assert(
-            0 == sizeof(soa_type) % sizeof(member_value_type<M>),
-            "Slice stride cannot be calculated for misaligned memory!" );
-
-        return member_slice_type<M>(
-            static_cast<member_pointer_type<M> >(
-                soa_type::template staticPtr<M>(_data.data()) ),
-            _size, _num_soa, slice_label );
+        return Cabana::slice<M>( *this, slice_label );
     }
 
     /*!
@@ -407,6 +446,13 @@ class AoSoA
       \return An un-typed raw-pointer to the entire data block.
     */
     void* ptr() const
+    { return _data.data(); }
+
+    /*!
+      \brief Get a typed raw pointer to the entire data block.
+      \return A typed raw-pointer to the entire data block.
+    */
+    soa_type* data() const
     { return _data.data(); }
 
   private:
@@ -426,25 +472,6 @@ class AoSoA
     // counted copy of the data.
     soa_view _data;
 };
-
-//---------------------------------------------------------------------------//
-// Static type checker.
-template<class >
-struct is_aosoa : public std::false_type {};
-
-template<class DataTypes,
-         class MemorySpace,
-         int VectorLength,
-         class MemoryTraits>
-struct is_aosoa<AoSoA<DataTypes,MemorySpace,VectorLength,MemoryTraits> >
-    : public std::true_type {};
-
-template<class DataTypes,
-         class MemorySpace,
-         int VectorLength,
-         class MemoryTraits>
-struct is_aosoa<const AoSoA<DataTypes,MemorySpace,VectorLength,MemoryTraits> >
-    : public std::true_type {};
 
 //---------------------------------------------------------------------------//
 

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -153,8 +153,8 @@ create_mirror_view_and_copy(
 
     Kokkos::Impl::DeepCopy<
         typename Space::memory_space,typename SrcAoSoA::memory_space>(
-            dst.ptr(),
-            src.ptr(),
+            dst.data(),
+            src.data(),
             src.numSoA() * sizeof(typename SrcAoSoA::soa_type) );
 
     return dst;
@@ -203,8 +203,8 @@ inline void deep_copy(
     }
 
     // Get the pointers to the beginning of the data blocks.
-    void* dst_data = dst.ptr();
-    const void* src_data = src.ptr();
+    void* dst_data = dst.data();
+    const void* src_data = src.data();
 
     // Return if both pointers are null.
     if ( dst_data == nullptr && src_data == nullptr )
@@ -327,7 +327,7 @@ inline void deep_copy(
 
     // Get the pointers to the beginning of the data blocks.
     auto dst_data = dst.data();
-    auto src_data = src.data();
+    const auto src_data = src.data();
 
     // Return if both pointers are null.
     if ( dst_data == nullptr && src_data == nullptr )

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -14,6 +14,7 @@
 
 #include <impl/Cabana_IndexSequence.hpp>
 #include <Cabana_MemberTypes.hpp>
+#include <Cabana_Macros.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -107,20 +108,132 @@ struct SoAImpl<VectorLength,IndexSequence<Indices...>,Types...>
 } // end namespace Impl
 
 //---------------------------------------------------------------------------//
+// SoA forward declaration.
+template<typename Types,int VectorLength>
+struct SoA;
+
+//---------------------------------------------------------------------------//
+// Static type checker.
+template<class >
+struct is_soa : public std::false_type {};
+
+template<class DataTypes, int VectorLength>
+struct is_soa<SoA<DataTypes,VectorLength> >
+    : public std::true_type {};
+
+template<class DataTypes, int VectorLength>
+struct is_soa<const SoA<DataTypes,VectorLength> >
+    : public std::true_type {};
+
+//---------------------------------------------------------------------------//
+// Get template helper.
+
+// Rank-0 non-const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_reference_type<M> >::type
+get( SoA_t& soa, const int a )
+{
+    return static_cast<typename SoA_t::template base<M>&>(
+        soa)._data[a];
+}
+
+// Rank-0 const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_value_type<M> >::type
+get( const SoA_t& soa, const int a )
+{
+    return static_cast<const typename SoA_t::template base<M>&>(
+        soa)._data[a];
+}
+
+// Rank-1 non-const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_reference_type<M> >::type
+get( SoA_t& soa, const int a, const int d0 )
+{
+    return static_cast<typename SoA_t::template base<M>&>(
+        soa)._data[d0][a];
+}
+
+// Rank-1 const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_value_type<M> >::type
+get( const SoA_t& soa, const int a, const int d0 )
+{
+    return static_cast<const typename SoA_t::template base<M>&>(
+        soa)._data[d0][a];
+}
+
+// Rank-2 non-const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_reference_type<M> >::type
+get( SoA_t& soa, const int a, const int d0, const int d1 )
+{
+    return static_cast<typename SoA_t::template base<M>&>(
+        soa)._data[d0][d1][a];
+}
+
+// Rank-2 const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_value_type<M> >::type
+get( const SoA_t& soa, const int a, const int d0, const int d1 )
+{
+    return static_cast<const typename SoA_t::template base<M>&>(
+        soa)._data[d0][d1][a];
+}
+
+// Rank-3 non-const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_reference_type<M> >::type
+get( SoA_t& soa, const int a, const int d0, const int d1, const int d2 )
+{
+    return static_cast<typename SoA_t::template base<M>&>(
+        soa)._data[d0][d1][d2][a];
+}
+
+// Rank-3 const
+template<std::size_t M, class SoA_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_soa<SoA_t>::value,
+    typename SoA_t::template member_value_type<M> >::type
+get( const SoA_t& soa, const int a, const int d0, const int d1, const int d2 )
+{
+    return static_cast<const typename SoA_t::template base<M>&>(
+        soa)._data[d0][d1][d2][a];
+}
+
+//---------------------------------------------------------------------------//
 /*!
   \brief Struct-of-Arrays
 
   A struct-of-arrays (SoA) is composed of groups of statically sized
   arrays. The array element types, which will be composed as members of the
   struct, are indicated through the Types parameter pack. If the types of the
-  members are contiguous then the struct itself will be contiguous. The layout
-  of the arrays is a function of the layout type. The layout type indicates
-  the size of the arrays and, if they have multidimensional data, if they are
-  row or column major order.
+  members are contiguous then the struct itself will be contiguous. The vector
+  length indicates the static length of each array.
 */
-template<typename Types,int VectorLength>
-struct SoA;
-
 template<typename... Types, int VectorLength>
 struct SoA<MemberTypes<Types...>,VectorLength>
     : Impl::SoAImpl<VectorLength,
@@ -159,6 +272,11 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     using member_pointer_type =
         typename std::add_pointer<member_value_type<M> >::type;
 
+    // Base type.
+    template<std::size_t M>
+    using base =
+        Impl::StructMember<M,vector_length,member_data_type<M> >;
+
     // -------------------------------
     // Member data type properties.
 
@@ -193,9 +311,11 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     }
 
     // -------------------------------
-    // Access the data value at a given member index.
+    // Access the data value at a given member index. These accessors are
+    // deprecated.
 
     // Rank 0
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A>
     KOKKOS_FORCEINLINE_FUNCTION
@@ -204,10 +324,10 @@ struct SoA<MemberTypes<Types...>,VectorLength>
                             member_reference_type<M> >::type
     get( const A& a )
     {
-        Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[a];
+        return Cabana::get<M>( *this, a );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A>
     KOKKOS_FORCEINLINE_FUNCTION
@@ -216,11 +336,11 @@ struct SoA<MemberTypes<Types...>,VectorLength>
                             member_value_type<M> >::type
     get( const A& a ) const
     {
-        const Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[a];
+        return Cabana::get<M>( *this, a );
     }
 
     // Rank 1
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0>
@@ -232,10 +352,10 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     get(  const A& a,
           const D0& d0 )
     {
-        Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][a];
+        return Cabana::get<M>( *this, a, d0 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0>
@@ -247,11 +367,11 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     get(  const A& a,
           const D0& d0 ) const
     {
-        const Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][a];
+        return Cabana::get<M>( *this, a, d0 );
     }
 
     // Rank 2
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0,
@@ -266,10 +386,10 @@ struct SoA<MemberTypes<Types...>,VectorLength>
          const D0& d0,
          const D1& d1 )
     {
-        Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][d1][a];
+        return Cabana::get<M>( *this, a, d0, d1 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0,
@@ -284,11 +404,11 @@ struct SoA<MemberTypes<Types...>,VectorLength>
          const D0& d0,
          const D1& d1 ) const
     {
-        const Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][d1][a];
+        return Cabana::get<M>( *this, a, d0, d1 );
     }
 
     // Rank 3
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0,
@@ -306,10 +426,10 @@ struct SoA<MemberTypes<Types...>,VectorLength>
          const D1& d1,
          const D2& d2 )
     {
-        Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][d1][d2][a];
+        return Cabana::get<M>( *this, a, d0, d1, d2 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename A,
              typename D0,
@@ -327,8 +447,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
          const D1& d1,
          const D2& d2 ) const
     {
-        const Impl::StructMember<M,vector_length,member_data_type<M> >& base = *this;
-        return base._data[d0][d1][d2][a];
+        return Cabana::get<M>( *this, a, d0, d1, d2 );
     }
 
     // ----------------
@@ -351,6 +470,8 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     }
 };
 
+//---------------------------------------------------------------------------//
+
 namespace Impl
 {
 //---------------------------------------------------------------------------//
@@ -369,7 +490,7 @@ soaElementMemberCopy( SoA<MemberTypes<Types...>,DstVectorLength>& dst,
                       const SoA<MemberTypes<Types...>,SrcVectorLength>& src,
                       const std::size_t src_idx )
 {
-    dst.template get<M>( dst_idx ) = src.template get<M>( src_idx );
+    get<M>( dst, dst_idx ) = get<M>( src, src_idx );
 }
 
 // Rank 1
@@ -383,7 +504,7 @@ soaElementMemberCopy( SoA<MemberTypes<Types...>,DstVectorLength>& dst,
                       const std::size_t src_idx )
 {
     for ( std::size_t i0 = 0; i0 < dst.template extent<M,0>(); ++i0 )
-        dst.template get<M>( dst_idx, i0 ) = src.template get<M>( src_idx, i0 );
+        get<M>( dst, dst_idx, i0 ) = get<M>( src, src_idx, i0 );
 }
 
 // Rank 2
@@ -398,8 +519,8 @@ soaElementMemberCopy( SoA<MemberTypes<Types...>,DstVectorLength>& dst,
 {
     for ( std::size_t i0 = 0; i0 < dst.template extent<M,0>(); ++i0 )
         for ( std::size_t i1 = 0; i1 < dst.template extent<M,1>(); ++i1 )
-                dst.template get<M>( dst_idx, i0, i1 ) =
-                    src.template get<M>( src_idx, i0, i1 );
+                get<M>( dst, dst_idx, i0, i1 ) =
+                    get<M>( src, src_idx, i0, i1 );
 }
 
 // Rank 3
@@ -415,8 +536,8 @@ soaElementMemberCopy( SoA<MemberTypes<Types...>,DstVectorLength>& dst,
     for ( std::size_t i0 = 0; i0 < dst.template extent<M,0>(); ++i0 )
         for ( std::size_t i1 = 0; i1 < dst.template extent<M,1>(); ++i1 )
             for ( std::size_t i2 = 0; i2 < dst.template extent<M,2>(); ++i2 )
-                dst.template get<M>( dst_idx, i0, i1, i2 ) =
-                    src.template get<M>( src_idx, i0, i1, i2 );
+                get<M>( dst, dst_idx, i0, i1, i2 ) =
+                    get<M>( src, src_idx, i0, i1, i2 );
 }
 
 // Copy the values of all members of an SoA from a source to a destination at

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -461,7 +461,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
             Impl::StructMember<M,vector_length,member_data_type<M>>*>(*this);
     }
 
-    // Get a pointer to a given SoA.
+    // Get a pointer to the first element of a member in a given SoA.
     template<std::size_t M>
     static void* staticPtr( SoA* p )
     {

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -14,6 +14,7 @@
 
 #include <Cabana_SoA.hpp>
 #include <Cabana_MemberTypes.hpp>
+#include <Cabana_Macros.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -23,9 +24,122 @@
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
+// Forward declaration of tuple.
 template<typename DataTypes>
 struct Tuple;
 
+//---------------------------------------------------------------------------//
+// Static type checker.
+template<class >
+struct is_tuple : public std::false_type {};
+
+template<class DataTypes>
+struct is_tuple<Tuple<DataTypes> >
+    : public std::true_type {};
+
+template<class DataTypes>
+struct is_tuple<const Tuple<DataTypes> >
+    : public std::true_type {};
+
+//---------------------------------------------------------------------------//
+// Get template helper.
+
+// Rank-0 non-const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_reference_type<M> >::type
+get( Tuple_t& tp )
+{
+    return get<M>(static_cast<typename Tuple_t::base&>(tp),0);
+}
+
+// Rank-0 const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename Tuple_t::template member_value_type<M>
+get( const Tuple_t& tp )
+{
+    return get<M>(static_cast<const typename Tuple_t::base&>(tp),0);
+}
+
+// Rank-1 non-const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_reference_type<M> >::type
+get( Tuple_t& tp, const int d0 )
+{
+    return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0);
+}
+
+// Rank-1 const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_value_type<M> >::type
+get( const Tuple_t& tp, const int d0 )
+{
+    return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0);
+}
+
+// Rank-2 non-const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_reference_type<M> >::type
+get( Tuple_t& tp, const int d0, const int d1 )
+{
+    return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0,d1);
+}
+
+// Rank-2 const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_value_type<M> >::type
+get( const Tuple_t& tp, const int d0, const int d1 )
+{
+    return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0,d1);
+}
+
+// Rank-3 non-const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_reference_type<M> >::type
+get( Tuple_t& tp, const int d0, const int d1, const int d2 )
+{
+    return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0,d1,d2);
+}
+
+// Rank-3 const
+template<std::size_t M, class Tuple_t>
+KOKKOS_FORCEINLINE_FUNCTION
+typename std::enable_if<
+    is_tuple<Tuple_t>::value,
+    typename Tuple_t::template member_value_type<M> >::type
+get( const Tuple_t& tp, const int d0, const int d1, const int d2 )
+{
+    return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0,d1,d2);
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Tuple
+
+  A tuple is a single element of a struct-of-arrays (SoA) (i.e. the struct)
+  and is composed of groups of statically sized arrays. The array element
+  types, which will be composed as members of the tuple, are indicated
+  through the Types parameter pack. If the types of the members are contiguous
+  then the tuple itself will be contiguous.
+*/
 template<typename... Types>
 struct Tuple<MemberTypes<Types...> >
     : SoA<MemberTypes<Types...>,1>
@@ -34,9 +148,11 @@ struct Tuple<MemberTypes<Types...> >
     using base = SoA<MemberTypes<Types...>,1>;
 
     // -------------------------------
-    // Access the data value at a given member index.
+    // Access the data value at a given member index. These accessors are
+    // deprecated.
 
     // Rank 0
+    CABANA_DEPRECATED
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
@@ -44,10 +160,10 @@ struct Tuple<MemberTypes<Types...> >
         typename base::template member_reference_type<M> >::type
     get()
     {
-        base& b = *this;
-        return b.template get<M>( 0 );
+        return Cabana::get<M>( *this );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
@@ -55,11 +171,11 @@ struct Tuple<MemberTypes<Types...> >
         typename base::template member_value_type<M> >::type
     get() const
     {
-        const base& b = *this;
-        return b.template get<M>( 0 );
+        return Cabana::get<M>( *this );
     }
 
     // Rank 1
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0>
     KOKKOS_FORCEINLINE_FUNCTION
@@ -69,10 +185,10 @@ struct Tuple<MemberTypes<Types...> >
         typename base::template member_reference_type<M> >::type
     get( const D0& d0 )
     {
-        base& b = *this;
-        return b.template get<M>( 0, d0 );
+        return Cabana::get<M>( *this, d0 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0>
     KOKKOS_FORCEINLINE_FUNCTION
@@ -82,11 +198,11 @@ struct Tuple<MemberTypes<Types...> >
         typename base::template member_value_type<M> >::type
     get( const D0& d0 ) const
     {
-        const base& b = *this;
-        return b.template get<M>( 0, d0 );
+        return Cabana::get<M>( *this, d0 );
     }
 
     // Rank 2
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0,
              typename D1>
@@ -99,10 +215,10 @@ struct Tuple<MemberTypes<Types...> >
     get( const D0& d0,
          const D1& d1 )
     {
-        base& b = *this;
-        return b.template get<M>( 0, d0, d1 );
+        return Cabana::get<M>( *this, d0, d1 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0,
              typename D1>
@@ -115,11 +231,11 @@ struct Tuple<MemberTypes<Types...> >
     get( const D0& d0,
          const D1& d1 ) const
     {
-        const base& b = *this;
-        return b.template get<M>( 0, d0, d1 );
+        return Cabana::get<M>( *this, d0, d1 );
     }
 
     // Rank 3
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0,
              typename D1,
@@ -135,10 +251,10 @@ struct Tuple<MemberTypes<Types...> >
          const D1& d1,
          const D2& d2 )
     {
-        base& b = *this;
-        return b.template get<M>( 0, d0, d1, d2 );
+        return Cabana::get<M>( *this, d0, d1, d2 );
     }
 
+    CABANA_DEPRECATED
     template<std::size_t M,
              typename D0,
              typename D1,
@@ -154,8 +270,7 @@ struct Tuple<MemberTypes<Types...> >
          const D1& d1,
          const D2& d2 ) const
     {
-        const base& b = *this;
-        return b.template get<M>( 0, d0, d1, d2 );
+        return Cabana::get<M>( *this, d0, d1, d2 );
     }
 };
 

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -32,10 +32,10 @@ void checkDataMembers(
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
 
-    auto slice_0 = mirror.template slice<0>();
-    auto slice_1 = mirror.template slice<1>();
-    auto slice_2 = mirror.template slice<2>();
-    auto slice_3 = mirror.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(mirror);
+    auto slice_1 = Cabana::slice<1>(mirror);
+    auto slice_2 = Cabana::slice<2>(mirror);
+    auto slice_3 = Cabana::slice<3>(mirror);
 
     for ( std::size_t idx = 0; idx < aosoa.size(); ++idx )
     {
@@ -93,19 +93,19 @@ void testAoSoA()
 
     // Get field slices.
     std::string s0_label = "slice_0";
-    auto slice_0 = aosoa.slice<0>( s0_label );
+    auto slice_0 = Cabana::slice<0>( aosoa, s0_label );
     EXPECT_EQ( slice_0.label(), s0_label );
 
     std::string s1_label = "slice_1";
-    auto slice_1 = aosoa.slice<1>( s1_label );
+    auto slice_1 = Cabana::slice<1>( aosoa, s1_label );
     EXPECT_EQ( slice_1.label(), s1_label );
 
     std::string s2_label = "slice_2";
-    auto slice_2 = aosoa.slice<2>( s2_label );
+    auto slice_2 = Cabana::slice<2>( aosoa, s2_label );
     EXPECT_EQ( slice_2.label(), s2_label );
 
     std::string s3_label = "slice_3";
-    auto slice_3 = aosoa.slice<3>( s3_label );
+    auto slice_3 = Cabana::slice<3>( aosoa, s3_label );
     EXPECT_EQ( slice_3.label(), s3_label );
 
     // Check sizes.
@@ -137,10 +137,10 @@ void testAoSoA()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto mirror_slice_0 = mirror.slice<0>();
-    auto mirror_slice_1 = mirror.slice<1>();
-    auto mirror_slice_2 = mirror.slice<2>();
-    auto mirror_slice_3 = mirror.slice<3>();
+    auto mirror_slice_0 = Cabana::slice<0>(mirror);
+    auto mirror_slice_1 = Cabana::slice<1>(mirror);
+    auto mirror_slice_2 = Cabana::slice<2>(mirror);
+    auto mirror_slice_3 = Cabana::slice<3>(mirror);
 
     // Initialize data with the rank accessors.
     float fval = 3.4;
@@ -237,11 +237,11 @@ void testRawData()
     EXPECT_EQ( aosoa.label(), label );
 
     // Get slices of fields.
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
-    auto slice_2 = aosoa.slice<2>();
-    auto slice_3 = aosoa.slice<3>();
-    auto slice_4 = aosoa.slice<4>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
+    auto slice_2 = Cabana::slice<2>(aosoa);
+    auto slice_3 = Cabana::slice<3>(aosoa);
+    auto slice_4 = Cabana::slice<4>(aosoa);
 
     // Get raw pointers to the data as one would in a C interface (no templates).
     float* p0 = slice_0.data();
@@ -293,11 +293,11 @@ void testRawData()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto mirror_slice_0 = mirror.slice<0>();
-    auto mirror_slice_1 = mirror.slice<1>();
-    auto mirror_slice_2 = mirror.slice<2>();
-    auto mirror_slice_3 = mirror.slice<3>();
-    auto mirror_slice_4 = mirror.slice<4>();
+    auto mirror_slice_0 = Cabana::slice<0>(mirror);
+    auto mirror_slice_1 = Cabana::slice<1>(mirror);
+    auto mirror_slice_2 = Cabana::slice<2>(mirror);
+    auto mirror_slice_3 = Cabana::slice<3>(mirror);
+    auto mirror_slice_4 = Cabana::slice<4>(mirror);
     for ( std::size_t idx = 0; idx < aosoa.size(); ++idx )
     {
         int s = Cabana::Impl::Index<16>::s( idx );
@@ -346,10 +346,10 @@ void testTuple()
         tuples( "tuples", num_data );
 
     // Initialize aosoa data.
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
-    auto slice_2 = aosoa.slice<2>();
-    auto slice_3 = aosoa.slice<3>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
+    auto slice_2 = Cabana::slice<2>(aosoa);
+    auto slice_3 = Cabana::slice<3>(aosoa);
     float fval = 3.4;
     double dval = 1.23;
     int ival = 1;
@@ -396,19 +396,19 @@ void testTuple()
             for ( int i = 0; i < dim_1; ++i )
                 for ( int j = 0; j < dim_2; ++j )
                     for ( int k = 0; k < dim_3; ++k )
-                        tuples( idx ).get<0>( i, j, k ) = fval * (i+j+k);
+                        Cabana::get<0>( tuples(idx), i, j, k ) = fval * (i+j+k);
 
             // Member 1.
-            tuples( idx ).get<1>() = ival;
+            Cabana::get<1>( tuples(idx) ) = ival;
 
             // Member 2.
             for ( int i = 0; i < dim_1; ++i )
-                tuples( idx ).get<2>( i ) = dval * i;
+                Cabana::get<2>( tuples(idx), i ) = dval * i;
 
             // Member 3.
             for ( int i = 0; i < dim_1; ++i )
                 for ( int j = 0; j < dim_2; ++j )
-                    tuples( idx ).get<3>( i, j ) = dval * (i+j);
+                    Cabana::get<3>( tuples(idx), i, j ) = dval * (i+j);
         });
 
     // Assign the tuple data back to the AoSoA.
@@ -469,19 +469,19 @@ void testAccess()
                 for ( int i = 0; i < dim_1; ++i )
                     for ( int j = 0; j < dim_2; ++j )
                         for ( int k = 0; k < dim_3; ++k )
-                            soa.get<0>( a, i, j, k ) = fval * (i+j+k);
+                            Cabana::get<0>( soa, a, i, j, k ) = fval * (i+j+k);
 
                 // Member 1.
-                soa.get<1>( a ) = ival;
+                Cabana::get<1>( soa, a ) = ival;
 
                 // Member 2.
                 for ( int i = 0; i < dim_1; ++i )
-                    soa.get<2>( a, i ) = dval * i;
+                    Cabana::get<2>( soa, a, i ) = dval * i;
 
                 // Member 3.
                 for ( int i = 0; i < dim_1; ++i )
                     for ( int j = 0; j < dim_2; ++j )
-                        soa.get<3>( a, i, j ) = dval * (i+j);
+                        Cabana::get<3>( soa, a, i, j ) = dval * (i+j);
             }
         });
 

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -230,7 +230,7 @@ void testMirror()
 
             // Check that the same memory space case didn't allocate any
             // memory. They should have the same pointer.
-            EXPECT_EQ( aosoa.ptr(), same_space_mirror.ptr() );
+            EXPECT_EQ( aosoa.data(), same_space_mirror.data() );
 
             // Check values.
             checkDataMembers(

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -30,10 +30,10 @@ void checkDataMembers(
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
 
-    auto slice_0 = mirror.template slice<0>();
-    auto slice_1 = mirror.template slice<1>();
-    auto slice_2 = mirror.template slice<2>();
-    auto slice_3 = mirror.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(mirror);
+    auto slice_1 = Cabana::slice<1>(mirror);
+    auto slice_2 = Cabana::slice<2>(mirror);
+    auto slice_3 = Cabana::slice<3>(mirror);
 
     for ( std::size_t idx = 0; idx < aosoa.size(); ++idx )
     {
@@ -90,10 +90,10 @@ void testDeepCopy()
     float fval = 3.4;
     double dval = 1.23;
     int ival = 1;
-    auto slice_0 = src_aosoa.template slice<0>();
-    auto slice_1 = src_aosoa.template slice<1>();
-    auto slice_2 = src_aosoa.template slice<2>();
-    auto slice_3 = src_aosoa.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(src_aosoa);
+    auto slice_1 = Cabana::slice<1>(src_aosoa);
+    auto slice_2 = Cabana::slice<2>(src_aosoa);
+    auto slice_3 = Cabana::slice<3>(src_aosoa);
     Kokkos::parallel_for(
         "initialize",
         Kokkos::RangePolicy<typename SrcMemorySpace::execution_space>(0,num_data),
@@ -125,10 +125,10 @@ void testDeepCopy()
 
     // Create a second AoSoA and deep copy by slice.
     DstAoSoA_t dst_aosoa_2( num_data );
-    auto dst_slice_0 = dst_aosoa_2.template slice<0>();
-    auto dst_slice_1 = dst_aosoa_2.template slice<1>();
-    auto dst_slice_2 = dst_aosoa_2.template slice<2>();
-    auto dst_slice_3 = dst_aosoa_2.template slice<3>();
+    auto dst_slice_0 = Cabana::slice<0>(dst_aosoa_2);
+    auto dst_slice_1 = Cabana::slice<1>(dst_aosoa_2);
+    auto dst_slice_2 = Cabana::slice<2>(dst_aosoa_2);
+    auto dst_slice_3 = Cabana::slice<3>(dst_aosoa_2);
     Cabana::deep_copy( dst_slice_0, slice_0 );
     Cabana::deep_copy( dst_slice_1, slice_1 );
     Cabana::deep_copy( dst_slice_2, slice_2 );
@@ -163,10 +163,10 @@ void testMirror()
     float fval = 3.4;
     double dval = 1.23;
     int ival = 1;
-    auto slice_0 = aosoa.template slice<0>();
-    auto slice_1 = aosoa.template slice<1>();
-    auto slice_2 = aosoa.template slice<2>();
-    auto slice_3 = aosoa.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
+    auto slice_2 = Cabana::slice<2>(aosoa);
+    auto slice_3 = Cabana::slice<3>(aosoa);
     Kokkos::parallel_for(
         "initialize",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,num_data),
@@ -258,16 +258,16 @@ void testAssign()
     float fval = 3.2;
     int ival = 1;
     Cabana::Tuple<DataTypes> tp;
-    tp.get<0>(0) = fval;
-    tp.get<0>(1) = fval;
-    tp.get<1>() = ival;
+    Cabana::get<0>(tp,0) = fval;
+    Cabana::get<0>(tp,1) = fval;
+    Cabana::get<1>(tp) = ival;
     Cabana::deep_copy( aosoa, tp );
 
     // Check the assignment
     auto host_aosoa = Cabana::Experimental::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
-    auto host_slice_0 = host_aosoa.slice<0>();
-    auto host_slice_1 = host_aosoa.slice<1>();
+    auto host_slice_0 = Cabana::slice<0>(host_aosoa);
+    auto host_slice_1 = Cabana::slice<1>(host_aosoa);
     for ( int n = 0; n < num_data; ++n )
     {
         EXPECT_EQ( host_slice_0(n,0), fval );
@@ -276,16 +276,16 @@ void testAssign()
     }
 
     // Assign every element in slices to the same value.
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
     fval = 5.4;
     ival = 12;
     Cabana::deep_copy( slice_0, fval );
     Cabana::deep_copy( slice_1, ival );
     host_aosoa = Cabana::Experimental::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
-    host_slice_0 = host_aosoa.slice<0>();
-    host_slice_1 = host_aosoa.slice<1>();
+    host_slice_0 = Cabana::slice<0>(host_aosoa);
+    host_slice_1 = Cabana::slice<1>(host_aosoa);
     for ( int n = 0; n < num_data; ++n )
     {
         EXPECT_EQ( host_slice_0(n,0), fval );

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -56,8 +56,8 @@ void test1( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data_src( "src", num_data );
-    auto slice_int_src = data_src.slice<0>();
-    auto slice_dbl_src = data_src.slice<1>();
+    auto slice_int_src = Cabana::slice<0>(data_src);
+    auto slice_dbl_src = Cabana::slice<1>(data_src);
 
     // Fill the data.
     auto fill_func =
@@ -73,8 +73,8 @@ void test1( const bool use_topology )
 
     // Create a second set of data to which we will migrate.
     AoSoA_t data_dst( "dst", num_data );
-    auto slice_int_dst = data_dst.slice<0>();
-    auto slice_dbl_dst = data_dst.slice<1>();
+    auto slice_int_dst = Cabana::slice<0>(data_dst);
+    auto slice_dbl_dst = Cabana::slice<1>(data_dst);
 
     // Do the migration
     Cabana::migrate( *distributor, data_src, data_dst );
@@ -82,8 +82,8 @@ void test1( const bool use_topology )
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_dst_host(
         "data_dst_host", num_data );
-    auto slice_int_dst_host = data_dst_host.slice<0>();
-    auto slice_dbl_dst_host = data_dst_host.slice<1>();
+    auto slice_int_dst_host = Cabana::slice<0>(data_dst_host);
+    auto slice_dbl_dst_host = Cabana::slice<1>(data_dst_host);
     Cabana::deep_copy( data_dst_host, data_dst );
     auto steering = distributor->getExportSteering();
     auto host_steering = Kokkos::create_mirror_view_and_copy(
@@ -128,8 +128,8 @@ void test2( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data( "data", num_data );
-    auto slice_int = data.slice<0>();
-    auto slice_dbl = data.slice<1>();
+    auto slice_int = Cabana::slice<0>(data);
+    auto slice_dbl = Cabana::slice<1>(data);
 
     // Fill the data.
     auto fill_func =
@@ -150,8 +150,8 @@ void test2( const bool use_topology )
     // Get host copies of the migrated data.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_host( "data_host", num_data / 2 );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data );
 
     // Check the migration. We received less than we sent so this should have
@@ -204,8 +204,8 @@ void test3( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data_src( "data_src", num_data );
-    auto slice_int_src = data_src.slice<0>();
-    auto slice_dbl_src = data_src.slice<1>();
+    auto slice_int_src = Cabana::slice<0>(data_src);
+    auto slice_dbl_src = Cabana::slice<1>(data_src);
 
     // Fill the data.
     auto fill_func =
@@ -222,8 +222,8 @@ void test3( const bool use_topology )
 
     // Create a second set of data to which we will migrate.
     AoSoA_t data_dst( "data_dst", num_data );
-    auto slice_int_dst = data_dst.slice<0>();
-    auto slice_dbl_dst = data_dst.slice<1>();
+    auto slice_int_dst = Cabana::slice<0>(data_dst);
+    auto slice_dbl_dst = Cabana::slice<1>(data_dst);
 
     // Do the migration with slices
     Cabana::migrate( *distributor, slice_int_src, slice_int_dst );
@@ -252,8 +252,8 @@ void test3( const bool use_topology )
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_dst_host( "data_dst_host", num_data );
     Cabana::deep_copy( data_dst_host, data_dst );
-    auto slice_int_dst_host = data_dst_host.slice<0>();
-    auto slice_dbl_dst_host = data_dst_host.slice<1>();
+    auto slice_int_dst_host = Cabana::slice<0>(data_dst_host);
+    auto slice_dbl_dst_host = Cabana::slice<1>(data_dst_host);
     for ( int i = 0; i < num_data; ++i )
     {
         EXPECT_EQ( slice_int_dst_host(i), inverse_rank + host_steering(i) );
@@ -302,8 +302,8 @@ void test4( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data_src( "data_src", num_data );
-    auto slice_int_src = data_src.slice<0>();
-    auto slice_dbl_src = data_src.slice<1>();
+    auto slice_int_src = Cabana::slice<0>(data_src);
+    auto slice_dbl_src = Cabana::slice<1>(data_src);
 
     // Fill the data.
     auto fill_func =
@@ -320,8 +320,8 @@ void test4( const bool use_topology )
 
     // Create a second set of data to which we will migrate.
     AoSoA_t data_dst( "data_dst", num_data );
-    auto slice_int_dst = data_dst.slice<0>();
-    auto slice_dbl_dst = data_dst.slice<1>();
+    auto slice_int_dst = Cabana::slice<0>(data_dst);
+    auto slice_dbl_dst = Cabana::slice<1>(data_dst);
 
     // Do the migration
     Cabana::migrate( *distributor, data_src, data_dst );
@@ -329,8 +329,8 @@ void test4( const bool use_topology )
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_dst_host( "data_dst_host", num_data );
-    auto slice_int_dst_host = data_dst_host.slice<0>();
-    auto slice_dbl_dst_host = data_dst_host.slice<1>();
+    auto slice_int_dst_host = Cabana::slice<0>(data_dst_host);
+    auto slice_dbl_dst_host = Cabana::slice<1>(data_dst_host);
     Cabana::deep_copy( data_dst_host, data_dst );
 
     // self sends
@@ -409,8 +409,8 @@ void test5( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data_src( "data_src", num_data );
-    auto slice_int_src = data_src.slice<0>();
-    auto slice_dbl_src = data_src.slice<1>();
+    auto slice_int_src = Cabana::slice<0>(data_src);
+    auto slice_dbl_src = Cabana::slice<1>(data_src);
 
     // Fill the data.
     auto fill_func =
@@ -427,8 +427,8 @@ void test5( const bool use_topology )
 
     // Create a second set of data to which we will migrate.
     AoSoA_t data_dst( "data_dst", my_size );
-    auto slice_int_dst = data_dst.slice<0>();
-    auto slice_dbl_dst = data_dst.slice<1>();
+    auto slice_int_dst = Cabana::slice<0>(data_dst);
+    auto slice_dbl_dst = Cabana::slice<1>(data_dst);
 
     // Do the migration with slices
     Cabana::migrate( *distributor, slice_int_src, slice_int_dst );
@@ -437,8 +437,8 @@ void test5( const bool use_topology )
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_host( "data_host", my_size );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data_dst );
 
     // self sends
@@ -506,8 +506,8 @@ void test6( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data( "data", num_data );
-    auto slice_int = data.slice<0>();
-    auto slice_dbl = data.slice<1>();
+    auto slice_int = Cabana::slice<0>(data);
+    auto slice_dbl = Cabana::slice<1>(data);
 
     // Fill the data.
     auto fill_func =
@@ -533,8 +533,8 @@ void test6( const bool use_topology )
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_host( "data_host", distributor->totalNumImport() );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data );
     auto steering = distributor->getExportSteering();
     auto host_steering = Kokkos::create_mirror_view_and_copy(
@@ -594,8 +594,8 @@ void test7( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data( "data", num_data );
-    auto slice_int = data.slice<0>();
-    auto slice_dbl = data.slice<1>();
+    auto slice_int = Cabana::slice<0>(data);
+    auto slice_dbl = Cabana::slice<1>(data);
 
     // Fill the data.
     auto fill_func =
@@ -617,8 +617,8 @@ void test7( const bool use_topology )
     // Check the migration.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace>
         data_host( "data_host", distributor->totalNumImport() );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data );
     EXPECT_EQ( slice_int_host(0), my_rank );
     EXPECT_EQ( slice_dbl_host(0,0), my_rank );

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -77,8 +77,8 @@ void test1( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data( "data", halo->numLocal() + halo->numGhost() );
-    auto slice_int = data.slice<0>();
-    auto slice_dbl = data.slice<1>();
+    auto slice_int = Cabana::slice<0>(data);
+    auto slice_dbl = Cabana::slice<1>(data);
 
     // Fill the local data.
     auto fill_func =
@@ -99,8 +99,8 @@ void test1( const bool use_topology )
     // Check the results of the gather.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host(
         "data_host", halo->numLocal() + halo->numGhost() );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data );
 
     // check that the local data didn't change.
@@ -276,8 +276,8 @@ void test2( const bool use_topology )
     using DataTypes = Cabana::MemberTypes<int,double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t data( "data", halo->numLocal() + halo->numGhost() );
-    auto slice_int = data.slice<0>();
-    auto slice_dbl = data.slice<1>();
+    auto slice_int = Cabana::slice<0>(data);
+    auto slice_dbl = Cabana::slice<1>(data);
 
     // Fill the local data.
     auto fill_func =
@@ -298,8 +298,8 @@ void test2( const bool use_topology )
     // Check the results of the gather.
     Cabana::AoSoA<DataTypes,Cabana::HostSpace> data_host(
         "data_host", halo->numLocal() + halo->numGhost() );
-    auto slice_int_host = data_host.slice<0>();
-    auto slice_dbl_host = data_host.slice<1>();
+    auto slice_int_host = Cabana::slice<0>(data_host);
+    auto slice_dbl_host = Cabana::slice<1>(data_host);
     Cabana::deep_copy( data_host, data );
 
     // check that the local data didn't change.

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -36,8 +36,8 @@ void testLinkedList()
     double dx = 1.0;
     double x_min = 0.0;
     double x_max = x_min + nx * dx;
-    auto pos = aosoa.slice<Position>();
-    auto cell_id = aosoa.slice<CellId>();
+    auto pos = Cabana::slice<Position>( aosoa, "position" );
+    auto cell_id = Cabana::slice<CellId>( aosoa, "cell_id" );
     Kokkos::parallel_for(
         "initialize",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,nx),
@@ -178,7 +178,7 @@ void testLinkedList()
     // Now bin and permute all of the particles.
     {
         Cabana::LinkedCellList<typename AoSoA_t::memory_space>
-            cell_list( aosoa.slice<Position>(), grid_delta, grid_min, grid_max );
+            cell_list( Cabana::slice<Position>(aosoa), grid_delta, grid_min, grid_max );
         Cabana::permute( cell_list, aosoa );
 
         // Copy data to the host for testing.
@@ -255,8 +255,8 @@ void testLinkedListSlice()
     double dx = 1.0;
     double x_min = 0.0;
     double x_max = x_min + nx * dx;
-    auto pos = aosoa.slice<Position>();
-    auto cell_id = aosoa.slice<CellId>();
+    auto pos = Cabana::slice<Position>(aosoa);
+    auto cell_id = Cabana::slice<CellId>(aosoa);
     Kokkos::parallel_for(
         "initialize",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,nx),

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -164,7 +164,7 @@ createParticles( const int num_particle,
     using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
     AoSoA_t aosoa( "aosoa", num_particle );
 
-    auto position = aosoa.slice<0>();
+    auto position = Cabana::slice<0>(aosoa);
     using PoolType = Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE>;
     using RandomType = Kokkos::Random_XorShift64<TEST_EXECSPACE>;
     PoolType pool( 342343901 );
@@ -420,11 +420,11 @@ void testVerletListFull()
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
     Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>
-        nlist( aosoa.slice<0>(), 0, aosoa.size(),
+        nlist( Cabana::slice<0>(aosoa), 0, aosoa.size(),
                test_radius, cell_size_ratio, grid_min, grid_max );
 
     // Check the neighbor list.
-    auto position = aosoa.slice<0>();
+    auto position = Cabana::slice<0>(aosoa);
     checkFullNeighborList( nlist, position, test_radius );
 }
 
@@ -444,11 +444,11 @@ void testVerletListHalf()
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
     Cabana::VerletList<TEST_MEMSPACE,Cabana::HalfNeighborTag,LayoutTag>
-        nlist( aosoa.slice<0>(), 0, aosoa.size(),
+        nlist( Cabana::slice<0>(aosoa), 0, aosoa.size(),
                test_radius, cell_size_ratio, grid_min, grid_max );
 
     // Check the neighbor list.
-    auto position = aosoa.slice<0>();
+    auto position = Cabana::slice<0>(aosoa);
     checkHalfNeighborList( nlist, position, test_radius );
 }
 
@@ -468,7 +468,7 @@ void testNeighborParallelFor()
     using ListType = Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>;
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
-    ListType nlist( aosoa.slice<0>(), 0, aosoa.size(),
+    ListType nlist( Cabana::slice<0>(aosoa), 0, aosoa.size(),
                     test_radius, cell_size_ratio, grid_min, grid_max );
 
     // Create Kokkos views for the write operation.
@@ -491,7 +491,7 @@ void testNeighborParallelFor()
     Kokkos::fence();
 
     // Get the expected result in serial
-    auto test_list = computeFullNeighborList( aosoa.slice<0>(), test_radius );
+    auto test_list = computeFullNeighborList( Cabana::slice<0>(aosoa), test_radius );
     auto test_list_copy = createTestListHostCopy( test_list );
     for ( int p = 0; p < num_particle; ++p )
         for ( int n = 0; n < test_list_copy.counts(p); ++n )
@@ -526,11 +526,11 @@ void testVerletListFullPartialRange()
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
     Cabana::VerletList<TEST_MEMSPACE,Cabana::FullNeighborTag,LayoutTag>
-        nlist( aosoa.slice<0>(), 0, num_ignore,
+        nlist( Cabana::slice<0>(aosoa), 0, num_ignore,
                test_radius, cell_size_ratio, grid_min, grid_max );
 
     // Check the neighbor list.
-    auto position = aosoa.slice<0>();
+    auto position = Cabana::slice<0>(aosoa);
     checkFullNeighborListPartialRange( nlist, position, test_radius, num_ignore);
 }
 

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -31,10 +31,10 @@ void checkDataMembers(
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
 
-    auto slice_0 = mirror.template slice<0>();
-    auto slice_1 = mirror.template slice<1>();
-    auto slice_2 = mirror.template slice<2>();
-    auto slice_3 = mirror.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(mirror);
+    auto slice_1 = Cabana::slice<1>(mirror);
+    auto slice_2 = Cabana::slice<2>(mirror);
+    auto slice_3 = Cabana::slice<3>(mirror);
 
     for ( int idx = begin; idx != end; ++idx )
     {
@@ -78,10 +78,10 @@ class AssignmentOp
                   double dval,
                   int ival )
         : _aosoa( aosoa )
-        , _slice_0( aosoa.template slice<0>() )
-        , _slice_1( aosoa.template slice<1>() )
-        , _slice_2( aosoa.template slice<2>() )
-        , _slice_3( aosoa.template slice<3>() )
+        , _slice_0( Cabana::slice<0>(aosoa) )
+        , _slice_1( Cabana::slice<1>(aosoa) )
+        , _slice_2( Cabana::slice<2>(aosoa) )
+        , _slice_3( Cabana::slice<3>(aosoa) )
         , _fval( fval )
         , _dval( dval )
         , _ival( ival )
@@ -183,10 +183,10 @@ void runTest2d()
 
     // Create a functor to operate on.
     using OpType = AssignmentOp<AoSoA_t,
-                                decltype(aosoa.slice<0>()),
-                                decltype(aosoa.slice<1>()),
-                                decltype(aosoa.slice<2>()),
-                                decltype(aosoa.slice<3>())>;
+                                typename AoSoA_t::member_slice_type<0>,
+                                typename AoSoA_t::member_slice_type<1>,
+                                typename AoSoA_t::member_slice_type<2>,
+                                typename AoSoA_t::member_slice_type<3>>;
     float fval = 3.4;
     double dval = 1.23;
     int ival = 1;

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -26,10 +26,10 @@ void initializeDataMembers(
     const float fval, const double dval, const int ival,
     const int dim_1, const int dim_2, const int dim_3 )
 {
-    auto slice_0 = aosoa.template slice<0>();
-    auto slice_1 = aosoa.template slice<1>();
-    auto slice_2 = aosoa.template slice<2>();
-    auto slice_3 = aosoa.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
+    auto slice_2 = Cabana::slice<2>(aosoa);
+    auto slice_3 = Cabana::slice<3>(aosoa);
 
     Kokkos::parallel_for(
         "init_members",
@@ -67,10 +67,10 @@ void checkDataMembers(
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
 
-    auto slice_0 = mirror.template slice<0>();
-    auto slice_1 = mirror.template slice<1>();
-    auto slice_2 = mirror.template slice<2>();
-    auto slice_3 = mirror.template slice<3>();
+    auto slice_0 = Cabana::slice<0>(mirror);
+    auto slice_1 = Cabana::slice<1>(mirror);
+    auto slice_2 = Cabana::slice<2>(mirror);
+    auto slice_3 = Cabana::slice<3>(mirror);
 
     for ( std::size_t idx = 0; idx != aosoa.size(); ++idx )
     {
@@ -121,10 +121,10 @@ void apiTest()
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Create some slices.
-    auto slice_0 = aosoa.slice<0>();
-    auto slice_1 = aosoa.slice<1>();
-    auto slice_2 = aosoa.slice<2>();
-    auto slice_3 = aosoa.slice<3>();
+    auto slice_0 = Cabana::slice<0>(aosoa);
+    auto slice_1 = Cabana::slice<1>(aosoa);
+    auto slice_2 = Cabana::slice<2>(aosoa);
+    auto slice_3 = Cabana::slice<3>(aosoa);
 
     // Check that they are slices.
     EXPECT_TRUE( Cabana::is_slice<decltype(slice_0)>::value );
@@ -258,10 +258,10 @@ void randomAccessTest()
     initializeDataMembers( aosoa, fval, dval, ival, dim_1, dim_2, dim_3 );
 
     // Create slices.
-    auto da_slice_0 = aosoa.slice<0>();
-    auto da_slice_1 = aosoa.slice<1>();
-    auto da_slice_2 = aosoa.slice<2>();
-    auto da_slice_3 = aosoa.slice<3>();
+    auto da_slice_0 = Cabana::slice<0>(aosoa);
+    auto da_slice_1 = Cabana::slice<1>(aosoa);
+    auto da_slice_2 = Cabana::slice<2>(aosoa);
+    auto da_slice_3 = Cabana::slice<3>(aosoa);
 
     // Create read-only random access slices.
     decltype(da_slice_0)::random_access_slice ra_slice_0 = da_slice_0;
@@ -273,10 +273,10 @@ void randomAccessTest()
     AoSoA_t aosoa_2( "aosoa_2", num_data );
 
     // Get normal slices of the data.
-    auto slice_0 = aosoa_2.slice<0>();
-    auto slice_1 = aosoa_2.slice<1>();
-    auto slice_2 = aosoa_2.slice<2>();
-    auto slice_3 = aosoa_2.slice<3>();
+    auto slice_0 = Cabana::slice<0>(aosoa_2);
+    auto slice_1 = Cabana::slice<1>(aosoa_2);
+    auto slice_2 = Cabana::slice<2>(aosoa_2);
+    auto slice_3 = Cabana::slice<3>(aosoa_2);
 
     // Assign the read-only data to the new aosoa.
     Kokkos::parallel_for(
@@ -322,7 +322,7 @@ void atomicAccessTest()
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Get a slice of the data.
-    auto slice = aosoa.slice<0>();
+    auto slice = Cabana::slice<0>(aosoa);
 
     // Set to 0.
     Kokkos::parallel_for(
@@ -348,7 +348,7 @@ void atomicAccessTest()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto mirror_slice = mirror.template slice<0>();
+    auto mirror_slice = Cabana::slice<0>(mirror);
 
     for ( int i = 0; i < num_data; ++i ) EXPECT_EQ( mirror_slice(i), num_data );
 }

--- a/core/unit_test/tstSoA.cpp
+++ b/core/unit_test/tstSoA.cpp
@@ -62,14 +62,14 @@ void testSoA()
 
     // Set some data with the soa.
     double v1 = 0.3343;
-    soa.get<0>( 3 ) = v1;
+    Cabana::get<0>( soa, 3 ) = v1;
 
     float v2 = 0.992;
-    soa.get<5>( 2, 1, 1, 1 ) = v2;
+    Cabana::get<5>( soa, 2, 1, 1, 1 ) = v2;
 
     // Check the data.
-    EXPECT_EQ( soa.get<0>(3), v1 );
-    EXPECT_EQ( soa.get<5>(2,1,1,1), v2 );
+    EXPECT_EQ( Cabana::get<0>(soa,3), v1 );
+    EXPECT_EQ( Cabana::get<5>(soa,2,1,1,1), v2 );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstSort.hpp
+++ b/core/unit_test/tstSort.hpp
@@ -43,9 +43,9 @@ void testSortByKey()
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
     // can see that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -84,9 +84,9 @@ void testSortByKey()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
         int reverse_index = aosoa.size() - p - 1;
@@ -129,9 +129,9 @@ void testBinByKey()
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
     // can see that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -183,9 +183,9 @@ void testBinByKey()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     EXPECT_EQ( bin_data.numBin(), num_data );
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
@@ -227,9 +227,9 @@ void testSortBySlice()
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -248,7 +248,7 @@ void testSortBySlice()
     Kokkos::fence();
 
     // Sort the aosoa by the 1D member.
-    auto binning_data = Cabana::sortByKey( aosoa.slice<1>() );
+    auto binning_data = Cabana::sortByKey( Cabana::slice<1>(aosoa) );
     Cabana::permute( binning_data, aosoa );
 
     // Copy the bin data so we can check it.
@@ -268,9 +268,9 @@ void testSortBySlice()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
         int reverse_index = aosoa.size() - p - 1;
@@ -309,9 +309,9 @@ void testSortBySliceDataOnly()
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -330,7 +330,7 @@ void testSortBySliceDataOnly()
     Kokkos::fence();
 
     // Sort the aosoa by the 1D member.
-    auto binning_data = Cabana::sortByKey( aosoa.slice<1>() );
+    auto binning_data = Cabana::sortByKey( Cabana::slice<1>(aosoa) );
 
     // Copy the bin data so we can check it.
     Kokkos::View<std::size_t*,TEST_MEMSPACE>
@@ -350,9 +350,9 @@ void testSortBySliceDataOnly()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
         int reverse_index = aosoa.size() - p - 1;
@@ -391,9 +391,9 @@ void testBinBySlice()
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -413,7 +413,7 @@ void testBinBySlice()
 
     // Bin the aosoa by the 1D member. Use one bin per data point to
     // effectively make this a sort.
-    auto bin_data = Cabana::binByKey( aosoa.slice<1>(), num_data-1 );
+    auto bin_data = Cabana::binByKey( Cabana::slice<1>(aosoa), num_data-1 );
     Cabana::permute( bin_data, aosoa );
 
     // Copy the bin data so we can check it.
@@ -443,9 +443,9 @@ void testBinBySlice()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     EXPECT_EQ( bin_data.numBin(), num_data );
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
@@ -487,9 +487,9 @@ void testBinBySliceDataOnly()
 
     // Create the AoSoA data. Create the data in reverse order so we can see
     // that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -510,7 +510,7 @@ void testBinBySliceDataOnly()
     // Bin the aosoa by the 1D member. Use one bin per data point to
     // effectively make this a sort. Don't actually move the particle data
     // though - just create the binning data.
-    auto bin_data = Cabana::binByKey( aosoa.slice<1>(), num_data-1 );
+    auto bin_data = Cabana::binByKey( Cabana::slice<1>(aosoa), num_data-1 );
 
     // Copy the bin data so we can check it.
     Kokkos::View<std::size_t*,TEST_MEMSPACE>
@@ -540,9 +540,9 @@ void testBinBySliceDataOnly()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
     EXPECT_EQ( bin_data.numBin(), num_data );
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
     {
@@ -588,9 +588,9 @@ void testSortByKeySlice()
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
     // can see that it is sorted.
-    auto v0 = aosoa.slice<0>();
-    auto v1 = aosoa.slice<1>();
-    auto v2 = aosoa.slice<2>();
+    auto v0 = Cabana::slice<0>(aosoa);
+    auto v1 = Cabana::slice<1>(aosoa);
+    auto v2 = Cabana::slice<2>(aosoa);
     Kokkos::parallel_for(
         "fill",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,aosoa.size()),
@@ -629,9 +629,9 @@ void testSortByKeySlice()
     auto mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    auto v0_mirror = mirror.slice<0>();
-    auto v1_mirror = mirror.slice<1>();
-    auto v2_mirror = mirror.slice<2>();
+    auto v0_mirror = Cabana::slice<0>(mirror);
+    auto v1_mirror = Cabana::slice<1>(mirror);
+    auto v2_mirror = Cabana::slice<2>(mirror);
 
     // Check the result of the slice 1 sort.
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
@@ -673,9 +673,9 @@ void testSortByKeySlice()
     mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    v0_mirror = mirror.slice<0>();
-    v1_mirror = mirror.slice<1>();
-    v2_mirror = mirror.slice<2>();
+    v0_mirror = Cabana::slice<0>(mirror);
+    v1_mirror = Cabana::slice<1>(mirror);
+    v2_mirror = Cabana::slice<2>(mirror);
 
     // Check the result of the slice 2 sort (slice 1 already done).
     for ( std::size_t p = 0; p < aosoa.size(); ++p )
@@ -717,9 +717,9 @@ void testSortByKeySlice()
     mirror =
         Cabana::Experimental::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
-    v0_mirror = mirror.slice<0>();
-    v1_mirror = mirror.slice<1>();
-    v2_mirror = mirror.slice<2>();
+    v0_mirror = Cabana::slice<0>(mirror);
+    v1_mirror = Cabana::slice<1>(mirror);
+    v2_mirror = Cabana::slice<2>(mirror);
 
     // Check the result of the slice 3 sort (slices 1-2 already done).
     for ( std::size_t p = 0; p < aosoa.size(); ++p )

--- a/core/unit_test/tstTuple.hpp
+++ b/core/unit_test/tstTuple.hpp
@@ -35,20 +35,20 @@ void checkDataMembers(
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
                 for ( std::size_t k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( mirror_view(idx).template get<0>( i, j, k ),
+                    EXPECT_EQ( Cabana::get<0>(mirror_view(idx),i,j,k),
                                fval * (i+j+k) );
 
         // Member 1.
-        EXPECT_EQ( mirror_view(idx).template get<1>(), ival );
+        EXPECT_EQ( Cabana::get<1>(mirror_view(idx)), ival );
 
         // Member 2.
         for ( std::size_t i = 0; i < dim_1; ++i )
-            EXPECT_EQ( mirror_view(idx).template get<2>( i ), dval * i );
+            EXPECT_EQ( Cabana::get<2>(mirror_view(idx),i), dval * i );
 
         // Member 3.
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
-                EXPECT_EQ( mirror_view(idx).template get<3>( i, j ), dval * (i+j) );
+                EXPECT_EQ( Cabana::get<3>(mirror_view(idx),i,j), dval * (i+j) );
     }
 }
 
@@ -87,19 +87,19 @@ void runTest()
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
                 for ( std::size_t k = 0; k < dim_3; ++k )
-                    tuples( idx ).get<0>( i, j, k ) = fval * (i+j+k);
+                    Cabana::get<0>( tuples(idx), i, j, k ) = fval * (i+j+k);
 
         // Member 1.
-        tuples( idx ).get<1>() = ival;
+        Cabana::get<1>( tuples(idx) ) = ival;
 
         // Member 2.
         for ( std::size_t i = 0; i < dim_1; ++i )
-            tuples( idx ).get<2>( i ) = dval * i;
+            Cabana::get<2>( tuples(idx), i ) = dval * i;
 
         // Member 3.
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
-                tuples( idx ).get<3>( i, j ) = dval * (i+j);
+                Cabana::get<3>( tuples(idx), i, j ) = dval * (i+j);
     };
     Kokkos::fence();
 


### PR DESCRIPTION
Adds template helpers for slicing and data access:

- `Cabana::slice<3>( aosoa )` instead of `aosoa.template slice<3>()`
- `Cabana::get<2>( tuple, 3, 1 )` instead of `tuple.template get<2>(3,1)`
- `Cabana::get<2>( soa, 3, 3, 1 )` instead of `soa.template get<2>(3,3,1)`

Affects `AoSoA`/`Slice`, `SoA`, and `Tuple`.  The original versions of these functions still exist but are now deprecated and call the new versions. The deprecated calls have been replaced in the tests and examples.