### PR TITLE
Remove ghosted global index spaces

### DIFF
--- a/cajita/src/Cajita_LocalGrid.cpp
+++ b/cajita/src/Cajita_LocalGrid.cpp
@@ -113,14 +113,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Cell t2, Global ) const
 }
 
 //---------------------------------------------------------------------------//
-// Get the global index space of the owned and ghosted cells.
-template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Cell t2, Global ) const
-{
-    return globalIndexSpace( t1, t2 );
-}
-
-//---------------------------------------------------------------------------//
 // Given a relative set of indices of a neighbor get the set of local cell
 // indices we own that we share with that neighbor to use as ghosts.
 template <class MeshType>
@@ -324,14 +316,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Node t2, Global ) const
 }
 
 //---------------------------------------------------------------------------//
-// Get the global index space of the owned and ghosted nodes.
-template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Node t2, Global ) const
-{
-    return globalIndexSpace( t1, t2 );
-}
-
-//---------------------------------------------------------------------------//
 // Given a relative set of indices of a neighbor get the set of local node
 // indices we own that we share with that neighbor to use as ghosts.
 template <class MeshType>
@@ -500,14 +484,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Face<Dim::I> t2,
 
 //---------------------------------------------------------------------------//
 template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Face<Dim::I> t2,
-                                               Global t3 ) const
-{
-    return faceIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::sharedIndexSpace( Own t1, Face<Dim::I> t2,
                                                      const int i, const int j,
                                                      const int k,
@@ -545,14 +521,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Face<Dim::J> t2,
 //---------------------------------------------------------------------------//
 template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Face<Dim::J> t2,
-                                               Global t3 ) const
-{
-    return faceIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Face<Dim::J> t2,
                                                Global t3 ) const
 {
     return faceIndexSpace( t1, t2, t3 );
@@ -604,14 +572,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Face<Dim::K> t2,
 
 //---------------------------------------------------------------------------//
 template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Face<Dim::K> t2,
-                                               Global t3 ) const
-{
-    return faceIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::sharedIndexSpace( Own t1, Face<Dim::K> t2,
                                                      const int i, const int j,
                                                      const int k,
@@ -649,14 +609,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Edge<Dim::I> t2,
 //---------------------------------------------------------------------------//
 template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Edge<Dim::I> t2,
-                                               Global t3 ) const
-{
-    return edgeIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Edge<Dim::I> t2,
                                                Global t3 ) const
 {
     return edgeIndexSpace( t1, t2, t3 );
@@ -708,14 +660,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Edge<Dim::J> t2,
 
 //---------------------------------------------------------------------------//
 template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Edge<Dim::J> t2,
-                                               Global t3 ) const
-{
-    return edgeIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::sharedIndexSpace( Own t1, Edge<Dim::J> t2,
                                                      const int i, const int j,
                                                      const int k,
@@ -760,14 +704,6 @@ IndexSpace<3> LocalGrid<MeshType>::indexSpace( Own t1, Edge<Dim::K> t2,
 
 //---------------------------------------------------------------------------//
 template <class MeshType>
-IndexSpace<3> LocalGrid<MeshType>::indexSpace( Ghost t1, Edge<Dim::K> t2,
-                                               Global t3 ) const
-{
-    return edgeIndexSpace( t1, t2, t3 );
-}
-
-//---------------------------------------------------------------------------//
-template <class MeshType>
 IndexSpace<3> LocalGrid<MeshType>::sharedIndexSpace( Own t1, Edge<Dim::K> t2,
                                                      const int i, const int j,
                                                      const int k,
@@ -787,7 +723,7 @@ IndexSpace<3> LocalGrid<MeshType>::sharedIndexSpace( Ghost t1, Edge<Dim::K> t2,
 }
 
 //---------------------------------------------------------------------------//
-// Get the global index space of the owned cells.
+// Get the global index space of the owned entities.
 template <class MeshType>
 template <class EntityType>
 IndexSpace<3> LocalGrid<MeshType>::globalIndexSpace( Own, EntityType ) const
@@ -799,25 +735,6 @@ IndexSpace<3> LocalGrid<MeshType>::globalIndexSpace( Own, EntityType ) const
     {
         min[d] = _global_grid->globalOffset( d );
         max[d] = min[d] + local_space.extent( d );
-    }
-
-    return IndexSpace<3>( min, max );
-}
-
-//---------------------------------------------------------------------------//
-// Get the global index space of the owned and ghosted cells.
-template <class MeshType>
-template <class EntityType>
-IndexSpace<3> LocalGrid<MeshType>::globalIndexSpace( Ghost, EntityType ) const
-{
-    auto own_local_space = indexSpace( Own(), EntityType(), Local() );
-    auto ghost_local_space = indexSpace( Ghost(), EntityType(), Local() );
-    std::array<long, 3> min;
-    std::array<long, 3> max;
-    for ( int d = 0; d < 3; ++d )
-    {
-        min[d] = _global_grid->globalOffset( d ) - own_local_space.min( d );
-        max[d] = min[d] + ghost_local_space.extent( d );
     }
 
     return IndexSpace<3>( min, max );
@@ -901,16 +818,6 @@ IndexSpace<3> LocalGrid<MeshType>::faceIndexSpace( Ghost, Face<Dir>,
 template <class MeshType>
 template <int Dir>
 IndexSpace<3> LocalGrid<MeshType>::faceIndexSpace( Own t1, Face<Dir> t2,
-                                                   Global ) const
-{
-    return globalIndexSpace( t1, t2 );
-}
-
-//---------------------------------------------------------------------------//
-// Get the global index space of the owned and ghosted nodes.
-template <class MeshType>
-template <int Dir>
-IndexSpace<3> LocalGrid<MeshType>::faceIndexSpace( Ghost t1, Face<Dir> t2,
                                                    Global ) const
 {
     return globalIndexSpace( t1, t2 );
@@ -1148,16 +1055,6 @@ IndexSpace<3> LocalGrid<MeshType>::edgeIndexSpace( Own t1, Edge<Dir> t2,
 }
 
 //---------------------------------------------------------------------------//
-// Get the global index space of the owned and ghosted nodes.
-template <class MeshType>
-template <int Dir>
-IndexSpace<3> LocalGrid<MeshType>::edgeIndexSpace( Ghost t1, Edge<Dir> t2,
-                                                   Global ) const
-{
-    return globalIndexSpace( t1, t2 );
-}
-
-//---------------------------------------------------------------------------//
 // Given a relative set of indices of a neighbor get the set of local
 // Dir-direction edge indices we own that we share with that neighbor to use
 // as ghosts.
@@ -1313,62 +1210,30 @@ LocalGrid<MeshType>::edgeSharedIndexSpace( Ghost, Edge<Dir>, const int off_i,
         DECOMP, ENTITY ) const;
 
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Own, Cell )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Ghost, Cell )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Own, Node )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Ghost, Node )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Own, Face<Dim::I> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Ghost,
-                                        Face<Dim::I> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Own, Face<Dim::J> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Ghost,
-                                        Face<Dim::J> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Own, Face<Dim::K> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, float, Ghost,
-                                        Face<Dim::K> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Own, Cell )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Ghost, Cell )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Own, Node )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Ghost, Node )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Own, Face<Dim::I> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Ghost,
-                                        Face<Dim::I> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Own, Face<Dim::J> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Ghost,
-                                        Face<Dim::J> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Own, Face<Dim::K> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( UniformMesh, double, Ghost,
-                                        Face<Dim::K> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Own, Cell )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Ghost, Cell )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Own, Node )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Ghost, Node )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Own,
-                                        Face<Dim::I> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Ghost,
                                         Face<Dim::I> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Own,
                                         Face<Dim::J> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Ghost,
