### PR TITLE
Communication Plan Construction Performance

### DIFF
--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -105,9 +105,9 @@ class Distributor : public CommunicationPlan<DeviceType>
                  const int mpi_tag = 1221 )
         : CommunicationPlan<DeviceType>( comm )
     {
-        this->createFromExportsAndTopology(
+        auto neighbor_ids = this->createFromExportsAndTopology(
             element_export_ranks, neighbor_ranks, mpi_tag );
-        this->createExportSteering( element_export_ranks );
+        this->createExportSteering( neighbor_ids, element_export_ranks );
     }
 
     /*!
@@ -146,8 +146,9 @@ class Distributor : public CommunicationPlan<DeviceType>
                  const int mpi_tag = 1221 )
         : CommunicationPlan<DeviceType>( comm )
     {
-        this->createFromExportsOnly( element_export_ranks, mpi_tag );
-        this->createExportSteering( element_export_ranks );
+        auto neighbor_ids =
+            this->createFromExportsOnly( element_export_ranks, mpi_tag );
+        this->createExportSteering( neighbor_ids, element_export_ranks );
     }
 };
 

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -115,9 +115,10 @@ class Halo : public CommunicationPlan<DeviceType>
         if ( element_export_ids.size() != element_export_ranks.size() )
             throw std::runtime_error("Export ids and ranks different sizes!");
 
-        this->createFromExportsAndTopology(
+        auto neighbor_ids = this->createFromExportsAndTopology(
             element_export_ranks, neighbor_ranks, mpi_tag );
-        this->createExportSteering( element_export_ranks, element_export_ids );
+        this->createExportSteering(
+            neighbor_ids, element_export_ranks, element_export_ids );
     }
 
     /*!
@@ -168,8 +169,10 @@ class Halo : public CommunicationPlan<DeviceType>
         if ( element_export_ids.size() != element_export_ranks.size() )
             throw std::runtime_error("Export ids and ranks different sizes!");
 
-        this->createFromExportsOnly( element_export_ranks, mpi_tag );
-        this->createExportSteering( element_export_ranks, element_export_ids );
+        auto neighbor_ids =
+            this->createFromExportsOnly( element_export_ranks, mpi_tag );
+        this->createExportSteering(
+            neighbor_ids, element_export_ranks, element_export_ids );
     }
 
     /*!


### PR DESCRIPTION
Initial investigation of communication plan construction scaling on Summit was shown to be poor when GPU-aware MPI was used. Further investigation has indicated that the thread scalability of the construction code when using the GPU was extremely poor. This PR focuses on on-node performance of the construction kernels for Halo and Distributor including both the fast case where communication topology is known a priori and the general case where it must be determined on the fly. The communication performance test is used for all measurements on Summit.

Some basic ideas behind the improvements:
- A lot of atomics where used on a small number of memory addresses in multiple instances. 
- An implementation of a fused count and permute list was generated. `atomic_fetch_add` is used in the GPU implementation and a duplicated version is used for threaded CPU devices 
- Instances of branch statements and for loops in kernels were removed
- Some indirection arrays where produced to streamline parallel for kernels