### PR TITLE
Add neighbor_parallel_reduce

### DIFF
--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -609,8 +609,8 @@ inline void neighbor_parallel_for(
   the Kokkos::parallel_reduce called by this code and can be used for
   identification and profiling purposes.
 */
-template <class FunctorType, class NeighborListType, class... ExecParameters,
-          class ReduceType>
+template <class FunctorType, class NeighborListType, class ReduceType,
+          class... ExecParameters>
 inline void neighbor_parallel_reduce(
     const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
     const FunctorType &functor, const NeighborListType &list,
@@ -679,8 +679,8 @@ inline void neighbor_parallel_reduce(
   the Kokkos::parallel_reduce called by this code and can be used for
   identification and profiling purposes.
 */
-template <class FunctorType, class NeighborListType, class... ExecParameters,
-          class ReduceType>
+template <class FunctorType, class NeighborListType, class ReduceType,
+          class... ExecParameters>
 inline void neighbor_parallel_reduce(
     const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
     const FunctorType &functor, const NeighborListType &list,
@@ -755,8 +755,8 @@ inline void neighbor_parallel_reduce(
   the Kokkos::parallel_reduce called by this code and can be used for
   identification and profiling purposes.
 */
-template <class FunctorType, class NeighborListType, class... ExecParameters,
-          class ReduceType>
+template <class FunctorType, class NeighborListType, class ReduceType,
+          class... ExecParameters>
 inline void neighbor_parallel_reduce(
     const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
     const FunctorType &functor, const NeighborListType &list,
@@ -840,8 +840,8 @@ inline void neighbor_parallel_reduce(
   the Kokkos::parallel_reduce called by this code and can be used for
   identification and profiling purposes.
 */
-template <class FunctorType, class NeighborListType, class... ExecParameters,
-          class ReduceType>
+template <class FunctorType, class NeighborListType, class ReduceType,
+          class... ExecParameters>
 inline void neighbor_parallel_reduce(
     const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
     const FunctorType &functor, const NeighborListType &list,
@@ -930,8 +930,8 @@ inline void neighbor_parallel_reduce(
   the Kokkos::parallel_reduce called by this code and can be used for
   identification and profiling purposes.
 */
-template <class FunctorType, class NeighborListType, class... ExecParameters,
-          class ReduceType>
+template <class FunctorType, class NeighborListType, class ReduceType,
+          class... ExecParameters>
 inline void neighbor_parallel_reduce(
     const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
     const FunctorType &functor, const NeighborListType &list,

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -46,6 +46,29 @@ KOKKOS_FORCEINLINE_FUNCTION
     functor( t, std::forward<IndexTypes>( indices )... );
 }
 
+// No work tag was provided so call reduce without a tag argument.
+template <class WorkTag, class FunctorType, class... IndexTypes,
+          class ReduceType>
+KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if<std::is_same<WorkTag, void>::value>::type
+    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices,
+                        ReduceType &reduce_val )
+{
+    functor( std::forward<IndexTypes>( indices )..., reduce_val );
+}
+
+// The user gave us a tag so call the reduce version using that.
+template <class WorkTag, class FunctorType, class... IndexTypes,
+          class ReduceType>
+KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if<!std::is_same<WorkTag, void>::value>::type
+    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices,
+                        ReduceType &reduce_val )
+{
+    const WorkTag t{};
+    functor( t, std::forward<IndexTypes>( indices )..., reduce_val );
+}
+
 } // end namespace Impl
 
 //---------------------------------------------------------------------------//
@@ -158,7 +181,7 @@ class TeamVectorOpTag
 //---------------------------------------------------------------------------//
 /*!
   \brief Execute \c functor in parallel according to the execution \c policy
-  with a thread-local serial loop over particle neighbors.
+  with a thread-local serial loop over particle first neighbors.
 
   \tparam FunctorType The functor type to execute.
 
@@ -237,8 +260,7 @@ inline void neighbor_parallel_for(
 //---------------------------------------------------------------------------//
 /*!
   \brief Execute \c functor in parallel according to the execution \c policy
-  with a thread-local serial loop over particle neighbors and serial loop over
-  particle angular neighbors.
+  with thread-local serial loops over particle first and second neighbors.
 
   \tparam ExecutionSpace The execution space in which to execute the functor.
 
@@ -307,7 +329,7 @@ inline void neighbor_parallel_for(
 //---------------------------------------------------------------------------//
 /*!
   \brief Execute \c functor in parallel according to the execution \c policy
-  with team parallelism over particle neighbors.
+  with team parallelism over particle first neighbors.
 
   \tparam ExecutionSpace The execution space in which to execute the functor.
 
@@ -397,8 +419,8 @@ inline void neighbor_parallel_for(
 //---------------------------------------------------------------------------//
 /*!
   \brief Execute \c functor in parallel according to the execution \c policy
-  with team parallelism over particle neighbors and serial loop over particle
-  angular neighbors.
+  with team parallelism over particle first neighbors and serial loop over
+  second neighbors.
 
   \tparam ExecutionSpace The execution space in which to execute the functor.
 
@@ -476,8 +498,8 @@ inline void neighbor_parallel_for(
 //---------------------------------------------------------------------------//
 /*!
   \brief Execute \c functor in parallel according to the execution \c policy
-  with team parallelism over particle neighbors and vector loop parallelism over
-  particle angular neighbors.
+  with team parallelism over particle first neighbors and vector loop
+  parallelism over second neighbors.
 
   \tparam ExecutionSpace The execution space in which to execute the functor.
 
@@ -552,6 +574,422 @@ inline void neighbor_parallel_for(
         Kokkos::parallel_for( team_policy, neigh_func );
     else
         Kokkos::parallel_for( str, team_policy, neigh_func );
+}
+
+//---------------------------------------------------------------------------//
+// Neighbor Parallel Reduce
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute \c functor reduction in parallel according to the execution \c
+  policy with a thread-local serial loop over particle first neighbors.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam NeighborListType The neighbor list type.
+
+  \tparam ExecParams The Kokkos range policy parameters.
+
+  \tparam ReduceType The reduction type.
+
+  \param exec_policy The policy over which to execute the functor.
+
+  \param functor The functor to execute in parallel
+
+  \param list The neighbor list over which to execute the neighbor operations.
+
+  \param neighborstag Iteration tag indicating operations over particle first
+  neighbors.
+
+  \param optag Algorithm tag indicating a serial loop strategy over particle
+  neighbors.
+
+  \param reduce_val Scalar to be reduced across particles and neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_reduce called by this code and can be used for
+  identification and profiling purposes.
+*/
+template <class FunctorType, class NeighborListType, class... ExecParameters,
+          class ReduceType>
+inline void neighbor_parallel_reduce(
+    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
+    const FunctorType &functor, const NeighborListType &list,
+    const FirstNeighborsTag, const SerialOpTag, ReduceType &reduce_val,
+    const std::string &str = "" )
+{
+    using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
+
+    using execution_space =
+        typename Kokkos::RangePolicy<ExecParameters...>::execution_space;
+
+    using index_type =
+        typename Kokkos::RangePolicy<ExecParameters...>::index_type;
+
+    using neighbor_list_traits = NeighborList<NeighborListType>;
+
+    using memory_space = typename neighbor_list_traits::memory_space;
+
+    static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
+
+    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType &ival )
+    {
+        for ( index_type n = 0;
+              n < neighbor_list_traits::numNeighbor( list, i ); ++n )
+            Impl::functorTagDispatch<work_tag>(
+                functor, i,
+                static_cast<index_type>(
+                    neighbor_list_traits::getNeighbor( list, i, n ) ),
+                ival );
+    };
+    if ( str.empty() )
+        Kokkos::parallel_reduce( exec_policy, neigh_reduce, reduce_val );
+    else
+        Kokkos::parallel_reduce( str, exec_policy, neigh_reduce, reduce_val );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute \c functor reduction in parallel according to the execution \c
+  policy with thread-local serial loops over particle first and second
+  neighbors.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam NeighborListType The neighbor list type.
+
+  \tparam ExecParams The Kokkos range policy parameters.
+
+  \tparam ReduceType The reduction type.
+
+  \param exec_policy The policy over which to execute the functor.
+
+  \param functor The functor to execute in parallel
+
+  \param list The neighbor list over which to execute the neighbor operations.
+
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
+
+  \param optag Algorithm tag indicating a serial loop strategy over particle
+  neighbors.
+
+  \param reduce_val Scalar to be reduced across particles and neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_reduce called by this code and can be used for
+  identification and profiling purposes.
+*/
+template <class FunctorType, class NeighborListType, class... ExecParameters,
+          class ReduceType>
+inline void neighbor_parallel_reduce(
+    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
+    const FunctorType &functor, const NeighborListType &list,
+    const SecondNeighborsTag, const SerialOpTag, ReduceType &reduce_val,
+    const std::string &str = "" )
+{
+    using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
+
+    using execution_space =
+        typename Kokkos::RangePolicy<ExecParameters...>::execution_space;
+
+    using index_type =
+        typename Kokkos::RangePolicy<ExecParameters...>::index_type;
+
+    using neighbor_list_traits = NeighborList<NeighborListType>;
+
+    using memory_space = typename neighbor_list_traits::memory_space;
+
+    static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
+
+    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType &ival )
+    {
+        const index_type nn = neighbor_list_traits::numNeighbor( list, i );
+
+        for ( index_type n = 0; n < nn; ++n )
+        {
+            const index_type j =
+                neighbor_list_traits::getNeighbor( list, i, n );
+
+            for ( index_type a = n + 1; a < nn; ++a )
+            {
+                const index_type k =
+                    neighbor_list_traits::getNeighbor( list, i, a );
+                Impl::functorTagDispatch<work_tag>( functor, i, j, k, ival );
+            }
+        }
+    };
+    if ( str.empty() )
+        Kokkos::parallel_reduce( exec_policy, neigh_reduce, reduce_val );
+    else
+        Kokkos::parallel_reduce( str, exec_policy, neigh_reduce, reduce_val );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute \c functor reduction in parallel according to the execution \c
+  policy with team parallelism over particle first neighbors.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam NeighborListType The neighbor list type.
+
+  \tparam ExecParams The Kokkos range policy parameters.
+
+  \tparam ReduceType The reduction type.
+
+  \param exec_policy The policy over which to execute the functor.
+
+  \param functor The functor to execute in parallel
+
+  \param list The neighbor list over which to execute the neighbor operations.
+
+  \param neighborstag Iteration tag indicating operations over particle first
+  neighbors.
+
+  \param optag Algorithm tag indicating a team parallel strategy over particle
+  neighbors.
+
+  \param reduce_val Scalar to be reduced across particles and neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_reduce called by this code and can be used for
+  identification and profiling purposes.
+*/
+template <class FunctorType, class NeighborListType, class... ExecParameters,
+          class ReduceType>
+inline void neighbor_parallel_reduce(
+    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
+    const FunctorType &functor, const NeighborListType &list,
+    const FirstNeighborsTag, const TeamOpTag, ReduceType &reduce_val,
+    const std::string &str = "" )
+{
+    using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
+
+    using execution_space =
+        typename Kokkos::RangePolicy<ExecParameters...>::execution_space;
+
+    using kokkos_policy =
+        Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
+    kokkos_policy team_policy( exec_policy.end() - exec_policy.begin(),
+                               Kokkos::AUTO );
+
+    using index_type = typename kokkos_policy::index_type;
+
+    using neighbor_list_traits = NeighborList<NeighborListType>;
+
+    using memory_space = typename neighbor_list_traits::memory_space;
+
+    static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
+
+    const auto range_begin = exec_policy.begin();
+
+    auto neigh_reduce = KOKKOS_LAMBDA(
+        const typename kokkos_policy::member_type &team, ReduceType &ival )
+    {
+        index_type i = team.league_rank() + range_begin;
+        ReduceType reduce_n = 0;
+
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(
+                team, neighbor_list_traits::numNeighbor( list, i ) ),
+            [&]( const index_type n, ReduceType &nval ) {
+                Impl::functorTagDispatch<work_tag>(
+                    functor, i,
+                    static_cast<index_type>(
+                        neighbor_list_traits::getNeighbor( list, i, n ) ),
+                    nval );
+            },
+            reduce_n );
+        ival += reduce_n;
+    };
+    if ( str.empty() )
+        Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );
+    else
+        Kokkos::parallel_reduce( str, team_policy, neigh_reduce, reduce_val );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute \c functor reduction in parallel according to the execution \c
+  policy with team parallelism over particle first neighbors and serial loop
+  over second neighbors.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam NeighborListType The neighbor list type.
+
+  \tparam ExecParams The Kokkos range policy parameters.
+
+  \tparam ReduceType The reduction type.
+
+  \param exec_policy The policy over which to execute the functor.
+
+  \param functor The functor to execute in parallel
+
+  \param list The neighbor list over which to execute the neighbor operations.
+
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
+
+  \param optag Algorithm tag indicating a team parallel strategy over particle
+  first neighbors and serial loops over second neighbors.
+
+  \param reduce_val Scalar to be reduced across particles and neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_reduce called by this code and can be used for
+  identification and profiling purposes.
+*/
+template <class FunctorType, class NeighborListType, class... ExecParameters,
+          class ReduceType>
+inline void neighbor_parallel_reduce(
+    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
+    const FunctorType &functor, const NeighborListType &list,
+    const SecondNeighborsTag, const TeamOpTag, ReduceType &reduce_val,
+    const std::string &str = "" )
+{
+    using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
+
+    using execution_space =
+        typename Kokkos::RangePolicy<ExecParameters...>::execution_space;
+
+    using kokkos_policy =
+        Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
+    kokkos_policy team_policy( exec_policy.end() - exec_policy.begin(),
+                               Kokkos::AUTO );
+
+    using index_type = typename kokkos_policy::index_type;
+
+    using neighbor_list_traits = NeighborList<NeighborListType>;
+
+    using memory_space = typename neighbor_list_traits::memory_space;
+
+    static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
+
+    const auto range_begin = exec_policy.begin();
+
+    auto neigh_reduce = KOKKOS_LAMBDA(
+        const typename kokkos_policy::member_type &team, ReduceType &ival )
+    {
+        index_type i = team.league_rank() + range_begin;
+        ReduceType reduce_n = 0;
+
+        const index_type nn = neighbor_list_traits::numNeighbor( list, i );
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange( team, nn ),
+            [&]( const index_type n, ReduceType &nval ) {
+                const index_type j =
+                    neighbor_list_traits::getNeighbor( list, i, n );
+
+                for ( index_type a = n + 1; a < nn; ++a )
+                {
+                    const index_type k =
+                        neighbor_list_traits::getNeighbor( list, i, a );
+                    Impl::functorTagDispatch<work_tag>( functor, i, j, k,
+                                                        nval );
+                }
+            },
+            reduce_n );
+        ival += reduce_n;
+    };
+    if ( str.empty() )
+        Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );
+    else
+        Kokkos::parallel_reduce( str, team_policy, neigh_reduce, reduce_val );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute \c functor reduction in parallel according to the execution \c
+  policy with team parallelism over particle first neighbors and vector loop
+  parallelism over second neighbors.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam NeighborListType The neighbor list type.
+
+  \tparam ExecParams The Kokkos range policy parameters.
+
+  \tparam ReduceType The reduction type.
+
+  \param exec_policy The policy over which to execute the functor.
+
+  \param functor The functor to execute in parallel
+
+  \param list The neighbor list over which to execute the neighbor operations.
+
+  \param neighborstag Iteration tag indicating operations over particle first
+  and second neighbors.
+
+  \param optag Algorithm tag indicating a team parallel strategy over particle
+  first neighbors and vector loops over second neighbors.
+
+  \param reduce_val Scalar to be reduced across particles and neighbors.
+
+  \param str Optional name for the functor. Will be forwarded if non-empty to
+  the Kokkos::parallel_reduce called by this code and can be used for
+  identification and profiling purposes.
+*/
+template <class FunctorType, class NeighborListType, class... ExecParameters,
+          class ReduceType>
+inline void neighbor_parallel_reduce(
+    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
+    const FunctorType &functor, const NeighborListType &list,
+    const SecondNeighborsTag, const TeamVectorOpTag, ReduceType &reduce_val,
+    const std::string &str = "" )
+{
+    using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
+
+    using execution_space =
+        typename Kokkos::RangePolicy<ExecParameters...>::execution_space;
+
+    using kokkos_policy =
+        Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
+    kokkos_policy team_policy( exec_policy.end() - exec_policy.begin(),
+                               Kokkos::AUTO );
+
+    using index_type = typename kokkos_policy::index_type;
+
+    using neighbor_list_traits = NeighborList<NeighborListType>;
+
+    using memory_space = typename neighbor_list_traits::memory_space;
+
+    static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
+
+    const auto range_begin = exec_policy.begin();
+
+    auto neigh_reduce = KOKKOS_LAMBDA(
+        const typename kokkos_policy::member_type &team, ReduceType &ival )
+    {
+        index_type i = team.league_rank() + range_begin;
+        ReduceType reduce_n = 0;
+
+        const index_type nn = neighbor_list_traits::numNeighbor( list, i );
+        Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange( team, nn ),
+            [&]( const index_type n, ReduceType &nval ) {
+                const index_type j =
+                    neighbor_list_traits::getNeighbor( list, i, n );
+                ReduceType reduce_a = 0;
+
+                Kokkos::parallel_reduce(
+                    Kokkos::ThreadVectorRange( team, n + 1, nn ),
+                    [&]( const index_type a, ReduceType &aval ) {
+                        const index_type k =
+                            neighbor_list_traits::getNeighbor( list, i, a );
+                        Impl::functorTagDispatch<work_tag>( functor, i, j, k,
+                                                            aval );
+                    },
+                    reduce_a );
+                nval += reduce_a;
+            },
+            reduce_n );
+        ival += reduce_n;
+    };
+    if ( str.empty() )
+        Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );
+    else
+        Kokkos::parallel_reduce( str, team_policy, neigh_reduce, reduce_val );
 }
 
 } // end namespace Cabana

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -800,7 +800,7 @@ inline void neighbor_parallel_reduce(
                     nval );
             },
             reduce_n );
