### PR TITLE
Verlet AllocateWithoutInit

### DIFF
--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -374,7 +374,8 @@ struct VerletListBuilder
     {
         // Allocate offsets.
         _data.offsets = Kokkos::View<int *, memory_space>(
-            "neighbor_offsets", _data.counts.size() );
+            Kokkos::ViewAllocateWithoutInitializing( "neighbor_offsets" ),
+            _data.counts.size() );
 
         // Calculate offsets from counts and the total number of counts.
         OffsetScanOp<memory_space> offset_op;
@@ -389,7 +390,8 @@ struct VerletListBuilder
 
         // Allocate the neighbor list.
         _data.neighbors = Kokkos::View<int *, memory_space>(
-            "neighbors", total_num_neighbor );
+            Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
+            total_num_neighbor );
 
         // Reset the counts. We count again when we fill.
         Kokkos::deep_copy( _data.counts, 0 );
@@ -415,7 +417,8 @@ struct VerletListBuilder
 
         // Allocate the neighbor list.
         _data.neighbors = Kokkos::View<int **, memory_space>(
-            "neighbors", _data.counts.size(), max_num_neighbor );
+            Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
+            _data.counts.size(), max_num_neighbor );
 
         // Reset the counts. We count again when we fill.
         Kokkos::deep_copy( _data.counts, 0 );

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -405,8 +405,8 @@ void testVerletListFull()
         nlist_full( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
                     cell_size_ratio, grid_min, grid_max );
 
-    Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>
-        nlist = nlist_full;
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag> nlist;
+    nlist = nlist_full;
 
     // Check the neighbor list.
     auto position = Cabana::slice<0>( aosoa );


### PR DESCRIPTION
In looking into #172, the most significant speedup came from allocating the neighbor lists without initialization, not from removing the count.

The unit test was modified to properly test #133

