### PR TITLE
Formalize Mirror

### DIFF
--- a/core/example/benchmark/Cabana_CommPerformance.cpp
+++ b/core/example/benchmark/Cabana_CommPerformance.cpp
@@ -313,12 +313,10 @@ void performanceTest( std::ostream& stream,
             // Migrate the aosoa as a whole. Do host/device
             // copies as needed.
             distributor_aosoa_migrate.start(fraction);
-            auto comm_src_particles =
-                Cabana::Experimental::create_mirror_view_and_copy(
-                    comm_memory_space(), src_particles );
-            auto comm_dst_particles =
-                Cabana::Experimental::create_mirror_view(
-                    comm_memory_space(), dst_particles );
+            auto comm_src_particles = Cabana::create_mirror_view_and_copy(
+                comm_memory_space(), src_particles );
+            auto comm_dst_particles = Cabana::create_mirror_view(
+                comm_memory_space(), dst_particles );
             Cabana::migrate(
                 distributor_fast, comm_src_particles, comm_dst_particles );
             Cabana::deep_copy( dst_particles, comm_dst_particles );
@@ -328,12 +326,10 @@ void performanceTest( std::ostream& stream,
             // copies as needed.
             distributor_slice_migrate.start(fraction);
 
-            comm_src_particles =
-                Cabana::Experimental::create_mirror_view_and_copy(
-                    comm_memory_space(), src_particles );
-            comm_dst_particles =
-                Cabana::Experimental::create_mirror_view(
-                    comm_memory_space(), dst_particles );
+            comm_src_particles = Cabana::create_mirror_view_and_copy(
+                comm_memory_space(), src_particles );
+            comm_dst_particles = Cabana::create_mirror_view(
+                comm_memory_space(), dst_particles );
 
             auto s0 = Cabana::slice<0>( comm_src_particles );
             auto d0 = Cabana::slice<0>( comm_dst_particles );
@@ -446,9 +442,8 @@ void performanceTest( std::ostream& stream,
 
             // Gather the aosoa as a whole. Do host/device copies as needed.
             halo_aosoa_gather.start(fraction);
-            auto comm_particles =
-                Cabana::Experimental::create_mirror_view_and_copy(
-                    comm_memory_space(), particles );
+            auto comm_particles = Cabana::create_mirror_view_and_copy(
+                comm_memory_space(), particles );
             Cabana::gather( halo_fast, comm_particles );
             Cabana::deep_copy( particles, comm_particles );
             halo_aosoa_gather.stop(fraction);
@@ -456,9 +451,8 @@ void performanceTest( std::ostream& stream,
             // Gather the aosoa using individual slices.
             halo_slice_gather.start(fraction);
 
-            comm_particles =
-                Cabana::Experimental::create_mirror_view_and_copy(
-                    comm_memory_space(), particles );
+            comm_particles = Cabana::create_mirror_view_and_copy(
+                comm_memory_space(), particles );
 
             auto s0 = Cabana::slice<0>( comm_particles );
             Cabana::gather( halo_fast, s0 );
@@ -479,9 +473,8 @@ void performanceTest( std::ostream& stream,
             // Scatter the aosoa using individual slices.
             halo_slice_scatter.start(fraction);
 
-            comm_particles =
-                Cabana::Experimental::create_mirror_view_and_copy(
-                    comm_memory_space(), particles );
+            comm_particles = Cabana::create_mirror_view_and_copy(
+                comm_memory_space(), particles );
 
             s0 = Cabana::slice<0>( comm_particles );
             Cabana::scatter( halo_fast, s0 );

--- a/core/example/tutorial/06_deep_copy/deep_copy.cpp
+++ b/core/example/tutorial/06_deep_copy/deep_copy.cpp
@@ -132,7 +132,7 @@ void deepCopyExample()
       allocated in a different mnemory space allowing for easy transfer back to
       the device:
      */
-    auto dst_aosoa_host = Cabana::Experimental::create_mirror_view_and_copy(
+    auto dst_aosoa_host = Cabana::create_mirror_view_and_copy(
         Kokkos::HostSpace(), dst_aosoa );
 
     /*

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -25,18 +25,12 @@
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
-
-namespace Experimental
-{
-//---------------------------------------------------------------------------//
 /*!
-  \brief Allocate a mirror of the given AoSoA in the given memory space.
+  \brief Allocate a mirror of the given AoSoA in the given space.
  */
 template<class Space, class SrcAoSoA>
 inline
-AoSoA<typename SrcAoSoA::member_types,
-      typename Space::memory_space,
-      SrcAoSoA::vector_length>
+AoSoA<typename SrcAoSoA::member_types,Space,SrcAoSoA::vector_length>
 create_mirror(
     const Space&,
     const SrcAoSoA& src,
@@ -44,19 +38,18 @@ create_mirror(
                              typename Space::memory_space>::value)>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
-                   "create_mirror_view() requires an AoSoA" );
-    auto dst = AoSoA<typename SrcAoSoA::member_types,
-                     typename Space::memory_space,
-                     SrcAoSoA::vector_length>(
-                         std::string(src.label()).append("_mirror"),
-                         src.size() );
-    return dst;
+                   "create_mirror() requires an AoSoA" );
+    return AoSoA<typename SrcAoSoA::member_types,
+                 Space,
+                 SrcAoSoA::vector_length>(
+                     std::string(src.label()).append("_mirror"),
+                     src.size() );
 }
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Create a mirror view of the given AoSoA in the given memory
-  space. Same space specialization returns the input AoSoA.
+  \brief Create a mirror view of the given AoSoA in the given space. Same
+  space specialization returns the input AoSoA.
 
   \note Memory allocation will only occur if the requested mirror memory space
   is different from that of the input AoSoA. If they are the same, the
@@ -87,9 +80,7 @@ create_mirror_view(
  */
 template<class Space, class SrcAoSoA>
 inline
-AoSoA<typename SrcAoSoA::member_types,
-      typename Space::memory_space,
-      SrcAoSoA::vector_length>
+AoSoA<typename SrcAoSoA::member_types,Space,SrcAoSoA::vector_length>
 create_mirror_view(
     const Space& space,
     const SrcAoSoA& src,
@@ -137,9 +128,7 @@ create_mirror_view_and_copy(
  */
 template<class Space, class SrcAoSoA>
 inline
-AoSoA<typename SrcAoSoA::member_types,
-      typename Space::memory_space,
-      SrcAoSoA::vector_length>
+AoSoA<typename SrcAoSoA::member_types,Space,SrcAoSoA::vector_length>
 create_mirror_view_and_copy(
     const Space& space,
     const SrcAoSoA& src,
@@ -159,10 +148,6 @@ create_mirror_view_and_copy(
 
     return dst;
 }
-
-//---------------------------------------------------------------------------//
-
-} // end namespace Experimental
 
 //---------------------------------------------------------------------------//
 /*!
@@ -238,9 +223,8 @@ inline void deep_copy(
     {
         // Create an AoSoA in the destination space with the same data layout
         // as the source.
-        auto src_copy_on_dst =
-            Experimental::create_mirror_view_and_copy(
-                typename dst_type::memory_space(), src );
+        auto src_copy_on_dst = create_mirror_view_and_copy(
+            typename dst_type::memory_space(), src );
 
         // Copy via tuples.
         auto copy_func =

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -28,9 +28,8 @@ void checkDataMembers(
     const float fval, const double dval, const int ival,
     const int dim_1, const int dim_2, const int dim_3 )
 {
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
 
     auto slice_0 = Cabana::slice<0>(mirror);
     auto slice_1 = Cabana::slice<1>(mirror);
@@ -134,9 +133,8 @@ void testAoSoA()
     EXPECT_EQ( end_a, 3 );
 
     // Create a mirror on the host and fill.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto mirror_slice_0 = Cabana::slice<0>(mirror);
     auto mirror_slice_1 = Cabana::slice<1>(mirror);
     auto mirror_slice_2 = Cabana::slice<2>(mirror);
@@ -290,9 +288,8 @@ void testRawData()
     Kokkos::fence();
 
     // Check the results.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto mirror_slice_0 = Cabana::slice<0>(mirror);
     auto mirror_slice_1 = Cabana::slice<1>(mirror);
     auto mirror_slice_2 = Cabana::slice<2>(mirror);

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -26,9 +26,8 @@ void checkDataMembers(
     const float fval, const double dval, const int ival,
     const int dim_1, const int dim_2, const int dim_3 )
 {
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
 
     auto slice_0 = Cabana::slice<0>(mirror);
     auto slice_1 = Cabana::slice<1>(mirror);
@@ -191,17 +190,17 @@ void testMirror()
         });
 
     // Create a mirror with the same memory space and copy separately.
-    auto same_space_mirror = Cabana::Experimental::create_mirror_view(
+    auto same_space_mirror = Cabana::create_mirror_view(
             TEST_MEMSPACE(), aosoa );
     Cabana::deep_copy( same_space_mirror, aosoa );
-    auto host_space_mirror = Cabana::Experimental::create_mirror_view(
+    auto host_space_mirror = Cabana::create_mirror_view(
         Kokkos::HostSpace(), aosoa );
     Cabana::deep_copy( host_space_mirror, aosoa );
 
     // Create a mirror with the same memory space and copy at the same time.
-    auto same_space_copy = Cabana::Experimental::create_mirror_view_and_copy(
+    auto same_space_copy = Cabana::create_mirror_view_and_copy(
         TEST_MEMSPACE(), aosoa );
-    auto host_space_copy = Cabana::Experimental::create_mirror_view_and_copy(
+    auto host_space_copy = Cabana::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
 
     // Check the mirrors/copies.
@@ -264,7 +263,7 @@ void testAssign()
     Cabana::deep_copy( aosoa, tp );
 
     // Check the assignment
-    auto host_aosoa = Cabana::Experimental::create_mirror_view_and_copy(
+    auto host_aosoa = Cabana::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
     auto host_slice_0 = Cabana::slice<0>(host_aosoa);
     auto host_slice_1 = Cabana::slice<1>(host_aosoa);
@@ -282,7 +281,7 @@ void testAssign()
     ival = 12;
     Cabana::deep_copy( slice_0, fval );
     Cabana::deep_copy( slice_1, ival );
-    host_aosoa = Cabana::Experimental::create_mirror_view_and_copy(
+    host_aosoa = Cabana::create_mirror_view_and_copy(
         Kokkos::HostSpace(), aosoa );
     host_slice_0 = Cabana::slice<0>(host_aosoa);
     host_slice_1 = Cabana::slice<1>(host_aosoa);

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -27,9 +27,8 @@ void checkDataMembers(
     const float fval, const double dval, const int ival,
     const int dim_1, const int dim_2, const int dim_3 )
 {
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
 
     auto slice_0 = Cabana::slice<0>(mirror);
     auto slice_1 = Cabana::slice<1>(mirror);

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -63,9 +63,8 @@ void checkDataMembers(
     const float fval, const double dval, const int ival,
     const int dim_1, const int dim_2, const int dim_3 )
 {
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
 
     auto slice_0 = Cabana::slice<0>(mirror);
     auto slice_1 = Cabana::slice<1>(mirror);
@@ -345,9 +344,8 @@ void atomicAccessTest()
     Kokkos::fence();
 
     // Check the results of the atomic increment.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto mirror_slice = Cabana::slice<0>(mirror);
 
     for ( int i = 0; i < num_data; ++i ) EXPECT_EQ( mirror_slice(i), num_data );

--- a/core/unit_test/tstSort.hpp
+++ b/core/unit_test/tstSort.hpp
@@ -81,8 +81,7 @@ void testSortByKey()
         Kokkos::HostSpace(), bin_permute );
 
     // Check the result of the sort.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
+    auto mirror = Cabana::create_mirror_view_and_copy(
             Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
@@ -180,9 +179,8 @@ void testBinByKey()
         Kokkos::HostSpace(), bin_size );
 
     // Check the result of the sort.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -265,9 +263,8 @@ void testSortBySlice()
         Kokkos::HostSpace(), bin_permute );
 
     // Check the result of the sort.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -347,9 +344,8 @@ void testSortBySliceDataOnly()
 
     // Check that the data didn't get sorted and the permutation vector is
     // correct.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -440,9 +436,8 @@ void testBinBySlice()
         Kokkos::HostSpace(), bin_size );
 
     // Check the result of the sort.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -537,9 +532,8 @@ void testBinBySliceDataOnly()
 
     // Check the result of the sort. Make sure nothing moved execpt the
     // binning data.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -626,9 +620,8 @@ void testSortByKeySlice()
         Kokkos::HostSpace(), bin_permute );
 
     // Check the result of the sort.
-    auto mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    auto mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     auto v0_mirror = Cabana::slice<0>(mirror);
     auto v1_mirror = Cabana::slice<1>(mirror);
     auto v2_mirror = Cabana::slice<2>(mirror);
@@ -670,9 +663,8 @@ void testSortByKeySlice()
         Kokkos::HostSpace(), bin_permute );
 
     // Check the result of the sort.
-    mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     v0_mirror = Cabana::slice<0>(mirror);
     v1_mirror = Cabana::slice<1>(mirror);
     v2_mirror = Cabana::slice<2>(mirror);
@@ -714,9 +706,8 @@ void testSortByKeySlice()
         Kokkos::HostSpace(), bin_permute );
 
     // Check the result of the sort.
-    mirror =
-        Cabana::Experimental::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), aosoa );
+    mirror = Cabana::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), aosoa );
     v0_mirror = Cabana::slice<0>(mirror);
     v1_mirror = Cabana::slice<1>(mirror);
     v2_mirror = Cabana::slice<2>(mirror);


### PR DESCRIPTION
This pull request removes the mirror creation mechanisms from the `Experimental` namespace and fixes the use of the requested `Space` type used for mirror construction. I have been using this quite a bit now and have been happy with the API and therefore I think it is time to remove it from experimental status. It mirrors very closely the Kokkos API for generating mirrors.