### PR TITLE
Adding tuple copy and assignment operators

### DIFF
--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -152,7 +152,7 @@ struct Tuple<MemberTypes<Types...>> : SoA<MemberTypes<Types...>, 1>
         Impl::tupleCopy( *this, 0, t, 0 );
     }
 
-    KOKKOS_FORCEINLINE_FUNCTION Tuple( const Tuple &&t )
+    KOKKOS_FORCEINLINE_FUNCTION Tuple( Tuple &&t )
     {
         Impl::tupleCopy( *this, 0, t, 0 );
     }

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -144,6 +144,30 @@ template <typename... Types>
 struct Tuple<MemberTypes<Types...>> : SoA<MemberTypes<Types...>, 1>
 {
     using base = SoA<MemberTypes<Types...>, 1>;
+
+    KOKKOS_FORCEINLINE_FUNCTION Tuple() = default;
+
+    KOKKOS_FORCEINLINE_FUNCTION Tuple( const Tuple &t )
+    {
+        Impl::tupleCopy( *this, 0, t, 0 );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION Tuple( const Tuple &&t )
+    {
+        Impl::tupleCopy( *this, 0, t, 0 );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION Tuple &operator=( const Tuple &t )
+    {
+        Impl::tupleCopy( *this, 0, t, 0 );
+        return *this;
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION Tuple &operator=( Tuple &&t )
+    {
+        Impl::tupleCopy( *this, 0, t, 0 );
+        return *this;
+    }
 };
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Upon investigation by @weinbe2 regarding Cabana performance it was noted that a number of non-optimal load/store paths were being generated in Cuda code by the default copy and assignment operators in `Cabana::Tuple` which end up being used in the `Tuple` extraction methods in `AoSoA` which in turn are used everywhere (buffer packing, sorting, etc.). This PR adds these, shows performance improvements with the binning/sorting benchmark for Cuda, no performance regressions for Serial and OpenMP code, as well as improved PTX code generated by NVCC.

Also note that due to the reduction in load/store paths due to this optimization we also reduce register usage with @weinbe2 noting a 25% reduction for his benchmark. 

Some timing results from Summit for re-ordering an AoSoA during a sort permute with AoSoA sizes varying from 1e3 to 1e7:

```
Old (22601f285bfdcc261152a5444057a941423a2d0e)
cuda_sort_aosoa_permute
problem_size min max ave
1000 121.015 127.025 122.626
10000 792.081 808.934 796.83
100000 1244.23 1311.03 1255.73
1000000 12244.6 12678.7 12462.5
10000000 132625 134445 133476
```

```
New (1fedad4ed9f4d1c1390c29efbccecf165d3e424d)
cuda_sort_aosoa_permute
problem_size min max ave
1000 116.952 123.833 119.023
10000 777.396 896.309 793.761
100000 1107.62 1131.33 1118.96
1000000 10651.1 10890.6 10737.1
10000000 112860 113323 113085
```

That gives a 15% improvement by adding these operators.
