### PR TITLE
Consistent Size Types

### DIFF
--- a/core/example/tutorial/04_aosoa/aosoa_example.cpp
+++ b/core/example/tutorial/04_aosoa/aosoa_example.cpp
@@ -116,14 +116,14 @@ void aosoaExample()
         */
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )
-                for ( int a = 0; a < aosoa.arraySize(s); ++a )
+                for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
                     Cabana::get<0>(soa,a,i,j) = 1.0 * (a + i + j);
 
         for ( int i = 0; i < 4; ++i )
-            for ( int a = 0; a < aosoa.arraySize(s); ++a )
+            for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
                 Cabana::get<1>(soa,a,i) = 1.0 * (a + i);
 
-        for ( int a = 0; a < aosoa.arraySize(s); ++a )
+        for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
             Cabana::get<2>(soa,a) = a + 1234;
     }
 

--- a/core/example/tutorial/05_slice/slice_example.cpp
+++ b/core/example/tutorial/05_slice/slice_example.cpp
@@ -106,14 +106,14 @@ void sliceExample()
     {
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )
-                for ( int a = 0; a < slice_0.arraySize(s); ++a )
+                for ( std::size_t a = 0; a < slice_0.arraySize(s); ++a )
                     slice_0.access(s,a,i,j) = 1.0 * (a + i + j);
 
         for ( int i = 0; i < 4; ++i )
-            for ( int a = 0; a < slice_0.arraySize(s); ++a )
+            for ( std::size_t a = 0; a < slice_0.arraySize(s); ++a )
                 slice_1.access(s,a,i) = 1.0 * (a + i);
 
-        for ( int a = 0; a < slice_0.arraySize(s); ++a )
+        for ( std::size_t a = 0; a < slice_0.arraySize(s); ++a )
             slice_2.access(s,a) = a + 1234;
     }
 

--- a/core/example/tutorial/07_sorting/sorting.cpp
+++ b/core/example/tutorial/07_sorting/sorting.cpp
@@ -60,14 +60,14 @@ void sortingExample()
         auto& soa = aosoa.access(s);
 
         // ASCENDING ORDER!
-        for ( int a = 0; a < aosoa.arraySize(s); ++a )
+        for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
         {
             Cabana::get<0>(soa,a) = forward_index_counter;
             ++forward_index_counter;
         }
 
         // DESCENDING ORDER!
