### PR TITLE
Adding empty() and shrinkToFit() to AoSoA

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -278,6 +278,17 @@ class AoSoA
     size_type size() const { return _size; }
 
     /*!
+      \brief Returns if the container is empty or not.
+
+      \return True if the number of tuples in the container is zero.
+
+      This is the number of actual objects held in the container, which is not
+      necessarily equal to its storage capacity.
+    */
+    KOKKOS_FUNCTION
+    bool empty() const { return ( _size == 0 ); }
+
+    /*!
       \brief Returns the size of the storage space currently allocated for the
       container, expressed in terms of tuples.
 
@@ -311,7 +322,9 @@ class AoSoA
       reallocation of the allocated storage space takes place.
 
       Notice that this function changes the actual content of the container by
-      inserting or erasing tuples from it.
+      inserting or erasing tuples from it. If reallocation occurs, all slices
+      and all references to the elements are invalidated. If no reallocation
+      takes place, no slices or references are invalidated.
     */
     void resize( const size_type n )
     {
@@ -339,6 +352,10 @@ class AoSoA
 
       In all other cases, the function call does not cause a reallocation and
       the container capacity is not affected.
+
+      If reallocation occurs, all slices and all references to the elements
+      are invalidated. If no reallocation takes place, no slices or references
+      are invalidated.
 
       This function has no effect on the container size and cannot alter its
       tuples.
@@ -376,6 +393,42 @@ class AoSoA
                     resized_data,
                     Kokkos::pair<size_type, size_type>( 0, _num_soa ) ),
                 _data );
+        _data = resized_data;
+    }
+
+    /*!
+      \brief Remove unused capacity.
+
+      Will reduce the capacity to be the smallest number of SoAs needed to
+      hold size() tuples. If reallocation occurs, all slices and all
+      references to the elements are invalidated. If no reallocation takes
+      place, no slices or references are invalidated.
+    */
+    void shrinkToFit()
+    {
+        static_assert( !memory_traits::is_unmanaged,
+                       "Cannot shrink unmanaged memory" );
+
+        // If we aren't asking for any fewer SoA objects then we have nothing
+        // to do. The amount of allocated data has to be at least as big as
+        // _num_soa so we just need to check here that they are equivalent. If
+        // they are equivalent, the container is already as small as it can be.
+        if ( _data.size() == _num_soa )
+            return;
+
+        // Assign the new capacity.
+        _capacity = _num_soa * vector_length;
+
+        // We need fewer SoA objects so allocate a new view and copy the
+        // existing data.
+        soa_view resized_data(
+            Kokkos::ViewAllocateWithoutInitializing( _data.label() ),
+            _num_soa );
+        if ( _num_soa > 0 )
+            Kokkos::deep_copy(
+                resized_data,
+                Kokkos::subview( _data, Kokkos::pair<size_type, size_type>(
+                                            0, _num_soa ) ) );
         _data = resized_data;
     }
 

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -286,7 +286,7 @@ class AoSoA
       necessarily equal to its storage capacity.
     */
     KOKKOS_FUNCTION
-    bool empty() const { return ( _size == 0 ); }
+    bool empty() const { return ( size() == 0 ); }
 
     /*!
       \brief Returns the size of the storage space currently allocated for the

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -105,6 +105,7 @@ void testAoSoA()
     EXPECT_EQ( aosoa.size(), int( 0 ) );
     EXPECT_EQ( aosoa.capacity(), int( 0 ) );
     EXPECT_EQ( aosoa.numSoA(), int( 0 ) );
+    EXPECT_TRUE( aosoa.empty() );
 
     // Resize
     int num_data = 35;
@@ -114,6 +115,7 @@ void testAoSoA()
     EXPECT_EQ( aosoa.size(), int( 35 ) );
     EXPECT_EQ( aosoa.capacity(), int( 48 ) );
     EXPECT_EQ( aosoa.numSoA(), int( 3 ) );
+    EXPECT_FALSE( aosoa.empty() );
 
     EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
     EXPECT_EQ( aosoa.arraySize( 1 ), int( 16 ) );
@@ -195,6 +197,26 @@ void testAoSoA()
     // Make sure sizes and data changed but the capacity did not.
     EXPECT_EQ( aosoa.size(), int( 29 ) );
     EXPECT_EQ( aosoa.capacity(), int( 1024 ) );
+    EXPECT_EQ( aosoa.numSoA(), int( 2 ) );
+    EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 1 ), int( 13 ) );
+    checkDataMembers( aosoa, fval, dval, ival, dim_1, dim_2, dim_3 );
+
+    // Now shrink to fit and check that the capacity changed to be as small as
+    // possible while the remainder of the size values and elements are the
+    // same.
+    aosoa.shrinkToFit();
+    EXPECT_EQ( aosoa.size(), int( 29 ) );
+    EXPECT_EQ( aosoa.capacity(), int( 32 ) );
+    EXPECT_EQ( aosoa.numSoA(), int( 2 ) );
+    EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 1 ), int( 13 ) );
+    checkDataMembers( aosoa, fval, dval, ival, dim_1, dim_2, dim_3 );
+
+    // Shrink again - nothing should change this time.
+    aosoa.shrinkToFit();
+    EXPECT_EQ( aosoa.size(), int( 29 ) );
+    EXPECT_EQ( aosoa.capacity(), int( 32 ) );
     EXPECT_EQ( aosoa.numSoA(), int( 2 ) );
     EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
     EXPECT_EQ( aosoa.arraySize( 1 ), int( 13 ) );


### PR DESCRIPTION
These two additional functions further align `Cabana::AoSoA` with a more `std::vector`-like memory management interface. The `empty()` function is convenience for size checks and `shrinkToFit()` allows users to clean up excess capacity in problems with dynamic particle populations. The latter will be particularly important in a variety of ongoing ECP use cases.