-                                        Face<Dim::J> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Own,
-                                        Face<Dim::K> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, float, Ghost,
                                         Face<Dim::K> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Own, Cell )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost, Cell )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Own, Node )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost, Node )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Own,
-                                        Face<Dim::I> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost,
                                         Face<Dim::I> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Own,
                                         Face<Dim::J> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost,
-                                        Face<Dim::J> )
 CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Own,
-                                        Face<Dim::K> )
-CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost,
                                         Face<Dim::K> )
 
 //---------------------------------------------------------------------------//
@@ -1381,84 +1246,60 @@ CAJITA_INST_LOCALGRID_GLOBALINDEXSPACE( NonUniformMesh, double, Ghost,
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::I, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::I, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::I, Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::J, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::J, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::J, Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::K, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Own, Dim::K, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::K, Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, float, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::I, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::I, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::J, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::J, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::K, Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Own, Dim::K, Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( UniformMesh, double, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::I,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::I,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::J,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::J,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::K,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Own, Dim::K,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::I,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::I,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::J,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::J,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::K,
                                       Local )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Own, Dim::K,
                                       Global )
 CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_FACEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::K,
-                                      Global )
 
 #define CAJITA_INST_LOCALGRID_FACESHAREDINDEXSPACE( MESH, FP, DECOMP, DIM )    \
     template IndexSpace<3> LocalGrid<MESH<FP>>::faceSharedIndexSpace(          \
@@ -1508,84 +1349,60 @@ CAJITA_INST_LOCALGRID_FACESHAREDINDEXSPACE( NonUniformMesh, float, Ghost,
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::I, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::I, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::I, Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::J, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::J, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::J, Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::K, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Own, Dim::K, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::K, Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, float, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::I, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::I, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::J, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::J, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::K, Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Own, Dim::K, Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( UniformMesh, double, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::I,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::I,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::J,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::J,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::K,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Own, Dim::K,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, float, Ghost, Dim::K,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::I,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::I,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::I,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::I,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::J,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::J,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::J,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::J,
-                                      Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::K,
                                       Local )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Own, Dim::K,
                                       Global )
 CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::K,
                                       Local )