-        for ( int a = 0; a < aosoa.arraySize(s); ++a )
+        for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
         {
             Cabana::get<1>(soa,a) = reverse_index_counter;
             --reverse_index_counter;

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -347,8 +347,8 @@ inline void deep_copy(
     }
 
     // Get the number of components in each slice element.
-    int num_comp = 1;
-    for ( int d = 2; d < dst.rank(); ++d )
+    std::size_t num_comp = 1;
+    for ( std::size_t d = 2; d < dst.rank(); ++d )
         num_comp *= dst.extent(d);
 
     // Gather the slice data in a flat view in the source space and copy it to
@@ -365,7 +365,7 @@ inline void deep_copy(
                 auto src_offset =
                 SrcSlice::index_type::s(i) * src.stride(0) +
                 SrcSlice::index_type::a(i);
-                for ( int n = 0; n < num_comp; ++n )
+                for ( std::size_t n = 0; n < num_comp; ++n )
                     gather_src( i * num_comp + n ) =
                         src_data[ src_offset + SrcSlice::vector_length * n ];
             };
@@ -384,7 +384,7 @@ inline void deep_copy(
             auto dst_offset =
             DstSlice::index_type::s(i) * dst.stride(0) +
             DstSlice::index_type::a(i);
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 dst_data[ dst_offset + DstSlice::vector_length * n ] =
                     gather_dst( i * num_comp + n );
         };

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -456,8 +456,8 @@ void migrate( const Distributor_t& distributor,
         throw std::runtime_error("Destination is the wrong size for migration!");
 
     // Get the number of components in the slices.
-    int num_comp = 1;
-    for ( int d = 2; d < src.rank(); ++d )
+    size_t num_comp = 1;
+    for ( size_t d = 2; d < src.rank(); ++d )
         num_comp *= src.extent(d);
 
     // Get the raw slice data.
@@ -510,11 +510,11 @@ void migrate( const Distributor_t& distributor,
             auto a_src = Slice_t::index_type::a( steering(i) );
             std::size_t src_offset = s_src*src.stride(0) + a_src;
             if ( i < num_stay )
-                for ( int n = 0; n < num_comp; ++n )
+                for ( std::size_t n = 0; n < num_comp; ++n )
                     recv_buffer( i, n ) =
                         src_data[ src_offset + n * Slice_t::vector_length ];
             else
-                for ( int n = 0; n < num_comp; ++n )
+                for ( std::size_t n = 0; n < num_comp; ++n )
                     send_buffer( i - num_stay, n ) =
                         src_data[ src_offset + n * Slice_t::vector_length ];
         };
@@ -589,7 +589,7 @@ void migrate( const Distributor_t& distributor,
             auto s = Slice_t::index_type::s( i );
             auto a = Slice_t::index_type::a( i );
             std::size_t dst_offset = s*dst.stride(0) + a;
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 dst_data[ dst_offset + n * Slice_t::vector_length ] =
                     recv_buffer( i, n );
         };

--- a/core/src/Cabana_ExecutionPolicy.hpp
+++ b/core/src/Cabana_ExecutionPolicy.hpp
@@ -31,7 +31,7 @@ namespace Impl
 
   \tparam VectorLength The inner array size of the AoSoA.
 */
-template<int VectorLength, typename IndexType>
+template<int VectorLength, class IndexType>
 class StructRange
 {
   public:

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -387,8 +387,8 @@ void gather( const Halo_t& halo,
         throw std::runtime_error("Slice is the wrong size for scatter!");
 
     // Get the number of components in the slice.
-    int num_comp = 1;
-    for ( int d = 2; d < slice.rank(); ++d )
+    std::size_t num_comp = 1;
+    for ( std::size_t d = 2; d < slice.rank(); ++d )
         num_comp *= slice.extent(d);
 
     // Get the raw slice data.
@@ -413,7 +413,7 @@ void gather( const Halo_t& halo,
             auto s = Slice_t::index_type::s( steering(i) );
             auto a = Slice_t::index_type::a( steering(i) );
             std::size_t slice_offset = s*slice.stride(0) + a;
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 send_buffer( i, n ) =
                     slice_data[ slice_offset + n * Slice_t::vector_length ];
         };
@@ -489,7 +489,7 @@ void gather( const Halo_t& halo,
             auto s = Slice_t::index_type::s( ghost_idx );
             auto a = Slice_t::index_type::a( ghost_idx );
             std::size_t slice_offset = s*slice.stride(0) + a;
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 slice_data[ slice_offset + Slice_t::vector_length * n ] =
                     recv_buffer( i, n );
         };
@@ -546,8 +546,8 @@ void scatter( const Halo_t& halo,
         throw std::runtime_error("Slice is the wrong size for scatter!");
 
     // Get the number of components in the slice.
-    int num_comp = 1;
-    for ( int d = 2; d < slice.rank(); ++d )
+    std::size_t num_comp = 1;
+    for ( std::size_t d = 2; d < slice.rank(); ++d )
         num_comp *= slice.extent(d);
 
     // Get the raw slice data. Wrap in a 1D Kokkos View so we can unroll the
@@ -575,7 +575,7 @@ void scatter( const Halo_t& halo,
             auto s = Slice_t::index_type::s( ghost_idx );
             auto a = Slice_t::index_type::a( ghost_idx );
             std::size_t slice_offset = s*slice.stride(0) + a;
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 send_buffer( i, n ) =
                     slice_data( slice_offset + Slice_t::vector_length * n );
         };
@@ -652,7 +652,7 @@ void scatter( const Halo_t& halo,
             auto s = Slice_t::index_type::s( steering(i) );
             auto a = Slice_t::index_type::a( steering(i) );
             std::size_t slice_offset = s*slice.stride(0) + a;
-            for ( int n = 0; n < num_comp; ++n )
+            for ( std::size_t n = 0; n < num_comp; ++n )
                 Kokkos::atomic_add(
                     &slice_data(slice_offset + Slice_t::vector_length * n),
                     recv_buffer(i,n) );

--- a/core/src/Cabana_MemberTypes.hpp
+++ b/core/src/Cabana_MemberTypes.hpp
@@ -46,7 +46,7 @@ struct is_member_types<const MemberTypes<Types...> >
   \class MemberTypeAtIndex
   \brief Get the type of the member at a given index.
 */
-template<std::size_t I, typename T, typename... Types>
+template<std::size_t M, typename T, typename... Types>
 struct MemberTypeAtIndexImpl;
 
 template<typename T, typename... Types>
@@ -55,20 +55,20 @@ struct MemberTypeAtIndexImpl<0,T,Types...>
     using type = T;
 };
 
-template<std::size_t I, typename T, typename... Types>
+template<std::size_t M, typename T, typename... Types>
 struct MemberTypeAtIndexImpl
 {
-    using type = typename MemberTypeAtIndexImpl<I-1,Types...>::type;
+    using type = typename MemberTypeAtIndexImpl<M-1,Types...>::type;
 };
 
-template<std::size_t I, typename... Types>
+template<std::size_t M, typename... Types>
 struct MemberTypeAtIndex;
 
-template<std::size_t I, typename... Types>
-struct MemberTypeAtIndex<I,MemberTypes<Types...> >
+template<std::size_t M, typename... Types>
+struct MemberTypeAtIndex<M,MemberTypes<Types...> >
 {
     using type =
-        typename MemberTypeAtIndexImpl<I,Types...>::type;
+        typename MemberTypeAtIndexImpl<M,Types...>::type;
 };
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -58,15 +58,15 @@ class NeighborList
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static int numNeighbor( const NeighborListType& list,
-                            const std::size_t particle_index );
+    static std::size_t numNeighbor( const NeighborListType& list,
+                                    const std::size_t particle_index );
 
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static int getNeighbor( const NeighborListType& list,
-                            const std::size_t particle_index,
-                            const int neighbor_index );
+    static std::size_t getNeighbor( const NeighborListType& list,
+                                    const std::size_t particle_index,
+                                    const std::size_t neighbor_index );
 };
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -204,8 +204,9 @@ inline void neighbor_parallel_for(
                 Impl::functorTagDispatch<work_tag>(
                     functor,
                     i,
-                    (index_type) NeighborList<NeighborListType>::getNeighbor(
-                        list,i,n) );
+                    static_cast<index_type>(
+                        NeighborList<NeighborListType>::getNeighbor(list,i,n))
+                    );
         },
         str );
 }
@@ -288,8 +289,9 @@ inline void neighbor_parallel_for(
                 Impl::functorTagDispatch<work_tag>(
                     functor,
                     i,
-                    (index_type) NeighborList<NeighborListType>::getNeighbor(
-                        list,i,n) );
+                    static_cast<index_type>(
+                        NeighborList<NeighborListType>::getNeighbor(list,i,n) )
+                    );
                 });
         },
         str );

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -585,7 +585,7 @@ class Slice
     KOKKOS_INLINE_FUNCTION
     size_type arraySize( const size_type s ) const
     {
-        return ( (size_type) s < _view.extent(0) - 1 )
+        return ( static_cast<size_type>(s) < _view.extent(0) - 1 )
             ? vector_length : ( _size % vector_length );
     }
 

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -106,7 +106,7 @@ struct InnerArrayType
   (including multidimensional arrays) as long as the type of T is trivial. A
   struct-of-arrays will be composed of these members of different types.
 */
