### PR TITLE
Removing view initialization in sort

### DIFF
--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -198,7 +198,8 @@ copySliceToKeys( SliceType slice )
 {
     using KeyViewType =
         Kokkos::View<typename SliceType::value_type *, DeviceType>;
-    KeyViewType keys( "slice_keys", slice.size() );
+    KeyViewType keys( Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ),
+                      slice.size() );
     Kokkos::RangePolicy<typename DeviceType::execution_space> exec_policy(
         0, slice.size() );
     auto copy_op = KOKKOS_LAMBDA( const std::size_t i )
@@ -561,7 +562,8 @@ void permute(
     auto end = binning_data.rangeEnd();
 
     Kokkos::View<typename AoSoA_t::tuple_type *, DeviceType> scratch_tuples(
-        "scratch_tuples", end - begin );
+        Kokkos::ViewAllocateWithoutInitializing( "scratch_tuples" ),
+        end - begin );
 
     auto permute_to_scratch = KOKKOS_LAMBDA( const std::size_t i )
     {
@@ -618,7 +620,8 @@ void permute(
     auto slice_data = slice.data();
 
     Kokkos::View<typename SliceType::value_type **, DeviceType> scratch_array(
-        "scratch_array", end - begin, num_comp );
+        Kokkos::ViewAllocateWithoutInitializing( "scratch_array" ), end - begin,
+        num_comp );
 
     auto permute_to_scratch = KOKKOS_LAMBDA( const std::size_t i )
     {


### PR DESCRIPTION
Another good catch by @weinbe2 - found a few more views in the sort with default initialization that don't need to be initialized. Here are some results from permutation in the sorting benchmark.

Before:
```
cuda_sort_aosoa_permute
problem_size min max ave
1000 60.994 69.426 63.3917
10000 233.201 303.037 249.196
100000 489.165 526.199 499.452
1000000 5007.85 5105.42 5047.19
10000000 61829.1 65204.9 62689.7
```

After:
```
cuda_sort_aosoa_permute
problem_size min max ave
1000 53.248 66.365 57.2939
10000 215.145 284.394 227.005
100000 300.092 318.178 311.052
1000000 2783.09 7576.42 3743.23
10000000 30717.9 34994 31908.1
```

Huge difference for large numbers of particles.