### PR TITLE
cmake: disable Ewald for non-mpi builds

### DIFF
--- a/core/example/longrange/CMakeLists.txt
+++ b/core/example/longrange/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_executable(Direct directsum_example.cpp)
-target_link_libraries(Direct cabanacore)
 if(Cabana_ENABLE_MPI)
+  add_executable(Direct directsum_example.cpp)
+  target_link_libraries(Direct cabanacore)
   add_executable(Ewald ewaldsum_example.cpp)
   target_link_libraries(Ewald cabanacore)
 endif()

--- a/core/example/longrange/CMakeLists.txt
+++ b/core/example/longrange/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_executable(Direct directsum_example.cpp)
 target_link_libraries(Direct cabanacore)
-add_executable(Ewald ewaldsum_example.cpp)
-target_link_libraries(Ewald cabanacore)
+if(Cabana_ENABLE_MPI)
+  add_executable(Ewald ewaldsum_example.cpp)
+  target_link_libraries(Ewald cabanacore)
+endif()
 
 if(Cabana_ENABLE_Cuda)
   find_package(CUDA REQUIRED)


### PR DESCRIPTION
Fix #184 