-template<std::size_t I, int VectorLength, typename T>
+template<std::size_t M, int VectorLength, typename T>
 struct StructMember
 {
     using array_type = typename InnerArrayType<T,VectorLength>::type;
@@ -165,7 +165,8 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M> >::type
-get( SoA_t& soa, const int a )
+get( SoA_t& soa,
+     const std::size_t a )
 {
     return Impl::soaMemberCast<M>(soa)._data[a];
 }
@@ -176,7 +177,8 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_value_type<M> >::type
-get( const SoA_t& soa, const int a )
+get( const SoA_t& soa,
+     const std::size_t a )
 {
     return Impl::soaMemberCast<M>(soa)._data[a];
 }
@@ -187,7 +189,9 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M> >::type
-get( SoA_t& soa, const int a, const int d0 )
+get( SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][a];
 }
@@ -198,7 +202,9 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_value_type<M> >::type
-get( const SoA_t& soa, const int a, const int d0 )
+get( const SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][a];
 }
@@ -209,7 +215,10 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M> >::type
-get( SoA_t& soa, const int a, const int d0, const int d1 )
+get( SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0,
+     const std::size_t d1 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][d1][a];
 }
@@ -220,7 +229,10 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_value_type<M> >::type
-get( const SoA_t& soa, const int a, const int d0, const int d1 )
+get( const SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0,
+     const std::size_t d1 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][d1][a];
 }