-        ival += reduce_n;
+        Kokkos::single( Kokkos::PerTeam( team ), [&]() { ival += reduce_n; } );
     };
     if ( str.empty() )
         Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );
@@ -890,7 +890,7 @@ inline void neighbor_parallel_reduce(
                 }
             },
             reduce_n );
-        ival += reduce_n;
+        Kokkos::single( Kokkos::PerTeam( team ), [&]() { ival += reduce_n; } );
     };
     if ( str.empty() )
         Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );
@@ -984,7 +984,7 @@ inline void neighbor_parallel_reduce(
                 nval += reduce_a;
             },
             reduce_n );
-        ival += reduce_n;
+        Kokkos::single( Kokkos::PerTeam( team ), [&]() { ival += reduce_n; } );
     };
     if ( str.empty() )
         Kokkos::parallel_reduce( team_policy, neigh_reduce, reduce_val );

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -816,10 +816,13 @@ void testFirstNeighborParallelReduce()
     // Get the expected result in serial
     auto test_list = computeFullNeighborList( positions, test_radius );
     auto test_list_copy = createTestListHostCopy( test_list );
+    auto aosoa_mirror =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto positions_mirror = Cabana::slice<0>( aosoa_mirror );
     for ( int p = 0; p < num_particle; ++p )
         for ( int n = 0; n < test_list_copy.counts( p ); ++n )
