### PR TITLE
Deprecate CABANA_[INLINE]_FUNCTION and memory/execution space aliases in Cabana::

### DIFF
--- a/core/performance_test/peakflops/03_Cabana_peakflops.cpp
+++ b/core/performance_test/peakflops/03_Cabana_peakflops.cpp
@@ -37,7 +37,7 @@ enum UserParticleFields
 using ParticleDataTypes = Cabana::MemberTypes<float>;
 
 // Declare the memory space.
-using MemorySpace = Cabana::HostSpace;
+using MemorySpace = Kokkos::HostSpace;
 
 // Set the type for the particle AoSoA.
 using ParticleList =

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -53,6 +53,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CabanaCore_config.hpp DESTINATION ${CM
 #-----------------------------------------------------------------------------
 
 add_library(cabanacore ${SOURCES_IMPL})
+target_compile_features(cabanacore PUBLIC cxx_attribute_deprecated)
 target_include_directories(cabanacore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(cabanacore Kokkos::kokkos)

--- a/core/src/Cabana_Macros.hpp
+++ b/core/src/Cabana_Macros.hpp
@@ -17,10 +17,6 @@
 #define CABANA_FUNCTION KOKKOS_FUNCTION
 #define CABANA_INLINE_FUNCTION KOKKOS_INLINE_FUNCTION
 #define CABANA_FORCEINLINE_FUNCTION KOKKOS_FORCEINLINE_FUNCTION
-#if __has_cpp_attribute( deprecated ) && __cpluplus >= 201402L
 #define CABANA_DEPRECATED [[deprecated]]
-#else
-#define CABANA_DEPRECATED
-#endif
 
 #endif // end CABANA_MACROS_HPP

--- a/core/src/Cabana_Macros.hpp
+++ b/core/src/Cabana_Macros.hpp
@@ -14,9 +14,14 @@
 
 #include <Kokkos_Core.hpp>
 
-#define CABANA_FUNCTION KOKKOS_FUNCTION
-#define CABANA_INLINE_FUNCTION KOKKOS_INLINE_FUNCTION
-#define CABANA_FORCEINLINE_FUNCTION KOKKOS_FORCEINLINE_FUNCTION
+#define CABANA_FUNCTION                                                        \
+    [[deprecated( "Use KOKKOS_FUNCTION macro instead" )]] KOKKOS_FUNCTION
+#define CABANA_INLINE_FUNCTION                                                 \
+    [[deprecated(                                                              \
+        "Use KOKKOS_INLINE_FUNCTION macro instead" )]] KOKKOS_INLINE_FUNCTION
+#define CABANA_FORCEINLINE_FUNCTION                                            \
+    [[deprecated( "Use KOKKOS_FORCEINLINE_FUNCTION macro "                     \
+                  "instead" )]] KOKKOS_FORCEINLINE_FUNCTION
 #define CABANA_DEPRECATED [[deprecated]]
 
 #endif // end CABANA_MACROS_HPP

--- a/core/src/Cabana_Types.hpp
+++ b/core/src/Cabana_Types.hpp
@@ -14,6 +14,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <Cabana_Macros.hpp>
+
 #include <type_traits>
 
 namespace Cabana
@@ -22,29 +24,29 @@ namespace Cabana
 // Execution Spaces
 //---------------------------------------------------------------------------//
 #if defined( KOKKOS_ENABLE_SERIAL )
-using Kokkos::Serial;
+using Serial CABANA_DEPRECATED = Kokkos::Serial;
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-using Kokkos::Threads;
+using Threads CABANA_DEPRECATED = Kokkos::Threads;
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-using Kokkos::OpenMP;
+using OpenMP CABANA_DEPRECATED = Kokkos::OpenMP;
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-using Kokkos::Cuda;
+using Cuda CABANA_DEPRECATED = Kokkos::Cuda;
 #endif
 
 //---------------------------------------------------------------------------//
 // Memory spaces
 //---------------------------------------------------------------------------//
 //! Host memory space
-using Kokkos::HostSpace;
+using HostSpace CABANA_DEPRECATED = Kokkos::HostSpace;
 
 #if defined( KOKKOS_ENABLE_CUDA )
-using Kokkos::CudaUVMSpace;
+using CudaUVMSpace CABANA_DEPRECATED = Kokkos::CudaUVMSpace;
 #endif
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -295,27 +295,27 @@ void testAssign()
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, deep_copy_to_host_same_layout_test )
 {
-    testDeepCopy<Cabana::HostSpace, TEST_MEMSPACE, 16, 16>();
+    testDeepCopy<Kokkos::HostSpace, TEST_MEMSPACE, 16, 16>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, deep_copy_from_host_same_layout_test )
 {
-    testDeepCopy<TEST_MEMSPACE, Cabana::HostSpace, 16, 16>();
+    testDeepCopy<TEST_MEMSPACE, Kokkos::HostSpace, 16, 16>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, deep_copy_to_host_different_layout_test )
 {
-    testDeepCopy<Cabana::HostSpace, TEST_MEMSPACE, 16, 32>();
-    testDeepCopy<Cabana::HostSpace, TEST_MEMSPACE, 64, 8>();
+    testDeepCopy<Kokkos::HostSpace, TEST_MEMSPACE, 16, 32>();
+    testDeepCopy<Kokkos::HostSpace, TEST_MEMSPACE, 64, 8>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, deep_copy_from_host_different_layout_test )
 {
-    testDeepCopy<TEST_MEMSPACE, Cabana::HostSpace, 64, 8>();
-    testDeepCopy<TEST_MEMSPACE, Cabana::HostSpace, 16, 32>();
+    testDeepCopy<TEST_MEMSPACE, Kokkos::HostSpace, 64, 8>();
+    testDeepCopy<TEST_MEMSPACE, Kokkos::HostSpace, 16, 32>();
 }
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -78,7 +78,7 @@ void test1( const bool use_topology )
     Cabana::migrate( *distributor, data_src, data_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_dst_host( "data_dst_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_dst_host( "data_dst_host",
                                                                num_data );
     auto slice_int_dst_host = Cabana::slice<0>( data_dst_host );
     auto slice_dbl_dst_host = Cabana::slice<1>( data_dst_host );
@@ -146,7 +146,7 @@ void test2( const bool use_topology )
     Cabana::migrate( *distributor, data );
 
     // Get host copies of the migrated data.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host( "data_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host( "data_host",
                                                            num_data / 2 );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );
