### PR TITLE
Adding strong type assertions to AoSoA

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -118,6 +118,8 @@ class AoSoA
     // Member data types.
     static_assert( is_member_types<DataTypes>::value,
                    "AoSoA data types must be member types" );
+    static_assert( CheckMemberTypes<DataTypes>::value,
+                   "AoSoA data type failure" );
     using member_types = DataTypes;
 
     // Device type.

--- a/core/src/Cabana_MemberTypes.hpp
+++ b/core/src/Cabana_MemberTypes.hpp
@@ -75,6 +75,54 @@ struct MemberTypeAtIndex<M, MemberTypes<Types...>>
 };
 
 //---------------------------------------------------------------------------//
+/*!
+  \class CheckMemberTypes
+  \brief Check that member types are valied.
+*/
+template <std::size_t M, typename T, typename... Types>
+struct CheckMemberTypesImpl;
+
+template <typename T, typename... Types>
+struct CheckMemberTypesImpl<0, T, Types...>
+{
+    using type = T;
+    static_assert( std::is_trivial<type>::value,
+                   "Member types must be trivial" );
+
+    using value_type = typename std::remove_all_extents<type>::type;
+    static_assert( std::is_arithmetic<value_type>::value,
+                   "Member value types must be arithmetic" );
+
+    // Return true so we get the whole stack to evaluate all the assertions.
+    static constexpr bool value = true;
+};
+
+template <std::size_t M, typename T, typename... Types>
+struct CheckMemberTypesImpl
+{
+    using type = T;
+    static_assert( std::is_trivial<type>::value,
+                   "Member types must be trivial" );
+
+    using value_type = typename std::remove_all_extents<type>::type;
+    static_assert( std::is_arithmetic<value_type>::value,
+                   "Member value types must be arithmetic" );
+
+    static constexpr bool value = CheckMemberTypesImpl<M - 1, Types...>::value;
+};
+
+template <typename... Types>
+struct CheckMemberTypes;
+
+template <typename... Types>
+struct CheckMemberTypes<MemberTypes<Types...>>
+{
+    static constexpr int size = MemberTypes<Types...>::size;
+    static constexpr bool value =
+        CheckMemberTypesImpl<size - 1, Types...>::value;
+};
+
+//---------------------------------------------------------------------------//
 
 } // end namespace Cabana
 


### PR DESCRIPTION
A user tried to use their own class in an `AoSoA` which violated the design structure. A `static_assert` was thrown but it wasn't clear why the user's class was invalid. This PR adds stronger checks. We assert types must be both trivial and fundamental allowing us to do a lot of compile-time work. This prevents users from using their own classes directly as `AoSoA` members although I would argue that the `AoSoA` and `Tuple` was intended to replace the user's particle classes with primitive data. 

We are still working to identify if there are valid performance-based use cases for allowing users to use their own classes within `AoSoA` but for now this makes our restrictions more clear and obvious. For example:

```
struct MyObject { float data[4]; };

void MyObjectTest()
{
    using DataTypes = Cabana::MemberTypes<MyObject,int>;
    using AoSoA_t = Cabana::AoSoA<DataTypes,TEST_MEMSPACE>;
    AoSoA_t aosoa("aosoa");
}
```
will now fail to compile as:
```
[1/2] Building CXX object core/unit_test/CMakeFiles/Slice_test_SERIAL.dir/SERIAL/tstSlice_SERIAL.cpp.o
FAILED: core/unit_test/CMakeFiles/Slice_test_SERIAL.dir/SERIAL/tstSlice_SERIAL.cpp.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++   -I/Users/uy7/software/Cabana/gtest -Icore/unit_test -I/Users/uy7/software/Cabana/core/unit_test -Icore/unit_test/SERIAL -I/Users/uy7/software/Cabana/core/src -Icore/src -isystem /Users/uy7/install/kokkos/debug/include -isystem /Users/uy7/install/openmpi-4.0.0/include -Wall -Wextra -pedantic -fcolor-diagnostics -DGTEST_HAS_PTHREAD=0 -g -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.14   -std=c++14 -MD -MT core/unit_test/CMakeFiles/Slice_test_SERIAL.dir/SERIAL/tstSlice_SERIAL.cpp.o -MF core/unit_test/CMakeFiles/Slice_test_SERIAL.dir/SERIAL/tstSlice_SERIAL.cpp.o.d -o core/unit_test/CMakeFiles/Slice_test_SERIAL.dir/SERIAL/tstSlice_SERIAL.cpp.o -c core/unit_test/SERIAL/tstSlice_SERIAL.cpp
In file included from core/unit_test/SERIAL/tstSlice_SERIAL.cpp:2:
In file included from /Users/uy7/software/Cabana/core/unit_test/tstSlice.hpp:12:
In file included from /Users/uy7/software/Cabana/core/src/Cabana_AoSoA.hpp:16:
/Users/uy7/software/Cabana/core/src/Cabana_MemberTypes.hpp:106:5: error: static_assert failed due to requirement 'std::is_arithmetic<Test::MyObject>::value' "Member value types must be arithmetic"
    static_assert( std::is_arithmetic<value_type>::value,
    ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/uy7/software/Cabana/core/src/Cabana_MemberTypes.hpp:119:35: note: in instantiation of template class 'Cabana::CheckMemberTypesImpl<1, Test::MyObject, int>' requested here
    static constexpr bool value = CheckMemberTypesImpl<size-1, Types...>::value;
                                  ^
/Users/uy7/software/Cabana/core/src/Cabana_AoSoA.hpp:121:20: note: in instantiation of template class 'Cabana::CheckMemberTypes<Cabana::MemberTypes<Test::MyObject, int> >' requested here
    static_assert( CheckMemberTypes<DataTypes>::value, "AoSoA data type failure" );
                   ^
/Users/uy7/software/Cabana/core/unit_test/tstSlice.hpp:348:13: note: in instantiation of template class 'Cabana::AoSoA<Cabana::MemberTypes<Test::MyObject, int>, Kokkos::HostSpace, 16, Kokkos::MemoryTraits<0> >' requested here
    AoSoA_t aosoa("aosoa");
            ^
1 error generated.
ninja: build stopped: subcommand failed.
```
Which clearly indicates that the `MyObject` class is not valid.