### PR TITLE
Fixing warnings for Cuda 10.1

### DIFF
--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -77,14 +77,14 @@ void deepCopyExample()
 
         for ( int i = 0; i < 3; ++i )
             for ( int j = 0; j < 3; ++j )
-                for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
+                for ( unsigned a = 0; a < src_aosoa.arraySize(s); ++a )
                     Cabana::get<0>(soa,a,i,j) = 1.0 * (a + i + j);
 
         for ( int i = 0; i < 4; ++i )
-            for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
+            for ( unsigned a = 0; a < src_aosoa.arraySize(s); ++a )
                 Cabana::get<1>(soa,a,i) = 1.0 * (a + i);
 
-        for ( int a = 0; a < src_aosoa.arraySize(s); ++a )
+        for ( unsigned a = 0; a < src_aosoa.arraySize(s); ++a )
             Cabana::get<2>(soa,a) = a + 1234;
     }
 

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -195,6 +195,7 @@ inline void neighbor_parallel_for(
         typename Kokkos::RangePolicy<ExecParameters...>::index_type;
 
     Kokkos::parallel_for(
+        str,
         exec_policy,
         KOKKOS_LAMBDA( const index_type i )
         {
@@ -207,8 +208,7 @@ inline void neighbor_parallel_for(
                     static_cast<index_type>(
                         NeighborList<NeighborListType>::getNeighbor(list,i,n))
                     );
-        },
-        str );
+        } );
 }
 
 //---------------------------------------------------------------------------//
@@ -277,11 +277,14 @@ inline void neighbor_parallel_for(
 
     using index_type = typename kokkos_policy::index_type;
 
+    const auto range_begin = exec_policy.begin();
+
     Kokkos::parallel_for(
+        str,
         team_policy,
         KOKKOS_LAMBDA( const typename kokkos_policy::member_type& team )
         {
-            index_type i = team.league_rank() + exec_policy.begin();
+            index_type i = team.league_rank() + range_begin;
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange(
                     team,NeighborList<NeighborListType>::numNeighbor(list,i)),
@@ -293,8 +296,7 @@ inline void neighbor_parallel_for(
                         NeighborList<NeighborListType>::getNeighbor(list,i,n) )
                     );
                 });
-        },
-        str );
+        } );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -467,6 +467,9 @@ class Slice
     // Maximum supported rank.
     static constexpr std::size_t max_supported_rank = 3;
 
+    // Maximum label length.
+    static constexpr std::size_t max_label_length = 128;
+
     // Kokkos view wrapper.
     using view_wrapper = Impl::KokkosViewWrapper<DataType,vector_length,soa_stride>;
 
@@ -523,8 +526,9 @@ class Slice
            const std::string& label = "" )
         : _view( data, view_wrapper::createLayout(num_soa) )
         , _size( size )
-        , _label( label )
-    {}
+    {
+        std::strcpy( _label, label.c_str() );
+    }
 
     /*!
       \brief Shallow copy constructor for different memory spaces for
@@ -537,8 +541,9 @@ class Slice
     Slice( const Slice<DataType,DeviceType,MAT,VectorLength,Stride>& rhs )
         : _view( rhs._view )
         , _size( rhs._size )
-        , _label( rhs._label )
-    {}
+    {
+        std::strcpy( _label, rhs._label );
+    }
 
     /*!
       \brief Assignement operator for different memory spaces for assigning
@@ -554,7 +559,7 @@ class Slice
     {
         _view = rhs._view;
         _size = rhs._size;
-        _label = rhs._label;
+        std::strcpy( _label, rhs._label );
         return *this;
     }
 
@@ -746,7 +751,7 @@ class Slice
     size_type _size;
 
     // Slice label.
-    std::string _label;
+    char _label[max_label_length];
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
There were new warnings on Summit after the upgrade to 10.1 (mostly related to lambda capture). My build is now warning free with `CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic"` and this environment:

```
uy7@login3:~/build/Cabana$ module list

Currently Loaded Modules:
  1) gcc/6.4.0   2) cuda/10.1.105   3) spectrum-mpi/10.3.0.0-20190419   4) cmake/3.14.2   5) git/2.13.0
```

Fixes #138 