@@ -243,7 +243,7 @@ void test3( const bool use_topology )
         Kokkos::HostSpace(), inverse_steering );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_dst_host( "data_dst_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_dst_host( "data_dst_host",
                                                                num_data );
     Cabana::deep_copy( data_dst_host, data_dst );
     auto slice_int_dst_host = Cabana::slice<0>( data_dst_host );
@@ -321,7 +321,7 @@ void test4( const bool use_topology )
     Cabana::migrate( *distributor, data_src, data_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_dst_host( "data_dst_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_dst_host( "data_dst_host",
                                                                num_data );
     auto slice_int_dst_host = Cabana::slice<0>( data_dst_host );
     auto slice_dbl_dst_host = Cabana::slice<1>( data_dst_host );
@@ -427,7 +427,7 @@ void test5( const bool use_topology )
     Cabana::migrate( *distributor, slice_dbl_src, slice_dbl_dst );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host( "data_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host( "data_host",
                                                            my_size );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );
@@ -521,7 +521,7 @@ void test6( const bool use_topology )
         EXPECT_EQ( data.size(), 0 );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host(
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host(
         "data_host", distributor->totalNumImport() );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );
@@ -602,7 +602,7 @@ void test7( const bool use_topology )
     EXPECT_EQ( data.size(), 1 );
 
     // Check the migration.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host(
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host(
         "data_host", distributor->totalNumImport() );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );
@@ -685,7 +685,7 @@ void test8( const bool use_topology )
     Cabana::migrate( *distributor, data );
 
     // Check the results.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host( "data_host",
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host( "data_host",
                                                            data.size() );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -95,7 +95,7 @@ void test1( const bool use_topology )
     Cabana::gather( *halo, data );
 
     // Check the results of the gather.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host(
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host(
         "data_host", halo->numLocal() + halo->numGhost() );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );
@@ -292,7 +292,7 @@ void test2( const bool use_topology )
     Cabana::gather( *halo, data );
 
     // Check the results of the gather.
-    Cabana::AoSoA<DataTypes, Cabana::HostSpace> data_host(
+    Cabana::AoSoA<DataTypes, Kokkos::HostSpace> data_host(
         "data_host", halo->numLocal() + halo->numGhost() );
     auto slice_int_host = Cabana::slice<0>( data_host );
     auto slice_dbl_host = Cabana::slice<1>( data_host );


### PR DESCRIPTION
Fixup for #207 and more deprecation

Turns out that `#if __has_cpp_attribute( deprecated ) && __cpluplus >= 201402L` does not work as intended.  I decided to add a CMake compile feature to the `cabanacore` target instead.
Note that this is another step towards requiring C++14...