### PR TITLE
Only pass non-empty parallel labels

### DIFF
--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -66,9 +66,9 @@ KOKKOS_FORCEINLINE_FUNCTION
   \param functor The vectorized functor to execute in parallel. Must accept
   both a struct and array index.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 
   A "functor" is a callable object containing the function to execute in
   parallel, data needed for that execution, and an optional \c execution_space
@@ -172,12 +172,14 @@ class TeamVectorOpTag
 
   \param list The neighbor list over which to execute the neighbor operations.
 
-  \param Algorithm tag indicating a serial loop strategy over particle
+  \param neighborstag Iteration tag indicating operations over particle first
   neighbors.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param optag Algorithm tag indicating a serial loop strategy over neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 
   A "functor" is a class containing the function to execute in parallel, data
   needed for that execution, and an optional \c execution_space typedef.  Here
@@ -250,15 +252,14 @@ inline void neighbor_parallel_for(
 
   \param list The neighbor list over which to execute the neighbor operations.
 
-  \param tag Algorithm tag indicating a serial loop strategy over particle
-  neighbors.
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
 
-  \param tag Algorithm tag indicating a serial loop strategy over particle
-  angular neighbors.
+  \param optag Algorithm tag indicating a serial loop strategy over neighbors.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
@@ -320,12 +321,14 @@ inline void neighbor_parallel_for(
 
   \param list The neighbor list over which to execute the neighbor operations.
 
-  \param tag Algorithm tag indicating a team parallel strategy over particle
+  \param neighborstag Iteration tag indicating operations over particle first
   neighbors.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param optag Algorithm tag indicating a team parallel strategy over neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 
   A "functor" is a class containing the function to execute in parallel, data
   needed for that execution, and an optional \c execution_space typedef.  Here
@@ -409,15 +412,15 @@ inline void neighbor_parallel_for(
 
   \param list The neighbor list over which to execute the neighbor operations.
 
-  \param tag Algorithm tag indicating a team parallel strategy over particle
-  neighbors.
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
 
-  \param tag Algorithm tag indicating a serial loop strategy over particle
-  angular neighbors.
+  \param optag Algorithm tag indicating a team parallel strategy over particle
+  first neighbors and serial execution over second neighbors.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
@@ -488,15 +491,15 @@ inline void neighbor_parallel_for(
 
   \param list The neighbor list over which to execute the neighbor operations.
 
-  \param tag Algorithm tag indicating a team parallel strategy over particle
-  neighbors.
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
 
-  \param tag Algorithm tag indicating a vector parallel loop strategy over
-  particle angular neighbors.
+  \param optag Algorithm tag indicating a team parallel strategy over particle
+  first neighbors and vector parallel loop strategy over second neighbors.
 
-  \param str An optional name for the functor. Will be forwarded to the
-  Kokkos::parallel_for called by this code and can be used for identification
-  and profiling purposes.
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_for called by this code and can be used for
+  identification and profiling purposes.
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -778,21 +778,21 @@ void testAngularParallelFor()
 TEST( TEST_CATEGORY, linked_cell_stencil_test ) { testLinkedCellStencil(); }
 
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, linked_cell_list_full_test )
+TEST( TEST_CATEGORY, verlet_list_full_test )
 {
     testVerletListFull<Cabana::VerletLayoutCSR>();
     testVerletListFull<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, linked_cell_list_half_test )
+TEST( TEST_CATEGORY, verlet_list_half_test )
 {
     testVerletListHalf<Cabana::VerletLayoutCSR>();
     testVerletListHalf<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, linked_cell_list_full_range_test )
+TEST( TEST_CATEGORY, verlet_list_full_range_test )
 {
     testVerletListFullPartialRange<Cabana::VerletLayoutCSR>();
     testVerletListFullPartialRange<Cabana::VerletLayout2D>();

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -615,10 +615,10 @@ void testNeighborParallelFor()
     Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, aosoa.size() );
     Cabana::neighbor_parallel_for( policy, serial_count_op, nlist,
                                    Cabana::FirstNeighborsTag(),
-                                   Cabana::SerialOpTag() );
+                                   Cabana::SerialOpTag(), "test_1st_serial" );
     Cabana::neighbor_parallel_for( policy, team_count_op, nlist,
                                    Cabana::FirstNeighborsTag(),
-                                   Cabana::TeamOpTag() );
+                                   Cabana::TeamOpTag(), "test_1st_team" );
     Kokkos::fence();
 
     // Get the expected result in serial
@@ -736,13 +736,13 @@ void testAngularParallelFor()
     Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, aosoa.size() );
     Cabana::neighbor_parallel_for( policy, serial_count_op, nlist,
                                    Cabana::SecondNeighborsTag(),
-                                   Cabana::SerialOpTag() );
+                                   Cabana::SerialOpTag(), "test_2nd_serial" );
     Cabana::neighbor_parallel_for( policy, team_count_op, nlist,
                                    Cabana::SecondNeighborsTag(),
-                                   Cabana::TeamOpTag() );
-    Cabana::neighbor_parallel_for( policy, vector_count_op, nlist,
-                                   Cabana::SecondNeighborsTag(),
-                                   Cabana::TeamVectorOpTag() );
+                                   Cabana::TeamOpTag(), "test_2nd_team" );
+    Cabana::neighbor_parallel_for(
+        policy, vector_count_op, nlist, Cabana::SecondNeighborsTag(),
+        Cabana::TeamVectorOpTag(), "test_2nd_vector" );
     Kokkos::fence();
 
     // Get the expected result in serial


### PR DESCRIPTION
~~Deprecate~~ Only forward labels with `simd_parallel_for` and `neighbor_parallel_for` if not empty ~~and add required label versions~~. This was discussed in #183 