-CAJITA_INST_LOCALGRID_EDGEINDEXSPACE( NonUniformMesh, double, Ghost, Dim::K,
-                                      Global )
 
 #define CAJITA_INST_LOCALGRID_EDGESHAREDINDEXSPACE( MESH, FP, DECOMP, DIM )    \
     template IndexSpace<3> LocalGrid<MESH<FP>>::edgeSharedIndexSpace(          \

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -67,42 +67,34 @@ class LocalGrid
     IndexSpace<3> indexSpace( Own, Cell, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Cell, Local ) const;
     IndexSpace<3> indexSpace( Own, Cell, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Cell, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Node, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Node, Local ) const;
     IndexSpace<3> indexSpace( Own, Node, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Node, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Face<Dim::I>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Face<Dim::I>, Local ) const;
     IndexSpace<3> indexSpace( Own, Face<Dim::I>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Face<Dim::I>, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Face<Dim::J>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Face<Dim::J>, Local ) const;
     IndexSpace<3> indexSpace( Own, Face<Dim::J>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Face<Dim::J>, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Face<Dim::K>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Face<Dim::K>, Local ) const;
     IndexSpace<3> indexSpace( Own, Face<Dim::K>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Face<Dim::K>, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Edge<Dim::I>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Edge<Dim::I>, Local ) const;
     IndexSpace<3> indexSpace( Own, Edge<Dim::I>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Edge<Dim::I>, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Edge<Dim::J>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Edge<Dim::J>, Local ) const;
     IndexSpace<3> indexSpace( Own, Edge<Dim::J>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Edge<Dim::J>, Global ) const;
 
     IndexSpace<3> indexSpace( Own, Edge<Dim::K>, Local ) const;
     IndexSpace<3> indexSpace( Ghost, Edge<Dim::K>, Local ) const;
     IndexSpace<3> indexSpace( Own, Edge<Dim::K>, Global ) const;
-    IndexSpace<3> indexSpace( Ghost, Edge<Dim::K>, Global ) const;
 
     /*
        Given a relative set of indices of a neighbor get the set of local
@@ -189,8 +181,6 @@ class LocalGrid
     // Get the global index space of the local grid.
     template <class EntityType>
     IndexSpace<3> globalIndexSpace( Own, EntityType ) const;
-    template <class EntityType>
-    IndexSpace<3> globalIndexSpace( Ghost, EntityType ) const;
 
     // Get the face index space of the local grid.
     template <int Dir>
@@ -199,8 +189,6 @@ class LocalGrid
     IndexSpace<3> faceIndexSpace( Own, Face<Dir>, Global ) const;
     template <int Dir>
     IndexSpace<3> faceIndexSpace( Ghost, Face<Dir>, Local ) const;
-    template <int Dir>
-    IndexSpace<3> faceIndexSpace( Ghost, Face<Dir>, Global ) const;
 
     // Given a relative set of indices of a neighbor get the set of local
     // face indices shared with that neighbor in the given decomposition.
@@ -220,8 +208,6 @@ class LocalGrid
     IndexSpace<3> edgeIndexSpace( Own, Edge<Dir>, Global ) const;
     template <int Dir>
     IndexSpace<3> edgeIndexSpace( Ghost, Edge<Dir>, Local ) const;
-    template <int Dir>
-    IndexSpace<3> edgeIndexSpace( Ghost, Edge<Dir>, Global ) const;
 
     // Given a relative set of indices of a neighbor get the set of local
     // edge indices shared with that neighbor in the given decomposition.

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -147,25 +147,6 @@ void periodicTest()
                    owned_cell_space.extent( d ) + 2 * halo_width );
     }
 
-    // Check the global ghosted cell bounds.
-    auto global_ghosted_cell_space =
-        local_grid->indexSpace( Ghost(), Cell(), Global() );
-    EXPECT_EQ( global_ghosted_cell_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_cell_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_cells[Dim::I] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_cell_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_cell_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_cells[Dim::J] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_cell_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_cell_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] +
-                   halo_width );
-
     // Check the cells we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -416,25 +397,6 @@ void periodicTest()
                    owned_node_space.extent( d ) + 2 * halo_width + 1 );
     }
 
-    // Check the ghosted global node bounds.
-    auto global_ghosted_node_space =
-        local_grid->indexSpace( Ghost(), Node(), Global() );
-    EXPECT_EQ( global_ghosted_node_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_node_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_nodes[Dim::I] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_node_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_node_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_nodes[Dim::J] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_node_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_node_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_nodes[Dim::K] +
-                   halo_width + 1 );
-
     // Check the nodes we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -671,24 +633,6 @@ void periodicTest()
                global_grid->globalOffset( Dim::K ) );
     EXPECT_EQ( global_owned_i_face_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] );
-
-    auto global_ghosted_i_face_space =
-        local_grid->indexSpace( Ghost(), Face<Dim::I>(), Global() );
-    EXPECT_EQ( global_ghosted_i_face_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_face_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_nodes[Dim::I] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_i_face_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_face_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_cells[Dim::J] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_i_face_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_face_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] +
-                   halo_width );
 
     // Check the I-faces we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
@@ -927,24 +871,6 @@ void periodicTest()
     EXPECT_EQ( global_owned_j_face_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] );
 
-    auto global_ghosted_j_face_space =
-        local_grid->indexSpace( Ghost(), Face<Dim::J>(), Global() );
-    EXPECT_EQ( global_ghosted_j_face_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_face_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_cells[Dim::I] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_j_face_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_face_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_nodes[Dim::J] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_j_face_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_face_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] +
-                   halo_width );
-
     // Check the j-faces we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -1088,24 +1014,6 @@ void periodicTest()
     EXPECT_EQ( global_owned_k_face_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_nodes[Dim::K] );
 
-    auto global_ghosted_k_face_space =
-        local_grid->indexSpace( Ghost(), Face<Dim::K>(), Global() );
-    EXPECT_EQ( global_ghosted_k_face_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_face_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_cells[Dim::I] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_k_face_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_face_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_cells[Dim::J] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_k_face_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_face_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_nodes[Dim::K] +
-                   halo_width + 1 );
-
     // Check the k-faces we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -1248,24 +1156,6 @@ void periodicTest()
                global_grid->globalOffset( Dim::K ) );
     EXPECT_EQ( global_owned_i_edge_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] );
-
-    auto global_ghosted_i_edge_space =
-        local_grid->indexSpace( Ghost(), Edge<Dim::I>(), Global() );
-    EXPECT_EQ( global_ghosted_i_edge_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_edge_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_nodes[Dim::I] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_i_edge_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_edge_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_cells[Dim::J] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_i_edge_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_i_edge_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] +
-                   halo_width + 1 );
 
     // Check the I-edges we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
@@ -1504,24 +1394,6 @@ void periodicTest()
     EXPECT_EQ( global_owned_j_edge_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] );
 
-    auto global_ghosted_j_edge_space =
-        local_grid->indexSpace( Ghost(), Edge<Dim::J>(), Global() );
-    EXPECT_EQ( global_ghosted_j_edge_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_edge_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_cells[Dim::I] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_j_edge_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_edge_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_nodes[Dim::J] +
-                   halo_width );
-    EXPECT_EQ( global_ghosted_j_edge_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_j_edge_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_cells[Dim::K] +
-                   halo_width + 1 );
-
     // Check the j-edges we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -1664,24 +1536,6 @@ void periodicTest()
                global_grid->globalOffset( Dim::K ) );
     EXPECT_EQ( global_owned_k_edge_space.max( Dim::K ),
                global_grid->globalOffset( Dim::K ) + local_num_nodes[Dim::K] );
-
-    auto global_ghosted_k_edge_space =
-        local_grid->indexSpace( Ghost(), Edge<Dim::K>(), Global() );
-    EXPECT_EQ( global_ghosted_k_edge_space.min( Dim::I ),
-               global_grid->globalOffset( Dim::I ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_edge_space.max( Dim::I ),
-               global_grid->globalOffset( Dim::I ) + local_num_cells[Dim::I] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_k_edge_space.min( Dim::J ),
-               global_grid->globalOffset( Dim::J ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_edge_space.max( Dim::J ),
-               global_grid->globalOffset( Dim::J ) + local_num_cells[Dim::J] +
-                   halo_width + 1 );
-    EXPECT_EQ( global_ghosted_k_edge_space.min( Dim::K ),
-               global_grid->globalOffset( Dim::K ) - halo_width );
-    EXPECT_EQ( global_ghosted_k_edge_space.max( Dim::K ),
-               global_grid->globalOffset( Dim::K ) + local_num_nodes[Dim::K] +
-                   halo_width );
 
     // Check the k-edges we own that we will share with our neighbors. Cover
     // enough of the neighbors that we know the bounds are correct in each

--- a/cajita/unit_test/tstLocalMesh.hpp
+++ b/cajita/unit_test/tstLocalMesh.hpp
@@ -569,8 +569,6 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
         local_grid->indexSpace( Ghost(), Cell(), Local() );
     auto own_cell_global_space =
         local_grid->indexSpace( Own(), Cell(), Global() );
-    auto ghost_cell_global_space =
-        local_grid->indexSpace( Ghost(), Cell(), Global() );
     auto own_cell_local_space =
         local_grid->indexSpace( Own(), Cell(), Local() );
 
@@ -613,18 +611,24 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
                      k_func( own_cell_global_space.max( Dim::K ) ) );
 
     EXPECT_FLOAT_EQ( ghost_lc_m( Dim::I ),
-                     i_func( ghost_cell_global_space.min( Dim::I ) ) );
+                     i_func( own_cell_global_space.min( Dim::I ) -
+                             own_cell_local_space.min( Dim::I ) ) );
     EXPECT_FLOAT_EQ( ghost_lc_m( Dim::J ),
-                     j_func( ghost_cell_global_space.min( Dim::J ) ) );
+                     j_func( own_cell_global_space.min( Dim::J ) -
+                             own_cell_local_space.min( Dim::J ) ) );
     EXPECT_FLOAT_EQ( ghost_lc_m( Dim::K ),
-                     k_func( ghost_cell_global_space.min( Dim::K ) ) );
+                     k_func( own_cell_global_space.min( Dim::K ) -
+                             own_cell_local_space.min( Dim::K ) ) );
 
     EXPECT_FLOAT_EQ( ghost_hc_m( Dim::I ),
-                     i_func( ghost_cell_global_space.max( Dim::I ) ) );
+                     i_func( own_cell_global_space.max( Dim::I ) +
+                             own_cell_local_space.min( Dim::I ) ) );
     EXPECT_FLOAT_EQ( ghost_hc_m( Dim::J ),
-                     j_func( ghost_cell_global_space.max( Dim::J ) ) );
+                     j_func( own_cell_global_space.max( Dim::J ) +
+                             own_cell_local_space.min( Dim::J ) ) );
     EXPECT_FLOAT_EQ( ghost_hc_m( Dim::K ),
-                     k_func( ghost_cell_global_space.max( Dim::K ) ) );
+                     k_func( own_cell_global_space.max( Dim::K ) +
+                             own_cell_local_space.min( Dim::K ) ) );
 
     // Check the cell locations and measures.
     auto cell_measure = createView<double, TEST_DEVICE>(
@@ -666,30 +670,42 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
                                  ( j_func( j + 1 ) - j_func( j ) ) *
                                  ( k_func( k + 1 ) - k_func( k ) );
                 double compute_m =
-                    cell_measure_h( i - ghost_cell_global_space.min( Dim::I ),
-                                    j - ghost_cell_global_space.min( Dim::J ),
-                                    k - ghost_cell_global_space.min( Dim::K ) );
+                    cell_measure_h( i - own_cell_global_space.min( Dim::I ) +
+                                        own_cell_local_space.min( Dim::I ),
+                                    j - own_cell_global_space.min( Dim::J ) +
+                                        own_cell_local_space.min( Dim::J ),
+                                    k - own_cell_global_space.min( Dim::K ) +
+                                        own_cell_local_space.min( Dim::K ) );
                 EXPECT_FLOAT_EQ( measure, compute_m );
 
                 double x_loc = ( i_func( i + 1 ) + i_func( i ) ) / 2.0;
-                double compute_x = cell_location_x_h(
-                    i - ghost_cell_global_space.min( Dim::I ),
-                    j - ghost_cell_global_space.min( Dim::J ),
-                    k - ghost_cell_global_space.min( Dim::K ) );
+                double compute_x =
+                    cell_location_x_h( i - own_cell_global_space.min( Dim::I ) +
+                                           own_cell_local_space.min( Dim::I ),
+                                       j - own_cell_global_space.min( Dim::J ) +
+                                           own_cell_local_space.min( Dim::J ),
+                                       k - own_cell_global_space.min( Dim::K ) +
+                                           own_cell_local_space.min( Dim::K ) );
                 EXPECT_FLOAT_EQ( x_loc, compute_x );
 
                 double y_loc = ( j_func( j + 1 ) + j_func( j ) ) / 2.0;
-                double compute_y = cell_location_y_h(
-                    i - ghost_cell_global_space.min( Dim::I ),
-                    j - ghost_cell_global_space.min( Dim::J ),
-                    k - ghost_cell_global_space.min( Dim::K ) );
+                double compute_y =
+                    cell_location_y_h( i - own_cell_global_space.min( Dim::I ) +
+                                           own_cell_local_space.min( Dim::I ),
+                                       j - own_cell_global_space.min( Dim::J ) +
+                                           own_cell_local_space.min( Dim::J ),
+                                       k - own_cell_global_space.min( Dim::K ) +
+                                           own_cell_local_space.min( Dim::K ) );
                 EXPECT_FLOAT_EQ( y_loc, compute_y );
 
                 double z_loc = ( k_func( k + 1 ) + k_func( k ) ) / 2.0;
-                double compute_z = cell_location_z_h(
-                    i - ghost_cell_global_space.min( Dim::I ),
-                    j - ghost_cell_global_space.min( Dim::J ),
-                    k - ghost_cell_global_space.min( Dim::K ) );
+                double compute_z =
+                    cell_location_z_h( i - own_cell_global_space.min( Dim::I ) +
+                                           own_cell_local_space.min( Dim::I ),
+                                       j - own_cell_global_space.min( Dim::J ) +
+                                           own_cell_local_space.min( Dim::J ),
+                                       k - own_cell_global_space.min( Dim::K ) +
+                                           own_cell_local_space.min( Dim::K ) );
                 EXPECT_FLOAT_EQ( z_loc, compute_z );
             }
 }


### PR DESCRIPTION
Some work with boundary conditions in Cajita revealed that we can't produce `IndexSpace` objects which contain `Global` indices in a `Ghost` decomposition and hence they have been removed. 

The reason for this is that `IndexSpace` covers a contiguous set of indices which can be satisfied for `Local` indices in both `Ghost` and `Own` decompositions as well as for `Global` indices in `Own` decompositions. However, when periodicity is used, we no longer have contiguous index sets of `Global` indices in `Ghost` decompositions for boundary blocks (the global indices wrap around the periodic boundary in the halo) and therefore we cannot make an `IndexSpace` of such indices. This makes sense as global indices are globally unique while local indices are not. Hence, the implementation of these was fundamentally a bug.

I am going to make another PR (#251) which builds a global-to-local and local-to-global indexer which should make life easier for implementing boundary conditions.