@@ -231,7 +243,11 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M> >::type
-get( SoA_t& soa, const int a, const int d0, const int d1, const int d2 )
+get( SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0,
+     const std::size_t d1,
+     const std::size_t d2 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][d1][d2][a];
 }
@@ -242,7 +258,11 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_value_type<M> >::type
-get( const SoA_t& soa, const int a, const int d0, const int d1, const int d2 )
+get( const SoA_t& soa,
+     const std::size_t a,
+     const std::size_t d0,
+     const std::size_t d1,
+     const std::size_t d2 )
 {
     return Impl::soaMemberCast<M>(soa)._data[d0][d1][d2][a];
 }
@@ -312,7 +332,7 @@ struct SoA<MemberTypes<Types...>,VectorLength>
     */
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    constexpr unsigned rank() const
+    constexpr std::size_t rank() const
     {
         return std::rank<member_data_type<M> >::value;
     }
@@ -339,136 +359,96 @@ struct SoA<MemberTypes<Types...>,VectorLength>
 
     // Rank 0
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(0==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value),
+    typename std::enable_if<0==std::rank<member_data_type<M> >::value,
                             member_reference_type<M> >::type
-    get( const A& a )
+    get( const std::size_t a )
     {
         return Cabana::get<M>( *this, a );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(0==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value),
+    typename std::enable_if<0==std::rank<member_data_type<M> >::value,
                             member_value_type<M> >::type
-    get( const A& a ) const
+    get( const std::size_t a ) const
     {
         return Cabana::get<M>( *this, a );
     }
 
     // Rank 1
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(1==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value),
+    typename std::enable_if<1==std::rank<member_data_type<M> >::value,
                             member_reference_type<M> >::type
-    get(  const A& a,
-          const D0& d0 )
+    get(  const std::size_t a,
+          const std::size_t d0 )
     {
         return Cabana::get<M>( *this, a, d0 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(1==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value),
+    typename std::enable_if<1==std::rank<member_data_type<M> >::value,
                             member_value_type<M> >::type
-    get(  const A& a,
-          const D0& d0 ) const
+    get(  const std::size_t a,
+          const std::size_t d0 ) const
     {
         return Cabana::get<M>( *this, a, d0 );
     }
 
     // Rank 2
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0,
-             typename D1>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(2==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value &&
-                             std::is_integral<D1>::value),
+    typename std::enable_if<2==std::rank<member_data_type<M> >::value,
                             member_reference_type<M> >::type
-    get( const A& a,
-         const D0& d0,
-         const D1& d1 )
+    get( const std::size_t a,
+         const std::size_t d0,
+         const std::size_t d1 )
     {
         return Cabana::get<M>( *this, a, d0, d1 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0,
-             typename D1>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(2==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value &&
-                             std::is_integral<D1>::value),
+    typename std::enable_if<2==std::rank<member_data_type<M> >::value,
                             member_value_type<M> >::type
-    get( const A& a,
-         const D0& d0,
-         const D1& d1 ) const
+    get( const std::size_t a,
+         const std::size_t d0,
+         const std::size_t d1 ) const
     {
         return Cabana::get<M>( *this, a, d0, d1 );
     }
 
     // Rank 3
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0,
-             typename D1,
-             typename D2>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(3==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value &&
-                             std::is_integral<D1>::value &&
-                             std::is_integral<D2>::value),
+    typename std::enable_if<3==std::rank<member_data_type<M> >::value,
                             member_reference_type<M> >::type
-    get( const A& a,
-         const D0& d0,
-         const D1& d1,
-         const D2& d2 )
+    get( const std::size_t a,
+         const std::size_t d0,
+         const std::size_t d1,
+         const std::size_t d2 )
     {
         return Cabana::get<M>( *this, a, d0, d1, d2 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename A,
-             typename D0,
-             typename D1,
-             typename D2>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
-    typename std::enable_if<(3==std::rank<member_data_type<M> >::value &&
-                             std::is_integral<A>::value &&
-                             std::is_integral<D0>::value &&
-                             std::is_integral<D1>::value &&
-                             std::is_integral<D2>::value),
+    typename std::enable_if<3==std::rank<member_data_type<M> >::value,
                             member_value_type<M> >::type
-    get( const A& a,
-         const D0& d0,
-         const D1& d1,
-         const D2& d2 ) const
+    get( const std::size_t a,
+         const std::size_t d0,
+         const std::size_t d1,
+         const std::size_t d2 ) const
     {
         return Cabana::get<M>( *this, a, d0, d1, d2 );
     }

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -613,8 +613,8 @@ void permute( const BinningDataType& binning_data,
     auto end = binning_data.rangeEnd();
 
     // Get the number of components in the slice.
-    int num_comp = 1;
-    for ( int d = 2; d < slice.rank(); ++d )
+    std::size_t num_comp = 1;
+    for ( std::size_t d = 2; d < slice.rank(); ++d )
         num_comp *= slice.extent(d);
 
     // Get the raw slice data.
@@ -631,7 +631,7 @@ void permute( const BinningDataType& binning_data,
           auto s = SliceType::index_type::s( permute_i );
           auto a = SliceType::index_type::a( permute_i );
           std::size_t slice_offset = s*slice.stride(0) + a;
-          for ( int n = 0; n < num_comp; ++n )
+          for ( std::size_t n = 0; n < num_comp; ++n )
               scratch_array( i-begin, n ) =
                   slice_data[ slice_offset + SliceType::vector_length * n ];
         };
@@ -647,7 +647,7 @@ void permute( const BinningDataType& binning_data,
           auto s = SliceType::index_type::s( i );
           auto a = SliceType::index_type::a( i );
           std::size_t slice_offset = s*slice.stride(0) + a;
-          for ( int n = 0; n < num_comp; ++n )
+          for ( std::size_t n = 0; n < num_comp; ++n )
               slice_data[ slice_offset + SliceType::vector_length * n ] =
                   scratch_array( i-begin, n );
         };

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -70,7 +70,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M> >::type
-get( Tuple_t& tp, const int d0 )
+get( Tuple_t& tp, const std::size_t d0 )
 {
     return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0);
 }
@@ -81,7 +81,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M> >::type
-get( const Tuple_t& tp, const int d0 )
+get( const Tuple_t& tp, const std::size_t d0 )
 {
     return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0);
 }
@@ -92,7 +92,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M> >::type
-get( Tuple_t& tp, const int d0, const int d1 )
+get( Tuple_t& tp, const std::size_t d0, const std::size_t d1 )
 {
     return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0,d1);
 }
@@ -103,7 +103,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M> >::type
-get( const Tuple_t& tp, const int d0, const int d1 )
+get( const Tuple_t& tp, const std::size_t d0, const std::size_t d1 )
 {
     return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0,d1);
 }
@@ -114,7 +114,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M> >::type
-get( Tuple_t& tp, const int d0, const int d1, const int d2 )
+get( Tuple_t& tp, const std::size_t d0, const std::size_t d1, const std::size_t d2 )
 {
     return get<M>(static_cast<typename Tuple_t::base&>(tp),0,d0,d1,d2);
 }
@@ -125,7 +125,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M> >::type
-get( const Tuple_t& tp, const int d0, const int d1, const int d2 )
+get( const Tuple_t& tp, const std::size_t d0, const std::size_t d1, const std::size_t d2 )
 {
     return get<M>(static_cast<const typename Tuple_t::base&>(tp),0,d0,d1,d2);
 }
@@ -156,7 +156,7 @@ struct Tuple<MemberTypes<Types...> >
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (0==std::rank<typename base::template member_data_type<M> >::value),
+        0==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_reference_type<M> >::type
     get()
     {
@@ -167,7 +167,7 @@ struct Tuple<MemberTypes<Types...> >
     template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (0==std::rank<typename base::template member_data_type<M> >::value),
+        0==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_value_type<M> >::type
     get() const
     {
@@ -176,99 +176,75 @@ struct Tuple<MemberTypes<Types...> >
 
     // Rank 1
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (1==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value),
+        1==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_reference_type<M> >::type
-    get( const D0& d0 )
+    get( const std::size_t d0 )
     {
         return Cabana::get<M>( *this, d0 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (1==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value),
+        1==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_value_type<M> >::type
-    get( const D0& d0 ) const
+    get( const std::size_t d0 ) const
     {
         return Cabana::get<M>( *this, d0 );
     }
 
     // Rank 2
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0,
-             typename D1>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (2==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value &&
-         std::is_integral<D1>::value),
+        2==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_reference_type<M> >::type
-    get( const D0& d0,
-         const D1& d1 )
+    get( const std::size_t d0,
+         const std::size_t d1 )
     {
         return Cabana::get<M>( *this, d0, d1 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0,
-             typename D1>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (2==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value &&
-         std::is_integral<D1>::value),
+        2==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_value_type<M> >::type
-    get( const D0& d0,
-         const D1& d1 ) const
+    get( const std::size_t d0,
+         const std::size_t d1 ) const
     {
         return Cabana::get<M>( *this, d0, d1 );
     }
 
     // Rank 3
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0,
-             typename D1,
-             typename D2>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (3==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value &&
-         std::is_integral<D1>::value &&
-         std::is_integral<D2>::value),
+        3==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_reference_type<M> >::type
-    get( const D0& d0,
-         const D1& d1,
-         const D2& d2 )
+    get( const std::size_t d0,
+         const std::size_t d1,
+         const std::size_t d2 )
     {
         return Cabana::get<M>( *this, d0, d1, d2 );
     }
 
     CABANA_DEPRECATED
-    template<std::size_t M,
-             typename D0,
-             typename D1,
-             typename D2>
+    template<std::size_t M>
     KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<
-        (3==std::rank<typename base::template member_data_type<M> >::value &&
-         std::is_integral<D0>::value &&
-         std::is_integral<D1>::value &&
-         std::is_integral<D2>::value),
+        3==std::rank<typename base::template member_data_type<M> >::value,
         typename base::template member_value_type<M> >::type
-    get( const D0& d0,
-         const D1& d1,
-         const D2& d2 ) const
+    get( const std::size_t d0,
+         const std::size_t d1,
+         const std::size_t d2 ) const
     {
         return Cabana::get<M>( *this, d0, d1, d2 );
     }

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -620,8 +620,8 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag,VerletLayoutCSR> >
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static int numNeighbor( const list_type& list,
-                            const std::size_t particle_index )
+    static std::size_t numNeighbor( const list_type& list,
+                                    const std::size_t particle_index )
     {
         return list._data.counts( particle_index );
     }
@@ -629,9 +629,9 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag,VerletLayoutCSR> >
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static int getNeighbor( const list_type& list,
-                            const std::size_t particle_index,
-                            const int neighbor_index )
+    static std::size_t getNeighbor( const list_type& list,
+                                    const std::size_t particle_index,
+                                    const std::size_t neighbor_index )
     {
         return list._data.neighbors(
             list._data.offsets(particle_index) + neighbor_index );
@@ -651,8 +651,8 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag,VerletLayout2D> >
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static int numNeighbor( const list_type& list,
-                            const std::size_t particle_index )
+    static std::size_t numNeighbor( const list_type& list,
+                                    const std::size_t particle_index )
     {
         return list._data.counts( particle_index );
     }
@@ -660,9 +660,9 @@ class NeighborList<VerletList<MemorySpace,AlgorithmTag,VerletLayout2D> >
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static int getNeighbor( const list_type& list,
-                            const std::size_t particle_index,
-                            const int neighbor_index )
+    static std::size_t getNeighbor( const list_type& list,
+                                    const std::size_t particle_index,
+                                    const std::size_t neighbor_index )
     {
         return list._data.neighbors( particle_index, neighbor_index );
     }

--- a/core/src/impl/Cabana_Index.hpp
+++ b/core/src/impl/Cabana_Index.hpp
@@ -31,13 +31,14 @@ namespace Impl
 
   \tparam VectorLength The inner array size of the AoSoA.
 */
-template<int VectorLength,
-         typename std::enable_if<
-             (Impl::IsVectorLengthValid<VectorLength>::value),
-             int>::type = 0>
+template<int VectorLength>
 class Index
 {
   public:
+
+    // Validate the inner array size.
+    static_assert( Impl::IsVectorLengthValid<VectorLength>::value,
+                   "Invalid vector length" );
 
     // Inner array size.
     static constexpr int vector_length = VectorLength;
@@ -56,11 +57,8 @@ class Index
 
       \return The index of the struct in which the tuple is located.
     */
-    template<typename I>
     KOKKOS_FORCEINLINE_FUNCTION
-    static constexpr
-    typename std::enable_if<std::is_integral<I>::value,std::size_t>::type
-    s( const I& i )
+    static constexpr std::size_t s( const std::size_t i )
     {
         return (i - (i & vector_length_offset)) >>
             vector_length_binary_bits;
@@ -74,11 +72,8 @@ class Index
       \return The index of the array index in the struct in which the tuple
       is located.
     */
-    template<typename I>
     KOKKOS_FORCEINLINE_FUNCTION
-    static constexpr
-    typename std::enable_if<std::is_integral<I>::value,int>::type
-    a( const I& i )
+    static constexpr std::size_t a( const std::size_t i )
     {
         return i & vector_length_offset;
     }
@@ -93,12 +88,8 @@ class Index
 
       \return The tuple index.
     */
-    template<typename S, typename A>
     KOKKOS_FORCEINLINE_FUNCTION
-    static constexpr
-    typename std::enable_if<(std::is_integral<S>::value &&
-                             std::is_integral<A>::value),std::size_t>::type
-    i( const S& s, const A& a )
+    static constexpr std::size_t i( const std::size_t s, const std::size_t a )
     {
         return (s << vector_length_binary_bits) + a;
     }

--- a/core/src/impl/Cabana_TypeTraits.hpp
+++ b/core/src/impl/Cabana_TypeTraits.hpp
@@ -22,19 +22,21 @@ namespace Impl
 {
 //---------------------------------------------------------------------------//
 // Checks if an integer is a power of two. N must be greater than 0.
-template<int N, typename std::enable_if<(N > 0),int>::type = 0>
+template<int N>
 struct IsPowerOfTwo
 {
+    static_assert( N > 0, "Vector length must be greather than 0" );
     static constexpr bool value = ( (N & (N - 1)) == 0 );
 };
 
 //---------------------------------------------------------------------------//
 // Calculate the base-2 logarithm of an integer which must be a power of 2 and
 // greater than 0.
-template<int N,
-         typename std::enable_if<(IsPowerOfTwo<N>::value),int>::type = 0>
+template<int N>
 struct LogBase2
 {
+    static_assert( IsPowerOfTwo<N>::value,
+                   "Vector length must be a power of two" );
     static constexpr int value = 1 + LogBase2<(N>>1U)>::value;
 };
 

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -463,7 +463,7 @@ void testAccess()
         KOKKOS_LAMBDA( const int s ){
             auto& soa = aosoa.access( s );
 
-            for ( int a = 0; a < aosoa.arraySize(s); ++a )
+            for ( std::size_t a = 0; a < aosoa.arraySize(s); ++a )
             {
                 // Member 0.
                 for ( int i = 0; i < dim_1; ++i )

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -190,7 +190,7 @@ void apiTest()
         "raw_ptr_update",
         Kokkos::RangePolicy<TEST_EXECSPACE>(0,slice_0.numSoA()),
         KOKKOS_LAMBDA( const int s ){
-            for ( int a = 0; a < slice_0.arraySize(s); ++a )
+            for ( std::size_t a = 0; a < slice_0.arraySize(s); ++a )
             {
                 // Member 0.
                 for ( int i = 0; i < dim_1; ++i )


### PR DESCRIPTION
The purpose of this PR is to make the use of size types consistent in the code. I used the following conventions.

- If available, I used the template alias `size_type` associated with the Kokkos memory space in scope (see `AoSoA` or `Slice`)
- When a Kokkos memory space was not in scope, I used `std::size_t` for sizes

I think we should talk about my use of `std::size_t` in some cases (particularly `Tuple` and `SoA`) where we don't know the memory space in which we are working. Once choice is to use an integer template parameter for consistency. The other choice is to stick with my use of `std::size_t`.