### PR TITLE
Adding missing MPI macros in benchmark timer

### DIFF
--- a/core/example/benchmark/Cabana_BenchmarkTimer.hpp
+++ b/core/example/benchmark/Cabana_BenchmarkTimer.hpp
@@ -17,7 +17,9 @@
 #include <string>
 #include <vector>
 
+#ifdef Cabana_ENABLE_MPI
 #include <mpi.h>
+#endif
 
 namespace Cabana
 {
@@ -115,6 +117,7 @@ void outputResults( std::ostream &stream, const std::string &data_point_name,
 // Write timer results on rank 0. Provide the values of the data points so
 // they can be injected into the table. This function does collective
 // communication.
+#ifdef Cabana_ENABLE_MPI
 template <class Scalar>
 void outputResults( std::ostream &stream, const std::string &data_point_name,
                     const std::vector<Scalar> &data_point_vals,
@@ -171,6 +174,7 @@ void outputResults( std::ostream &stream, const std::string &data_point_name,
         }
     }
 }
+#endif
 
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
Non-MPI builds were failing when building the binning/sorting benchmark.