-            test_sum += positions( p, 0 ) +
-                        positions( test_list_copy.neighbors( p, n ), 0 );
+            test_sum += positions_mirror( p, 0 ) +
+                        positions_mirror( test_list_copy.neighbors( p, n ), 0 );
 
     // Check the result.
     EXPECT_FLOAT_EQ( test_sum, serial_sum );
@@ -875,12 +878,16 @@ void testSecondNeighborParallelReduce()
     // Get the expected result in serial
     auto test_list = computeFullNeighborList( positions, test_radius );
     auto test_list_copy = createTestListHostCopy( test_list );
+    auto aosoa_mirror =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto positions_mirror = Cabana::slice<0>( aosoa_mirror );
     for ( int p = 0; p < num_particle; ++p )
         for ( int n = 0; n < test_list_copy.counts( p ); ++n )
             for ( int a = n + 1; a < test_list_copy.counts( p ); ++a )
-                test_sum += positions( p, 0 ) +
-                            positions( test_list_copy.neighbors( p, n ), 0 ) +
-                            positions( test_list_copy.neighbors( p, a ), 0 );
+                test_sum +=
+                    positions_mirror( p, 0 ) +
+                    positions_mirror( test_list_copy.neighbors( p, n ), 0 ) +
+                    positions_mirror( test_list_copy.neighbors( p, a ), 0 );
 
     // Check the result.
     EXPECT_FLOAT_EQ( test_sum, serial_sum );

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -567,7 +567,7 @@ void testVerletListHalf()
 
 //---------------------------------------------------------------------------//
 template <class LayoutTag>
