### PR TITLE
AoSoA resize without deprecated code

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -371,7 +371,8 @@ class AoSoA
                 Kokkos::subview(
                     resized_data,
                     Kokkos::pair<size_type, size_type>( 0, _num_soa ) ),
-                _data );
+                Kokkos::subview( _data, Kokkos::pair<size_type, size_type>(
+                                            0, _num_soa ) ) );
         _data = resized_data;
     }
 
@@ -405,7 +406,9 @@ class AoSoA
             _num_soa );
         if ( _num_soa > 0 )
             Kokkos::deep_copy(
-                resized_data,
+                Kokkos::subview(
+                    resized_data,
+                    Kokkos::pair<size_type, size_type>( 0, _num_soa ) ),
                 Kokkos::subview( _data, Kokkos::pair<size_type, size_type>(
                                             0, _num_soa ) ) );
         _data = resized_data;

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -406,9 +406,7 @@ class AoSoA
             _num_soa );
         if ( _num_soa > 0 )
             Kokkos::deep_copy(
-                Kokkos::subview(
-                    resized_data,
-                    Kokkos::pair<size_type, size_type>( 0, _num_soa ) ),
+                resized_data,
                 Kokkos::subview( _data, Kokkos::pair<size_type, size_type>(
                                             0, _num_soa ) ) );
         _data = resized_data;

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -221,6 +221,17 @@ void testAoSoA()
     EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
     EXPECT_EQ( aosoa.arraySize( 1 ), int( 13 ) );
     checkDataMembers( aosoa, fval, dval, ival, dim_1, dim_2, dim_3 );
+
+    // Now resize smaller, then larger again to confirm underlying
+    // Kokkos::deep_copy will work without deprecated code.
+    aosoa.resize( 15 );
+    aosoa.resize( 47 );
+    EXPECT_EQ( aosoa.size(), int( 47 ) );
+    EXPECT_EQ( aosoa.capacity(), int( 48 ) );
+    EXPECT_EQ( aosoa.numSoA(), int( 3 ) );
+    EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 1 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 2 ), int( 15 ) );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
When resizing an AoSoA, the underlying deep_copy can fail without deprecated code because of mismatched sizes. This only comes up with multiple subsequent resize operations with differing numbers of SoA. 