### PR TITLE
Halo Owner Ranks

### DIFF
--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -115,6 +115,7 @@ class Halo : public CommunicationPlan<DeviceType>
             element_export_ranks, neighbor_ranks, mpi_tag );
         this->createExportSteering( neighbor_ids, element_export_ranks,
                                     element_export_ids );
+        createGhostOwningRanks();
     }
 
     /*!
@@ -167,6 +168,7 @@ class Halo : public CommunicationPlan<DeviceType>
             this->createFromExportsOnly( element_export_ranks, mpi_tag );
         this->createExportSteering( neighbor_ids, element_export_ranks,
                                     element_export_ids );
+        createGhostOwningRanks();
     }
 
     /*!
@@ -185,8 +187,45 @@ class Halo : public CommunicationPlan<DeviceType>
     */
     std::size_t numGhost() const { return this->totalNumImport(); }
 
+    /*!
+      \brief For each ghost, get the MPI rank that it came from (i.e. the rank
+      that uniquely owns the ghost).
+
+      \return A Kokkos view of size numGhost() containing the owning MPI rank
+      of the ghost.
+     */
+    Kokkos::View<int *, DeviceType> ghostOwningRanks() const
+    {
+        return _ghost_owning_ranks;
+    }
+
+  private:
+    // Create the ghost owning ranks.
+    void createGhostOwningRanks()
+    {
+        _ghost_owning_ranks = Kokkos::View<int *, DeviceType>(
+            Kokkos::ViewAllocateWithoutInitializing( "ghost_owning_ranks" ),
+            numGhost() );
+
+        auto owning_ranks_mirror = Kokkos::create_mirror_view(
+            Kokkos::HostSpace(), _ghost_owning_ranks );
+
+        std::size_t ghost_id = 0;
+        for ( int n = 0; n < this->numNeighbor(); ++n )
+        {
+            auto nrank = this->neighborRank( n );
+            for ( std::size_t i = 0; i < this->numImport( n ); ++i, ++ghost_id )
+            {
+                owning_ranks_mirror( ghost_id ) = nrank;
+            }
+        }
+
+        Kokkos::deep_copy( _ghost_owning_ranks, owning_ranks_mirror );
+    }
+
   private:
     std::size_t _num_local;
+    Kokkos::View<int *, DeviceType> _ghost_owning_ranks;
 };
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -203,13 +203,18 @@ class Halo : public CommunicationPlan<DeviceType>
     // Create the ghost owning ranks.
     void createGhostOwningRanks()
     {
+        // Allocate a view to hold the owner rank for each ghost element.
         _ghost_owning_ranks = Kokkos::View<int *, DeviceType>(
             Kokkos::ViewAllocateWithoutInitializing( "ghost_owning_ranks" ),
             numGhost() );
 
+        // Build the owning ranks on the host.
         auto owning_ranks_mirror = Kokkos::create_mirror_view(
             Kokkos::HostSpace(), _ghost_owning_ranks );
 
+        // The ghosts are ordered by the neighbor they came from. The ghosts
+        // that are imports from neighbor 0 is first, the imports from
+        // neighbor 1 are second, and so on.
         std::size_t ghost_id = 0;
         for ( int n = 0; n < this->numNeighbor(); ++n )
         {
@@ -220,6 +225,7 @@ class Halo : public CommunicationPlan<DeviceType>
             }
         }
 
+        // Copy owning ranks to the device so it is device-accessible.
         Kokkos::deep_copy( _ghost_owning_ranks, owning_ranks_mirror );
     }
 

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -78,7 +78,7 @@ void test1( const bool use_topology )
     EXPECT_EQ( halo->numGhost(), ghost_own_ranks.size() );
     auto own_ranks_host = Kokkos::create_mirror_view_and_copy(
         Kokkos::HostSpace(), ghost_own_ranks );
-    for ( int i = 0; i < my_size; ++i )
+    for ( int i = 0; i < static_cast<int>( halo->numGhost() ); ++i )
     {
         if ( i == 0 )
         {
@@ -296,7 +296,7 @@ void test2( const bool use_topology )
     EXPECT_EQ( halo->numGhost(), ghost_own_ranks.size() );
     auto own_ranks_host = Kokkos::create_mirror_view_and_copy(
         Kokkos::HostSpace(), ghost_own_ranks );
-    for ( int i = 0; i < my_size; ++i )
+    for ( int i = 0; i < static_cast<int>( halo->numGhost() ); ++i )
     {
         if ( i == 0 )
         {

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -73,6 +73,27 @@ void test1( const bool use_topology )
     EXPECT_EQ( halo->numLocal(), num_local );
     EXPECT_EQ( halo->numGhost(), my_size );
 
+    // Check the owning ranks of the ghost data.
+    auto ghost_own_ranks = halo->ghostOwningRanks();
+    EXPECT_EQ( halo->numGhost(), ghost_own_ranks.size() );
+    auto own_ranks_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), ghost_own_ranks );
+    for ( int i = 0; i < my_size; ++i )
+    {
+        if ( i == 0 )
+        {
+            EXPECT_EQ( own_ranks_host( i ), my_rank );
+        }
+        else if ( i == my_rank )
+        {
+            EXPECT_EQ( own_ranks_host( i ), 0 );
+        }
+        else
+        {
+            EXPECT_EQ( own_ranks_host( i ), i );
+        }
+    }
+
     // Create an AoSoA of local data with space allocated for local data.
     using DataTypes = Cabana::MemberTypes<int, double[2]>;
     using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE>;
@@ -269,6 +290,27 @@ void test2( const bool use_topology )
     // Check the plan.
     EXPECT_EQ( halo->numLocal(), num_local );
     EXPECT_EQ( halo->numGhost(), my_size );
+
+    // Check the owning ranks of the ghost data.
+    auto ghost_own_ranks = halo->ghostOwningRanks();
+    EXPECT_EQ( halo->numGhost(), ghost_own_ranks.size() );
+    auto own_ranks_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), ghost_own_ranks );
+    for ( int i = 0; i < my_size; ++i )
+    {
+        if ( i == 0 )
+        {
+            EXPECT_EQ( own_ranks_host( i ), my_rank );
+        }
+        else if ( i == my_rank )
+        {
+            EXPECT_EQ( own_ranks_host( i ), 0 );
+        }
+        else
+        {
+            EXPECT_EQ( own_ranks_host( i ), i );
+        }
+    }
 
     // Create an AoSoA of local data with space allocated for local data.
     using DataTypes = Cabana::MemberTypes<int, double[2]>;


### PR DESCRIPTION
After working with @streeve on the issue of handling periodic boundaries with the halo it became clear that we could resolve this issue by providing a user with the rank that owns each ghost value in a halo. Once the owner is known, a user can then perform any operation needed on the ghost data after gathering or before scattering based on the rank the data came from (e.g. performing a periodic shift of particle coordinates for particles that were communicated across a periodic boundary).

This information was already available in the halo and could have ostensibly been generated by the user, but the new function `Cabana::Halo::ghostOwningRanks()` provides a simple output with this information for the user.

Fixes #77 