-void testNeighborParallelFor()
+void testFirstNeighborParallelFor()
 {
     // Create the AoSoA and fill with random particle positions.
     int num_particle = 1e3;
@@ -677,7 +677,7 @@ void testVerletListFullPartialRange()
 
 //---------------------------------------------------------------------------//
 template <class LayoutTag>
-void testAngularParallelFor()
+void testSecondNeighborParallelFor()
 {
     // Create the AoSoA and fill with random particle positions.
     int num_particle = 1e3;
@@ -773,6 +773,122 @@ void testAngularParallelFor()
 }
 
 //---------------------------------------------------------------------------//
+template <class LayoutTag>
+void testFirstNeighborParallelReduce()
+{
+    // Create the AoSoA and fill with random particle positions.
+    int num_particle = 1e3;
+    double test_radius = 2.32;
+    double cell_size_ratio = 0.5;
+    double box_min = -5.3 * test_radius;
+    double box_max = 4.7 * test_radius;
+    auto aosoa = createParticles( num_particle, box_min, box_max );
+    auto positions = Cabana::slice<0>( aosoa );
+
+    // Create the neighbor list.
+    using ListType =
+        Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>;
+    double grid_min[3] = {box_min, box_min, box_min};
+    double grid_max[3] = {box_max, box_max, box_max};
+    ListType nlist( positions, 0, aosoa.size(), test_radius, cell_size_ratio,
+                    grid_min, grid_max );
+
+    // Reduction variables
+    double test_sum = 0;
+    double serial_sum = 0;
+    double team_sum = 0;
+
+    // Test the list parallel operation by adding a value from each neighbor
+    // to the particle and compare to counts.
+    auto sum_op = KOKKOS_LAMBDA( const int i, const int n, double &sum )
+    {
+        sum += positions( i, 0 ) + positions( n, 0 );
+    };
+    Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, aosoa.size() );
+    Cabana::neighbor_parallel_reduce(
+        policy, sum_op, nlist, Cabana::FirstNeighborsTag(),
+        Cabana::SerialOpTag(), serial_sum, "test_reduce_serial" );
+    Cabana::neighbor_parallel_reduce(
+        policy, sum_op, nlist, Cabana::FirstNeighborsTag(), Cabana::TeamOpTag(),
+        team_sum, "test_reduce_team" );
+    Kokkos::fence();
+
+    // Get the expected result in serial
+    auto test_list = computeFullNeighborList( positions, test_radius );
+    auto test_list_copy = createTestListHostCopy( test_list );
+    for ( int p = 0; p < num_particle; ++p )
+        for ( int n = 0; n < test_list_copy.counts( p ); ++n )
+            test_sum += positions( p, 0 ) +
+                        positions( test_list_copy.neighbors( p, n ), 0 );
+
+    // Check the result.
+    EXPECT_FLOAT_EQ( test_sum, serial_sum );
+    EXPECT_FLOAT_EQ( test_sum, team_sum );
+}
+
+//---------------------------------------------------------------------------//
+template <class LayoutTag>
+void testSecondNeighborParallelReduce()
+{
+    // Create the AoSoA and fill with random particle positions.
+    int num_particle = 1e3;
+    double test_radius = 2.32;
+    double cell_size_ratio = 0.5;
+    double box_min = -5.3 * test_radius;
+    double box_max = 4.7 * test_radius;
+    auto aosoa = createParticles( num_particle, box_min, box_max );
+    auto positions = Cabana::slice<0>( aosoa );
+
+    // Create the neighbor list.
+    using ListType =
+        Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag>;
+    double grid_min[3] = {box_min, box_min, box_min};
+    double grid_max[3] = {box_max, box_max, box_max};
+    ListType nlist( positions, 0, aosoa.size(), test_radius, cell_size_ratio,
+                    grid_min, grid_max );
+
+    // Reduction variables
+    double test_sum = 0;
+    double serial_sum = 0;
+    double team_sum = 0;
+    double vector_sum = 0;
+
+    // Test the list parallel operation by adding a value from each neighbor
+    // to the particle and compare to counts.
+    auto sum_op =
+        KOKKOS_LAMBDA( const int i, const int n, const int a, double &sum )
+    {
+        sum += positions( i, 0 ) + positions( n, 0 ) + positions( a, 0 );
+    };
+    Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, aosoa.size() );
+    Cabana::neighbor_parallel_reduce(
+        policy, sum_op, nlist, Cabana::SecondNeighborsTag(),
+        Cabana::SerialOpTag(), serial_sum, "test_reduce_serial" );
+    Cabana::neighbor_parallel_reduce(
+        policy, sum_op, nlist, Cabana::SecondNeighborsTag(),
+        Cabana::TeamOpTag(), team_sum, "test_reduce_team" );
+    Cabana::neighbor_parallel_reduce(
+        policy, sum_op, nlist, Cabana::SecondNeighborsTag(),
+        Cabana::TeamVectorOpTag(), vector_sum, "test_reduce_vector" );
+    Kokkos::fence();
+
+    // Get the expected result in serial
+    auto test_list = computeFullNeighborList( positions, test_radius );
+    auto test_list_copy = createTestListHostCopy( test_list );
+    for ( int p = 0; p < num_particle; ++p )
+        for ( int n = 0; n < test_list_copy.counts( p ); ++n )
+            for ( int a = n + 1; a < test_list_copy.counts( p ); ++a )
+                test_sum += positions( p, 0 ) +
+                            positions( test_list_copy.neighbors( p, n ), 0 ) +
+                            positions( test_list_copy.neighbors( p, a ), 0 );
+
+    // Check the result.
+    EXPECT_FLOAT_EQ( test_sum, serial_sum );
+    EXPECT_FLOAT_EQ( test_sum, team_sum );
+    EXPECT_FLOAT_EQ( test_sum, vector_sum );
+}
+
+//---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, linked_cell_stencil_test ) { testLinkedCellStencil(); }
@@ -801,13 +917,22 @@ TEST( TEST_CATEGORY, verlet_list_full_range_test )
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, parallel_for_test )
 {
-    testNeighborParallelFor<Cabana::VerletLayoutCSR>();
-    testNeighborParallelFor<Cabana::VerletLayout2D>();
+    testFirstNeighborParallelFor<Cabana::VerletLayoutCSR>();
+    testFirstNeighborParallelFor<Cabana::VerletLayout2D>();
 
-    testAngularParallelFor<Cabana::VerletLayoutCSR>();
-    testAngularParallelFor<Cabana::VerletLayout2D>();
+    testSecondNeighborParallelFor<Cabana::VerletLayoutCSR>();
+    testSecondNeighborParallelFor<Cabana::VerletLayout2D>();
 }
 
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, parallel_reduce_test )
+{
+    testFirstNeighborParallelReduce<Cabana::VerletLayoutCSR>();
+    testFirstNeighborParallelReduce<Cabana::VerletLayout2D>();
+
+    testSecondNeighborParallelReduce<Cabana::VerletLayoutCSR>();
+    testSecondNeighborParallelReduce<Cabana::VerletLayout2D>();
+}
 //---------------------------------------------------------------------------//
 
 } // end namespace Test


### PR DESCRIPTION
This adds `neighbor_parallel_reduce` options that mirror the `neighbor_parallel_for`. I'll use these to give energy calculation the same flexibility as current force calculation (particularly where force and energy computes are fused). 

I didn't add a `simd_parallel_reduce`, but can if there's a use case