### PR TITLE
Creating benchmark timer and added BinSort performance test

### DIFF
--- a/core/example/benchmark/CMakeLists.txt
+++ b/core/example/benchmark/CMakeLists.txt
@@ -7,3 +7,8 @@ if(Cabana_ENABLE_MPI AND Cabana_ENABLE_Cuda AND Cabana_ENABLE_OpenMP)
   add_executable(CommPerformance Cabana_CommPerformance.cpp)
   target_link_libraries(CommPerformance cabanacore)
 endif()
+
+if(Cabana_ENABLE_Serial OR Cabana_ENABLE_Cuda OR Cabana_ENABLE_OpenMP)
+  add_executable(BinSortPerformance Cabana_BinSortPerformance.cpp)
+  target_link_libraries(BinSortPerformance cabanacore)
+endif()

--- a/core/example/benchmark/Cabana_BenchmarkTimer.hpp
+++ b/core/example/benchmark/Cabana_BenchmarkTimer.hpp
@@ -1,0 +1,180 @@
+/****************************************************************************
+ * Copyright (c) 2018-2019 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include <mpi.h>
+
+namespace Cabana
+{
+namespace Benchmark
+{
+//---------------------------------------------------------------------------//
+// Local timer. Carries multiple data points (the independent variable in
+// the parameter sweep) for each timer to allow for parametric sweeps. Each
+// timer can do multiple runs over each data point in the parameter sweep. The
+// name of the data point and its values can then be injected into the output
+// table.
+class Timer
+{
+  public:
+    // Create the timer.
+    Timer( const std::string &name, const int num_data )
+        : _name( name )
+        , _starts( num_data )
+        , _data( num_data )
+        , _is_stopped( num_data, true )
+    {
+    }
+
+    // Start the timer for the given data point.
+    void start( const int data_point )
+    {
+        if ( !_is_stopped[data_point] )
+            throw std::logic_error( "attempted to start a running timer" );
+        _starts[data_point] = std::chrono::high_resolution_clock::now();
+        _is_stopped[data_point] = false;
+    }
+
+    // Stop the timer at the given data point.
+    void stop( const int data_point )
+    {
+        if ( _is_stopped[data_point] )
+            throw std::logic_error( "attempted to stop a stopped timer" );
+        auto now = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double, std::micro> fp_micro =
+            now - _starts[data_point];
+        _data[data_point].push_back( fp_micro.count() );
+        _is_stopped[data_point] = true;
+    }
+
+  public:
+    std::string _name;
+    std::vector<std::chrono::high_resolution_clock::time_point> _starts;
+    std::vector<std::vector<double>> _data;
+    std::vector<bool> _is_stopped;
+};
+
+//---------------------------------------------------------------------------//
+// Local output.
+// Write timer results. Provide the values of the data points so
+// they can be injected into the table.
+template <class Scalar>
+void outputResults( std::ostream &stream, const std::string &data_point_name,
+                    const std::vector<Scalar> &data_point_vals,
+                    const Timer &timer )
+{
+    // Write the data header.
+    stream << "\n";
+    stream << timer._name << "\n";
+    stream << data_point_name << " min max ave"
+           << "\n";
+
+    // Write out each data point
+    for ( std::size_t n = 0; n < timer._data.size(); ++n )
+    {
+        if ( !timer._is_stopped[n] )
+            throw std::logic_error(
+                "attempted to output from a running timer" );
+
+        // Compute the minimum.
+        double local_min =
+            *std::min_element( timer._data[n].begin(), timer._data[n].end() );
+
+        // Compute the maximum.
+        double local_max =
+            *std::max_element( timer._data[n].begin(), timer._data[n].end() );
+
+        // Compute the average.
+        double local_sum = std::accumulate( timer._data[n].begin(),
+                                            timer._data[n].end(), 0.0 );
+        double average = local_sum / timer._data[n].size();
+
+        // Output.
+        stream << data_point_vals[n] << " " << local_min << " " << local_max
+               << " " << average << "\n";
+    }
+}
+
+//---------------------------------------------------------------------------//
+// Parallel output.
+// Write timer results on rank 0. Provide the values of the data points so
+// they can be injected into the table. This function does collective
+// communication.
+template <class Scalar>
+void outputResults( std::ostream &stream, const std::string &data_point_name,
+                    const std::vector<Scalar> &data_point_vals,
+                    const Timer &timer, MPI_Comm comm )
+{
+    // Get comm rank;
+    int comm_rank;
+    MPI_Comm_rank( comm, &comm_rank );
+
+    // Get comm size;
+    int comm_size;
+    MPI_Comm_size( comm, &comm_size );
+
+    // Write the data header.
+    if ( 0 == comm_rank )
+    {
+        stream << "\n";
+        stream << timer._name << "\n";
+        stream << "num_rank " << data_point_name << " min max ave"
+               << "\n";
+    }
+
+    // Write out each data point
+    for ( std::size_t n = 0; n < timer._data.size(); ++n )
+    {
+        if ( !timer._is_stopped[n] )
+            throw std::logic_error(
+                "attempted to output from a running timer" );
+
+        // Compute the minimum.
+        double local_min =
+            *std::min_element( timer._data[n].begin(), timer._data[n].end() );
+        double global_min = 0.0;
+        MPI_Reduce( &local_min, &global_min, 1, MPI_DOUBLE, MPI_MIN, 0, comm );
+
+        // Compute the maximum.
+        double local_max =
+            *std::max_element( timer._data[n].begin(), timer._data[n].end() );
+        double global_max = 0.0;
+        MPI_Reduce( &local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, 0, comm );
+
+        // Compute the average.
+        double local_sum = std::accumulate( timer._data[n].begin(),
+                                            timer._data[n].end(), 0.0 );
+        double average = 0.0;
+        MPI_Reduce( &local_sum, &average, 1, MPI_DOUBLE, MPI_SUM, 0, comm );
+        average /= timer._data[n].size() * comm_size;
+
+        // Output on rank 0.
+        if ( 0 == comm_rank )
+        {
+            stream << comm_size << " " << data_point_vals[n] << " "
+                   << global_min << " " << global_max << " " << average << "\n";
+        }
+    }
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Benchmark
+} // end namespace Cabana
+
+//---------------------------------------------------------------------------//

--- a/core/example/benchmark/Cabana_BinSortPerformance.cpp
+++ b/core/example/benchmark/Cabana_BinSortPerformance.cpp
@@ -1,0 +1,227 @@
+/****************************************************************************
+ * Copyright (c) 2018-2019 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "Cabana_BenchmarkTimer.hpp"
+
+#include <Cabana_Core.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+//---------------------------------------------------------------------------//
+// Performance test.
+template <class Device>
+void performanceTest( std::ostream &stream, const std::string &test_prefix )
+{
+    // Declare problem sizes.
+    std::vector<int> problem_sizes = {1000, 10000, 100000, 1000000, 10000000};
+    int num_problem_size = problem_sizes.size();
+
+    // Generate a random set of keys
+    Kokkos::View<unsigned long *, Device> keys(
+        Kokkos::ViewAllocateWithoutInitializing( "keys" ),
+        problem_sizes.back() );
+    Kokkos::View<unsigned long *, Kokkos::HostSpace> host_keys(
+        Kokkos::ViewAllocateWithoutInitializing( "host_keys" ),
+        problem_sizes.back() );
+    std::minstd_rand0 generator( 3439203991 );
+    for ( int n = 0; n < problem_sizes.back(); ++n )
+        host_keys( n ) = generator();
+    Kokkos::deep_copy( keys, host_keys );
+
+    // Declare the number of bins to generate.
+    std::vector<int> num_bins = {10,     100,     1000,    10000,
+                                 100000, 1000000, 10000000};
+    int num_bin_size = num_bins.size();
+
+    // Number of runs in the test loops.
+    int num_run = 10;
+
+    // Define the aosoa.
+    using member_types = Cabana::MemberTypes<double[3], double[3], double, int>;
+    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+
+    // Create aosoas.
+    std::vector<aosoa_type> aosoas( num_problem_size );
+    for ( int i = 0; i < num_problem_size; ++i )
+        aosoas[i] = aosoa_type( "aosoa", problem_sizes[i] );
+
+    // BINNING
+    // -------
+
+    // Loop over number of bins.
+    for ( int b = 0; b < num_bin_size; ++b )
+    {
+        // Compute the number of problems we will run with this bin size.
+        int bin_num_problem = 0;
+        for ( int p = 0; p < num_problem_size; ++p )
+            if ( num_bins[b] <= problem_sizes[p] )
+                ++bin_num_problem;
+
+        // Create binning timers.
+        std::stringstream create_time_name;
+        create_time_name << test_prefix << "bin_create_" << num_bins[b];
+        Cabana::Benchmark::Timer create_timer( create_time_name.str(),
+                                               bin_num_problem );
+        std::stringstream aosoa_permute_time_name;
+        aosoa_permute_time_name << test_prefix << "bin_aosoa_permute_"
+                                << num_bins[b];
+        Cabana::Benchmark::Timer aosoa_permute_timer(
+            aosoa_permute_time_name.str(), bin_num_problem );
+        std::stringstream slice_permute_time_name;
+        slice_permute_time_name << test_prefix << "bin_slice_permute_"
+                                << num_bins[b];
+        Cabana::Benchmark::Timer slice_permute_timer(
+            slice_permute_time_name.str(), bin_num_problem );
+
+        // Loop over the problem sizes.
+        int pid = 0;
+        std::vector<double> psizes;
+        for ( int p = 0; p < num_problem_size; ++p )
+        {
+            // Only run this problem size if the number of bins does not
+            // exceed the problem size.
+            if ( num_bins[b] <= problem_sizes[p] )
+            {
+                // Track the problem size.
+                psizes.push_back( problem_sizes[p] );
+
+                // Run tests and time the ensemble
+                for ( int t = 0; t < num_run; ++t )
+                {
+                    // Create the binning.
+                    auto key_sv = Kokkos::subview(
+                        keys, Kokkos::pair<int, int>( 0, problem_sizes[p] ) );
+                    create_timer.start( pid );
+                    auto bin_data = Cabana::binByKey( key_sv, num_bins[b] );
+                    create_timer.stop( pid );
+
+                    // Permute the aosoa
+                    aosoa_permute_timer.start( pid );
+                    Cabana::permute( bin_data, aosoas[p] );
+                    aosoa_permute_timer.stop( pid );
+
+                    // Permute a slice of the first member
+                    auto slice = Cabana::slice<0>( aosoas[p] );
+                    slice_permute_timer.start( pid );
+                    Cabana::permute( bin_data, slice );
+                    slice_permute_timer.stop( pid );
+                }
+
+                // Increment the problem id.
+                ++pid;
+            }
+        }
+
+        // Output results.
+        outputResults( stream, "problem_size", psizes, create_timer );
+        outputResults( stream, "problem_size", psizes, aosoa_permute_timer );
+        outputResults( stream, "problem_size", psizes, slice_permute_timer );
+    }
+
+    // SORTING
+    // -------
+
+    // Create sorting timers.
+    Cabana::Benchmark::Timer create_timer( test_prefix + "sort_create",
+                                           num_problem_size );
+    Cabana::Benchmark::Timer aosoa_permute_timer(
+        test_prefix + "sort_aosoa_permute", num_problem_size );
+    Cabana::Benchmark::Timer slice_permute_timer(
+        test_prefix + "sort_slice_permute", num_problem_size );
+
+    // Loop over the problem sizes.
+    for ( int p = 0; p < num_problem_size; ++p )
+    {
+        // Run tests and time the ensemble
+        for ( int t = 0; t < num_run; ++t )
+        {
+            // Create the binning.
+            auto key_sv = Kokkos::subview(
+                keys, Kokkos::pair<int, int>( 0, problem_sizes[p] ) );
+            create_timer.start( p );
+            auto bin_data = Cabana::sortByKey( key_sv );
+            create_timer.stop( p );
+
+            // Permute the aosoa
+            aosoa_permute_timer.start( p );
+            Cabana::permute( bin_data, aosoas[p] );
+            aosoa_permute_timer.stop( p );
+
+            // Permute a slice of the first member
+            auto slice = Cabana::slice<0>( aosoas[p] );
+            slice_permute_timer.start( p );
+            Cabana::permute( bin_data, slice );
+            slice_permute_timer.stop( p );
+        }
+    }
+
+    // Output results.
+    outputResults( stream, "problem_size", problem_sizes, create_timer );
+    outputResults( stream, "problem_size", problem_sizes, aosoa_permute_timer );
+    outputResults( stream, "problem_size", problem_sizes, slice_permute_timer );
+}
+
+//---------------------------------------------------------------------------//
+// main
+int main( int argc, char *argv[] )
+{
+    // Initialize environment
+    Kokkos::initialize( argc, argv );
+
+    // Check arguments.
+    if ( argc < 2 )
+        throw std::runtime_error( "Incorrect number of arguments. \n \
+             First argument -  file name for output \n \
+             \n \
+             Example: \n \
+             $/: ./BinSortPerformance test_results.txt\n" );
+
+    // Get the name of the output file.
+    std::string filename = argv[1];
+
+    // Open the output file on rank 0.
+    std::fstream file;
+    file.open( filename, std::fstream::out );
+
+    // Run the tests.
+#ifdef KOKKOS_ENABLE_SERIAL
+    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
+    performanceTest<SerialDevice>( file, "serial_" );
+#endif
+
+#ifdef KOKKOS_ENABLE_OPENMP
+    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
+    performanceTest<OpenMPDevice>( file, "openmp_" );
+#endif
+
+#ifdef KOKKOS_ENABLE_CUDA
+    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+    performanceTest<CudaDevice>( file, "cuda_" );
+#endif
+
+    // Close the output file on rank 0.
+    file.close();
+
+    // Finalize
+    Kokkos::finalize();
+    return 0;
+}
+
+//---------------------------------------------------------------------------//

--- a/core/example/benchmark/Cabana_CommPerformance.cpp
+++ b/core/example/benchmark/Cabana_CommPerformance.cpp
@@ -9,12 +9,13 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+#include "Cabana_BenchmarkTimer.hpp"
+
 #include <Cabana_Core.hpp>
 
 #include <Kokkos_Core.hpp>
 
 #include <algorithm>
-#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <numeric>
@@ -23,123 +24,6 @@
 #include <vector>
 
 #include <mpi.h>
-
-//---------------------------------------------------------------------------//
-// Parallel timer. Carries multiple data points (the independent variable in
-// the parameter sweep) for each timer to allow for parametric sweeps. Each
-// timer can do multiple runs over each data point in the parameter sweep. The
-// name of the data point and its values can then be injected into the output
-// table.
-class ParallelTimer
-{
-  public:
-    // Create the timer.
-    ParallelTimer( MPI_Comm comm, const std::string &name, const int num_data )
-        : _comm( comm )
-        , _name( name )
-        , _starts( num_data )
-        , _data( num_data )
-        , _is_stopped( num_data, true )
-    {
-    }
-
-    // Start the timer for the given data point. It is assumed that this
-    // function is called collectively across all ranks in the communicator.
-    void start( const int data_point )
-    {
-        if ( !_is_stopped[data_point] )
-            throw std::logic_error( "attempted to start a running timer" );
-        auto now = std::chrono::high_resolution_clock::now();
-        _starts[data_point].push_back( now );
-        _is_stopped[data_point] = false;
-    }
-
-    // Stop the timer at the given data point. It is assumed that this
-    // function is called collectively across all ranks in the communicator.
-    void stop( const int data_point )
-    {
-        if ( _is_stopped[data_point] )
-            throw std::logic_error( "attempted to stop a stopped timer" );
-        auto now = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::micro> fp_micro =
-            now - _starts[data_point].back();
-        _data[data_point].push_back( fp_micro.count() );
-        _is_stopped[data_point] = true;
-    }
-
-    // Write timer results on rank 0. Provide the values of the data points so
-    // they can be injected into the table. This function does collective
-    // communication.
-    template <typename Scalar>
-    void outputResults( std::ostream &stream,
-                        const std::string &data_point_name,
-                        const std::vector<Scalar> &data_point_vals ) const
-    {
-        // Get comm rank;
-        int comm_rank;
-        MPI_Comm_rank( _comm, &comm_rank );
-
-        // Get comm size;
-        int comm_size;
-        MPI_Comm_size( _comm, &comm_size );
-
-        // Write the data header.
-        if ( 0 == comm_rank )
-        {
-            stream << "\n";
-            stream << _name << "\n";
-            stream << "num_rank " << data_point_name << " min max ave"
-                   << "\n";
-        }
-
-        // Write out each data point
-        for ( std::size_t n = 0; n < _data.size(); ++n )
-        {
-            if ( !_is_stopped[n] )
-                throw std::logic_error(
-                    "attempted to output from a running timer" );
-
-            // Compute the minimum.
-            double local_min =
-                *std::min_element( _data[n].begin(), _data[n].end() );
-            double global_min = 0.0;
-            MPI_Reduce( &local_min, &global_min, 1, MPI_DOUBLE, MPI_MIN, 0,
-                        _comm );
-
-            // Compute the maximum.
-            double local_max =
-                *std::max_element( _data[n].begin(), _data[n].end() );
-            double global_max = 0.0;
-            MPI_Reduce( &local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, 0,
-                        _comm );
-
-            // Compute the average.
-            double local_sum =
-                std::accumulate( _data[n].begin(), _data[n].end(), 0.0 );
-            double average = 0.0;
-            MPI_Reduce( &local_sum, &average, 1, MPI_DOUBLE, MPI_SUM, 0,
-                        _comm );
-            average /= _data[n].size() * comm_size;
-
-            // Output on rank 0.
-            if ( 0 == comm_rank )
-            {
-                stream << comm_size << " " << data_point_vals[n] << " "
-                       << global_min << " " << global_max << " " << average
-                       << "\n";
-            }
-        }
-    }
-
-  private:
-    MPI_Comm _comm;
-    std::string _name;
-    std::vector<std::size_t> _byte_sizes;
-    std::vector<std::vector<std::chrono::high_resolution_clock::time_point>>
-        _starts;
-    std::vector<std::vector<double>> _data;
-    std::vector<bool> _is_stopped;
-};
 
 //---------------------------------------------------------------------------//
 // Performance test.
@@ -230,14 +114,14 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
     // -----------
 
     // Create distributor timers.
-    ParallelTimer distributor_fast_create(
-        comm, test_prefix + "distributor_fast_create", num_fraction );
-    ParallelTimer distributor_general_create(
-        comm, test_prefix + "distributor_general_create", num_fraction );
-    ParallelTimer distributor_aosoa_migrate(
-        comm, test_prefix + "distributor_aosoa_migrate", num_fraction );
-    ParallelTimer distributor_slice_migrate(
-        comm, test_prefix + "distributor_slice_migrate", num_fraction );
+    Cabana::Benchmark::Timer distributor_fast_create(
+        test_prefix + "distributor_fast_create", num_fraction );
+    Cabana::Benchmark::Timer distributor_general_create(
+        test_prefix + "distributor_general_create", num_fraction );
+    Cabana::Benchmark::Timer distributor_aosoa_migrate(
+        test_prefix + "distributor_aosoa_migrate", num_fraction );
+    Cabana::Benchmark::Timer distributor_slice_migrate(
+        test_prefix + "distributor_slice_migrate", num_fraction );
 
     // Loop over comm fractions.
     for ( int fraction = 0; fraction < num_fraction; ++fraction )
@@ -342,26 +226,29 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
     }
 
     // Output results.
-    distributor_fast_create.outputResults( stream, "send_bytes", comm_bytes );
-    distributor_general_create.outputResults( stream, "send_bytes",
-                                              comm_bytes );
-    distributor_aosoa_migrate.outputResults( stream, "send_bytes", comm_bytes );
-    distributor_slice_migrate.outputResults( stream, "send_bytes", comm_bytes );
+    outputResults( stream, "send_bytes", comm_bytes, distributor_fast_create,
+                   comm );
+    outputResults( stream, "send_bytes", comm_bytes, distributor_general_create,
+                   comm );
+    outputResults( stream, "send_bytes", comm_bytes, distributor_aosoa_migrate,
+                   comm );
+    outputResults( stream, "send_bytes", comm_bytes, distributor_slice_migrate,
+                   comm );
 
     // HALO
     // ----
 
     // Create halo timers.
-    ParallelTimer halo_fast_create( comm, test_prefix + "halo_fast_create",
-                                    num_fraction );
-    ParallelTimer halo_general_create(
-        comm, test_prefix + "halo_general_create", num_fraction );
-    ParallelTimer halo_aosoa_gather( comm, test_prefix + "halo_aosoa_gather",
-                                     num_fraction );
-    ParallelTimer halo_slice_gather( comm, test_prefix + "halo_slice_gather",
-                                     num_fraction );
-    ParallelTimer halo_slice_scatter( comm, test_prefix + "halo_slice_scatter",
-                                      num_fraction );
+    Cabana::Benchmark::Timer halo_fast_create( test_prefix + "halo_fast_create",
+                                               num_fraction );
+    Cabana::Benchmark::Timer halo_general_create(
+        test_prefix + "halo_general_create", num_fraction );
+    Cabana::Benchmark::Timer halo_aosoa_gather(
+        test_prefix + "halo_aosoa_gather", num_fraction );
+    Cabana::Benchmark::Timer halo_slice_gather(
+        test_prefix + "halo_slice_gather", num_fraction );
+    Cabana::Benchmark::Timer halo_slice_scatter(
+        test_prefix + "halo_slice_scatter", num_fraction );
 
     // Loop over comm fractions.
     for ( int fraction = 0; fraction < num_fraction; ++fraction )
@@ -479,11 +366,12 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
     }
 
     // Output results.
-    halo_fast_create.outputResults( stream, "send_bytes", comm_bytes );
-    halo_general_create.outputResults( stream, "send_bytes", comm_bytes );
-    halo_aosoa_gather.outputResults( stream, "send_bytes", comm_bytes );
-    halo_slice_gather.outputResults( stream, "send_bytes", comm_bytes );
-    halo_slice_scatter.outputResults( stream, "send_bytes", comm_bytes );
+    outputResults( stream, "send_bytes", comm_bytes, halo_fast_create, comm );
+    outputResults( stream, "send_bytes", comm_bytes, halo_general_create,
+                   comm );
+    outputResults( stream, "send_bytes", comm_bytes, halo_aosoa_gather, comm );
+    outputResults( stream, "send_bytes", comm_bytes, halo_slice_gather, comm );
+    outputResults( stream, "send_bytes", comm_bytes, halo_slice_scatter, comm );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR does two things:

1. Creates a more general `BenchmarkTimer` for performance tests with and without MPI and updates the `CommPerformance` test to use this timer.
2. Adds a performance test for binning and sorting on a single node. 

The binning/sorting performance test is designed to run on machines like Summit. For sorting it sweeps across a parameter space of problem sizes while for binning it sweeps both problem size and number of bins parametrically to be able to quickly assess algorithmic performance in a single run.

Code was verified to give proper output on Summit and the ORNL Condo Cray XC30