### PR TITLE
Do not remove reference in type traits

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -51,8 +51,7 @@ struct is_aosoa_impl<AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>>
 };
 
 template <class T>
-struct is_aosoa : public is_aosoa_impl<typename std::remove_cv<
-                      typename std::remove_reference<T>::type>::type>::type
+struct is_aosoa : public is_aosoa_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -153,8 +153,7 @@ struct is_distributor_impl<Distributor<DeviceType>> : public std::true_type
 
 template <class T>
 struct is_distributor
-    : public is_distributor_impl<typename std::remove_cv<
-          typename std::remove_reference<T>::type>::type>::type
+    : public is_distributor_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -195,8 +195,7 @@ struct is_halo_impl<Halo<DeviceType>> : public std::true_type
 };
 
 template <class T>
-struct is_halo : public is_halo_impl<typename std::remove_cv<
-                     typename std::remove_reference<T>::type>::type>::type
+struct is_halo : public is_halo_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -294,8 +294,7 @@ struct is_linked_cell_list_impl<LinkedCellList<DeviceType>>
 
 template <class T>
 struct is_linked_cell_list
-    : public is_linked_cell_list_impl<typename std::remove_cv<
-          typename std::remove_reference<T>::type>::type>::type
+    : public is_linked_cell_list_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_MemberTypes.hpp
+++ b/core/src/Cabana_MemberTypes.hpp
@@ -42,8 +42,7 @@ struct is_member_types_impl<MemberTypes<Types...>> : public std::true_type
 
 template <class T>
 struct is_member_types
-    : public is_member_types_impl<typename std::remove_cv<
-          typename std::remove_reference<T>::type>::type>::type
+    : public is_member_types_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -823,8 +823,7 @@ struct is_slice_impl<
 };
 
 template <class T>
-struct is_slice : public is_slice_impl<typename std::remove_cv<
-                      typename std::remove_reference<T>::type>::type>::type
+struct is_slice : public is_slice_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -41,8 +41,7 @@ struct is_soa_impl<SoA<DataTypes, VectorLength>> : public std::true_type
 };
 
 template <class T>
-struct is_soa : public is_soa_impl<typename std::remove_cv<
-                    typename std::remove_reference<T>::type>::type>::type
+struct is_soa : public is_soa_impl<typename std::remove_cv<T>::type>::type
 {
 };
 

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -41,8 +41,7 @@ struct is_tuple_impl<Tuple<DataTypes>> : public std::true_type
 };
 
 template <class T>
-struct is_tuple : public is_tuple_impl<typename std::remove_cv<
-                      typename std::remove_reference<T>::type>::type>::type
+struct is_tuple : public is_tuple_impl<typename std::remove_cv<T>::type>::type
 {
 };
 


### PR DESCRIPTION
Fixup for #205

I realized I should not have removed the reference to be consistent with the type traits in the standard library.