### PR TITLE
CabanaConfig.cmake: remember where kokkos came from

### DIFF
--- a/core/src/CabanaConfig.cmakein
+++ b/core/src/CabanaConfig.cmakein
@@ -1,4 +1,7 @@
 include(CMakeFindDependencyMacro)
+if(NOT DEFINED Kokkos_DIR)
+  set(Kokkos_DIR @Kokkos_DIR@)
+endif()
 find_dependency(Kokkos REQUIRED)
 if(@Cabana_ENABLE_MPI@)
   find_dependency(MPI REQUIRED CXX)


### PR DESCRIPTION
@rfbird does this change with picking up the same kokkos with setting `CMAKE_PREFIX_PATH`?