### PR TITLE
Add host_mirror_type for explicit use with host data

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -113,12 +113,8 @@ class AoSoA
     using aosoa_type = AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>;
 
     // Host mirror type.
-    using host_mirror_type = AoSoA<
-        DataTypes,
-        Kokkos::HostSpace, // mirrors return AoSoA build with spaces not device
-        VectorLength,
-        MemoryTraits
-    >;
+    using host_mirror_type =
+        AoSoA<DataTypes, Kokkos::HostSpace, VectorLength, MemoryTraits>;
 
     // Member data types.
     static_assert( is_member_types<DataTypes>::value,

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -113,8 +113,7 @@ class AoSoA
     using aosoa_type = AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>;
 
     // Host mirror type.
-    using host_mirror_type =
-        AoSoA<DataTypes, Kokkos::HostSpace, VectorLength>;
+    using host_mirror_type = AoSoA<DataTypes, Kokkos::HostSpace, VectorLength>;
 
     // Member data types.
     static_assert( is_member_types<DataTypes>::value,

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -114,7 +114,7 @@ class AoSoA
 
     // Host mirror type.
     using host_mirror_type =
-        AoSoA<DataTypes, Kokkos::HostSpace, VectorLength, MemoryTraits>;
+        AoSoA<DataTypes, Kokkos::HostSpace, VectorLength>;
 
     // Member data types.
     static_assert( is_member_types<DataTypes>::value,

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -112,6 +112,14 @@ class AoSoA
     // AoSoA type.
     using aosoa_type = AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>;
 
+    // Host mirror type.
+    using host_mirror_type = AoSoA<
+        DataTypes,
+        Kokkos::HostSpace, // mirrors return AoSoA build with spaces not device
+        VectorLength,
+        MemoryTraits
+    >;
+
     // Member data types.
     static_assert( is_member_types<DataTypes>::value,
                    "AoSoA data types must be member types" );

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -66,8 +66,8 @@ inline SrcAoSoA create_mirror_view(
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Create a mirror view on the host of the given AoSoA in the given
-  memory space. Different space specialization allocates a new AoSoA.
+  \brief Create a mirror view of the given AoSoA in the given memory space.
+  Different space specialization allocates a new AoSoA.
 
   \note Memory allocation will only occur if the requested mirror
   memory space is different from that of the input AoSoA. If they are the
@@ -110,9 +110,9 @@ inline SrcAoSoA create_mirror_view_and_copy(
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Create a mirror on the host of the given AoSoA in the given memory
-  space and deep copy the AoSoA into the mirror. Different space
-  specialization allocates a new AoSoA and performs the deep copy.
+  \brief Create a mirror of the given AoSoA in the given memory space and deep
+  copy the AoSoA into the mirror. Different space specialization allocates a
+  new AoSoA and performs the deep copy.
 
   \note Memory allocation will only occur if the requested mirror
   memory space is different from that of the input AoSoA. If they are the


### PR DESCRIPTION
This adds a comparable type helper to `Kokkos::HostMirror` is useful if you want to store a class level pointer to the data

- Also removes misleading comment that says deep copy occurs to the host, when it really occurs to the specified (memory) space