### PR TITLE
VerletList 2D fill/refill

### DIFF
--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -392,11 +392,14 @@ struct VerletListBuilder
 
     void initCounts( VerletLayout2D )
     {
-        count = false;
+        if ( max_n > 0 )
+        {
+            count = false;
 
-        _data.neighbors = Kokkos::View<int **, memory_space>(
-            Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
-            _data.counts.size(), max_n );
+            _data.neighbors = Kokkos::View<int **, memory_space>(
+                Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
+                _data.counts.size(), max_n );
+        }
     }
 
     void processCounts( VerletLayoutCSR )
@@ -445,7 +448,8 @@ struct VerletListBuilder
         Kokkos::fence();
 
         // Reallocate the neighbor list if previous size is exceeded.
-        if ( (std::size_t)max_num_neighbor > _data.neighbors.extent( 1 ) )
+        if ( count or (std::size_t)max_num_neighbor >
+             _data.neighbors.extent( 1 ) )
         {
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );
@@ -639,7 +643,7 @@ class VerletList
                 const typename PositionSlice::value_type cell_size_ratio,
                 const typename PositionSlice::value_type grid_min[3],
                 const typename PositionSlice::value_type grid_max[3],
-                const std::size_t max_neigh = 32,
+                const std::size_t max_neigh = 0,
                 typename std::enable_if<( is_slice<PositionSlice>::value ),
                                         int>::type * = 0 )
     {

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -80,7 +80,7 @@ struct VerletListData<DeviceType, VerletLayout2D>
     void addNeighbor( const int pid, const int nid ) const
     {
         std::size_t count = Kokkos::atomic_fetch_add( &counts( pid ), 1 );
-        if ( count < neighbors.extent(1) )
+        if ( count < neighbors.extent( 1 ) )
             neighbors( pid, count ) = nid;
     }
 };
@@ -388,8 +388,7 @@ struct VerletListBuilder
         }
     };
 
-    void initCounts( VerletLayoutCSR )
-    {}
+    void initCounts( VerletLayoutCSR ) {}
 
     void initCounts( VerletLayout2D )
     {
@@ -446,7 +445,7 @@ struct VerletListBuilder
         Kokkos::fence();
 
         // Reallocate the neighbor list if previous size is exceeded.
-        if ( (std::size_t) max_num_neighbor > _data.neighbors.extent( 1 ) )
+        if ( (std::size_t)max_num_neighbor > _data.neighbors.extent( 1 ) )
         {
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -79,7 +79,7 @@ struct VerletListData<DeviceType, VerletLayout2D>
     KOKKOS_INLINE_FUNCTION
     void addNeighbor( const int pid, const int nid ) const
     {
-        int count = Kokkos::atomic_fetch_add( &counts( pid ), 1 );
+        std::size_t count = Kokkos::atomic_fetch_add( &counts( pid ), 1 );
         if ( count < neighbors.extent(1) )
             neighbors( pid, count ) = nid;
     }

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -450,7 +450,8 @@ struct VerletListBuilder
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );
             _data.neighbors = Kokkos::View<int **, memory_space>(
-                "neighbors", _data.counts.size(), max_num_neighbor );
+                Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
+                _data.counts.size(), max_num_neighbor );
         }
     }
 

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -448,8 +448,8 @@ struct VerletListBuilder
         Kokkos::fence();
 
         // Reallocate the neighbor list if previous size is exceeded.
-        if ( count or (std::size_t)max_num_neighbor >
-             _data.neighbors.extent( 1 ) )
+        if ( count or ( std::size_t )
+                              max_num_neighbor > _data.neighbors.extent( 1 ) )
         {
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -703,6 +703,13 @@ class NeighborList<VerletList<MemorySpace, AlgorithmTag, VerletLayoutCSR>>
 
     using TypeTag = AlgorithmTag;
 
+    // Get the total number of neighbors (maximum size of CSR list).
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t maxNeighbor( const list_type &list )
+    {
+        return list._data.neighbors.extent( 0 );
+    }
+
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
     static std::size_t numNeighbor( const list_type &list,
@@ -732,6 +739,13 @@ class NeighborList<VerletList<MemorySpace, AlgorithmTag, VerletLayout2D>>
     using list_type = VerletList<MemorySpace, AlgorithmTag, VerletLayout2D>;
 
     using TypeTag = AlgorithmTag;
+
+    // Get the maximum number of neighbors per particle.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t maxNeighbor( const list_type &list )
+    {
+        return list._data.neighbors.extent( 1 );
+    }
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -411,6 +411,12 @@ void testVerletListFull()
     // Check the neighbor list.
     auto position = Cabana::slice<0>( aosoa );
     checkFullNeighborList( nlist, position, test_radius );
+
+    // Check again after building with a user-defined array allocation size
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>
+        nlist_max( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
+                   cell_size_ratio, grid_min, grid_max, 100 );
+    checkFullNeighborList( nlist_max, position, test_radius );
 }
 
 //---------------------------------------------------------------------------//
@@ -435,6 +441,12 @@ void testVerletListHalf()
     // Check the neighbor list.
     auto position = Cabana::slice<0>( aosoa );
     checkHalfNeighborList( nlist, position, test_radius );
+
+    // Check again after building with a user-defined array allocation size
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag>
+        nlist_max( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
+                   cell_size_ratio, grid_min, grid_max, 100 );
+    checkHalfNeighborList( nlist_max, position, test_radius );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -412,11 +412,17 @@ void testVerletListFull()
     auto position = Cabana::slice<0>( aosoa );
     checkFullNeighborList( nlist, position, test_radius );
 
-    // Check again after building with a user-defined array allocation size
+    // Check again, building with a large array allocation size
     Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>
         nlist_max( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
                    cell_size_ratio, grid_min, grid_max, 100 );
     checkFullNeighborList( nlist_max, position, test_radius );
+
+    // Check again, building with a small array allocation size (refill)
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>
+        nlist_max2( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
+                    cell_size_ratio, grid_min, grid_max, 2 );
+    checkFullNeighborList( nlist_max2, position, test_radius );
 }
 
 //---------------------------------------------------------------------------//
@@ -442,11 +448,17 @@ void testVerletListHalf()
     auto position = Cabana::slice<0>( aosoa );
     checkHalfNeighborList( nlist, position, test_radius );
 
-    // Check again after building with a user-defined array allocation size
+    // Check again, building with a large array allocation size
     Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag>
         nlist_max( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
                    cell_size_ratio, grid_min, grid_max, 100 );
     checkHalfNeighborList( nlist_max, position, test_radius );
+
+    // Check again, building with a small array allocation size (refill)
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag>
+        nlist_max2( Cabana::slice<0>( aosoa ), 0, aosoa.size(), test_radius,
+                    cell_size_ratio, grid_min, grid_max, 2 );
+    checkHalfNeighborList( nlist_max2, position, test_radius );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Optimization for 2D neighbor layout where count and fill is replaced with fill (and refill only if the preallocated array is exceeded). The CSR layout count and fill is unchanged.

A `Cabana::NeighborList::maxNeighbor` function is added to easily keep the array size for the next neighbor list build.