### PR TITLE
Local-to-Global Cajita Index Conversion

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS_PUBLIC
   Cajita_GlobalGrid.hpp
   Cajita_GlobalMesh.hpp
   Cajita_Halo.hpp
+  Cajita_IndexConversion.hpp
   Cajita_IndexSpace.hpp
   Cajita_Interpolation.hpp
   Cajita_LocalMesh.hpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -18,6 +18,7 @@
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_Halo.hpp>
+#include <Cajita_IndexConversion.hpp>
 #include <Cajita_IndexSpace.hpp>
 #include <Cajita_Interpolation.hpp>
 #include <Cajita_LocalGrid.hpp>

--- a/cajita/src/Cajita_IndexConversion.hpp
+++ b/cajita/src/Cajita_IndexConversion.hpp
@@ -1,0 +1,184 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_INDEXCONVERSION_HPP
+#define CAJITA_INDEXCONVERSION_HPP
+
+#include <Cajita_IndexSpace.hpp>
+#include <Cajita_Types.hpp>
+
+#include <Kokkos_Core.hpp>
+
+namespace Cajita
+{
+namespace IndexConversion
+{
+//---------------------------------------------------------------------------//
+// Local-to-global indexer
+template <class MeshType, class EntityType>
+struct L2G
+{
+    // Mesh type
+    using mesh_type = MeshType;
+
+    // Entity type.
+    using entity_type = EntityType;
+
+    // Owned local indices minimum.
+    Kokkos::Array<int, 3> local_own_min;
+
+    // Owned local indices maximum.
+    Kokkos::Array<int, 3> local_own_max;
+
+    // Owned global indices minimum.
+    Kokkos::Array<int, 3> global_own_min;
+
+    // Global number of entities.
+    Kokkos::Array<int, 3> global_num_entity;
+
+    // Periodicity.
+    Kokkos::Array<bool, 3> periodic;
+
+    // True if block is on low boundary.
+    Kokkos::Array<bool, 3> boundary_lo;
+
+    // True if block is on high boundary.
+    Kokkos::Array<bool, 3> boundary_hi;
+
+    // Constructor.
+    L2G( const LocalGrid<MeshType> &local_grid )
+    {
+        // Local index set of owned entities.
+        auto local_own_space =
+            local_grid.indexSpace( Own(), EntityType(), Local() );
+
+        // Get the local owned min.
+        for ( int d = 0; d < 3; ++d )
+            local_own_min[d] = local_own_space.min( d );
+
+        // Get the local owned max.
+        for ( int d = 0; d < 3; ++d )
+            local_own_max[d] = local_own_space.max( d );
+
+        // Global index set of owned entities.
+        auto global_own_space =
+            local_grid.indexSpace( Own(), EntityType(), Global() );
+
+        // Get the global owned min.
+        for ( int d = 0; d < 3; ++d )
+            global_own_min[d] = global_own_space.min( d );
+
+        // Get the global grid.
+        const auto &global_grid = local_grid.globalGrid();
+
+        // Global number of entities.
+        for ( int d = 0; d < 3; ++d )
+            global_num_entity[d] =
+                global_grid.globalNumEntity( EntityType(), d );
+
+        // Periodicity
+        for ( int d = 0; d < 3; ++d )
+            periodic[d] = global_grid.isPeriodic( d );
+
+        // Determine if a block is on the low or high boundaries.
+        for ( int d = 0; d < 3; ++d )
+        {
+            auto block = global_grid.dimBlockId( d );
+            boundary_lo[d] = ( 0 == block );
+            boundary_hi[d] = ( global_grid.dimNumBlock( d ) - 1 == block );
+        }
+    }
+
+    // Convert local indices to global indices.
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const int li, const int lj, const int lk, int &gi, int &gj,
+                     int &gk ) const
+    {
+        // I
+        // Compute periodic wrap-around on low I boundary.
+        if ( periodic[Dim::I] && li < local_own_min[Dim::I] &&
+             boundary_lo[Dim::I] )
+        {
+            gi = global_num_entity[Dim::I] - local_own_min[Dim::I] + li;
+        }
+
+        // Compute periodic wrap-around on high I boundary.
+        else if ( periodic[Dim::I] && local_own_max[Dim::I] <= li &&
+                  boundary_hi[Dim::I] )
+        {
+            gi = li - local_own_max[Dim::I];
+        }
+
+        // Otherwise compute I indices as normal.
+        else
+        {
+            gi = li - local_own_min[Dim::I] + global_own_min[Dim::I];
+        }
+
+        // J
+        // Compute periodic wrap-around on low J boundary.
+        if ( periodic[Dim::J] && lj < local_own_min[Dim::J] &&
+             boundary_lo[Dim::J] )
+        {
+            gj = global_num_entity[Dim::J] - local_own_min[Dim::J] + lj;
+        }
+
+        // Compute periodic wrap-around on high J boundary.
+        else if ( periodic[Dim::J] && local_own_max[Dim::J] <= lj &&
+                  boundary_hi[Dim::J] )
+        {
+            gj = lj - local_own_max[Dim::J];
+        }
+
+        // Otherwise compute J indices as normal.
+        else
+        {
+            gj = lj - local_own_min[Dim::J] + global_own_min[Dim::J];
+        }
+
+        // K
+        // Compute periodic wrap-around on low K boundary.
+        if ( periodic[Dim::K] && lk < local_own_min[Dim::K] &&
+             boundary_lo[Dim::K] )
+        {
+            gk = global_num_entity[Dim::K] - local_own_min[Dim::K] + lk;
+        }
+
+        // Compute periodic wrap-around on high K boundary.
+        else if ( periodic[Dim::K] && local_own_max[Dim::K] <= lk &&
+                  boundary_hi[Dim::K] )
+        {
+            gk = lk - local_own_max[Dim::K];
+        }
+
+        // Otherwise compute K indices as normal.
+        else
+        {
+            gk = lk - local_own_min[Dim::K] + global_own_min[Dim::K];
+        }
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Creation function.
+template <class MeshType, class EntityType>
+L2G<MeshType, EntityType> createL2G( const LocalGrid<MeshType> &local_grid,
+                                     EntityType )
+{
+    return L2G<MeshType, EntityType>( local_grid );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace IndexConversion
+} // end namespace Cajita
+
+#endif // end CAJITA_INDEXCONVERSION_HPP

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SERIAL_TESTS
 set(MPI_TESTS
   GlobalGrid
   LocalGrid
+  IndexConversion
   LocalMesh
   Array
   Halo

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -1,0 +1,193 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita_Array.hpp>
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_Halo.hpp>
+#include <Cajita_IndexConversion.hpp>
+#include <Cajita_IndexSpace.hpp>
+#include <Cajita_LocalGrid.hpp>
+#include <Cajita_Types.hpp>
+#include <Cajita_UniformDimPartitioner.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+#include <array>
+#include <numeric>
+
+using namespace Cajita;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+template <class EntityType>
+void testConversion( const std::array<bool, 3> &is_dim_periodic )
+{
+    // Let MPI compute the partitioning for this test.
+    UniformDimPartitioner partitioner;
+
+    // Create the global mesh.
+    double cell_size = 0.23;
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2]};
+    auto global_mesh = createUniformGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Create the global grid.
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Create a local grid.
+    int halo_width = 3;
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+
+    // Create an array for global node indices.
+    auto array_layout = createArrayLayout( local_grid, 3, EntityType() );
+    auto global_index_array =
+        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+    auto index_view = global_index_array->view();
+
+    // Fill the owned array with global indices.
+    auto own_local_space =
+        local_grid->indexSpace( Own(), EntityType(), Local() );
+    auto own_global_space =
+        local_grid->indexSpace( Own(), EntityType(), Global() );
+    Kokkos::parallel_for(
+        "fill_indices",
+        createExecutionPolicy( own_global_space, TEST_EXECSPACE() ),
+        KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+            int li = i - own_global_space.min( Dim::I ) +
+                     own_local_space.min( Dim::I );
+            int lj = j - own_global_space.min( Dim::J ) +
+                     own_local_space.min( Dim::J );
+            int lk = k - own_global_space.min( Dim::K ) +
+                     own_local_space.min( Dim::K );
+            index_view( li, lj, lk, Dim::I ) = i;
+            index_view( li, lj, lk, Dim::J ) = j;
+            index_view( li, lj, lk, Dim::K ) = k;
+        } );
+
+    // Gather to get the ghosted global indices.
+    auto halo = createHalo( *global_index_array, FullHaloPattern() );
+    halo->gather( *global_index_array );
+
+    // Do a loop over ghosted local indices and fill with the index
+    // conversion.
+    auto global_l2g_array =
+        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+    auto l2g_view = global_l2g_array->view();
+    auto ghost_local_space =
+        local_grid->indexSpace( Ghost(), EntityType(), Local() );
+    auto l2g = IndexConversion::createL2G( *local_grid, EntityType() );
+    Kokkos::parallel_for(
+        "fill_l2g",
+        createExecutionPolicy( ghost_local_space, TEST_EXECSPACE() ),
+        KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+            int gi, gj, gk;
+            l2g( i, j, k, gi, gj, gk );
+            l2g_view( i, j, k, Dim::I ) = gi;
+            l2g_view( i, j, k, Dim::J ) = gj;
+            l2g_view( i, j, k, Dim::K ) = gk;
+        } );
+
+    // Compare the results.
+    auto index_view_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), index_view );
+    auto l2g_view_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), l2g_view );
+    for ( int i = ghost_local_space.min( Dim::I );
+          i < ghost_local_space.max( Dim::I ); ++i )
+        for ( int j = ghost_local_space.min( Dim::J );
+              j < ghost_local_space.max( Dim::J ); ++j )
+            for ( int k = ghost_local_space.min( Dim::K );
+                  k < ghost_local_space.max( Dim::K ); ++k )
+                for ( int d = 0; d < 3; ++d )
+                    EXPECT_EQ( l2g_view_host( i, j, k, d ),
+                               index_view_host( i, j, k, d ) );
+}
+
+//---------------------------------------------------------------------------//
+TEST( index_conversion, node_periodic_test )
+{
+    testConversion<Node>( {{true, true, true}} );
+}
+TEST( index_conversion, cell_periodic_test )
+{
+    testConversion<Cell>( {{true, true, true}} );
+}
+TEST( index_conversion, face_i_periodic_test )
+{
+    testConversion<Face<Dim::I>>( {{true, true, true}} );
+}
+TEST( index_conversion, face_j_periodic_test )
+{
+    testConversion<Face<Dim::J>>( {{true, true, true}} );
+}
+TEST( index_conversion, face_k_periodic_test )
+{
+    testConversion<Face<Dim::K>>( {{true, true, true}} );
+}
+TEST( index_conversion, edge_i_periodic_test )
+{
+    testConversion<Edge<Dim::I>>( {{true, true, true}} );
+}
+TEST( index_conversion, edge_j_periodic_test )
+{
+    testConversion<Edge<Dim::J>>( {{true, true, true}} );
+}
+TEST( index_conversion, edge_k_periodic_test )
+{
+    testConversion<Edge<Dim::K>>( {{true, true, true}} );
+}
+
+TEST( index_conversion, node_not_periodic_test )
+{
+    testConversion<Node>( {{false, false, false}} );
+}
+TEST( index_conversion, cell_not_periodic_test )
+{
+    testConversion<Cell>( {{false, false, false}} );
+}
+TEST( index_conversion, face_i_not_periodic_test )
+{
+    testConversion<Face<Dim::I>>( {{false, false, false}} );
+}
+TEST( index_conversion, face_j_not_periodic_test )
+{
+    testConversion<Face<Dim::J>>( {{false, false, false}} );
+}
+TEST( index_conversion, face_k_not_periodic_test )
+{
+    testConversion<Face<Dim::K>>( {{false, false, false}} );
+}
+TEST( index_conversion, edge_i_not_periodic_test )
+{
+    testConversion<Edge<Dim::I>>( {{false, false, false}} );
+}
+TEST( index_conversion, edge_j_not_periodic_test )
+{
+    testConversion<Edge<Dim::J>>( {{false, false, false}} );
+}
+TEST( index_conversion, edge_k_not_periodic_test )
+{
+    testConversion<Edge<Dim::K>>( {{false, false, false}} );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
A follow on to #250. This PR allows for the proper computation of global indices from local indices within a parallel for including global indices in a halo region. The converter is implemented as a functor over a given local grid and entity type. 

Note that we do not provide a global-to-local index converter as, per the bug in #250, is often ambiguous and therefore not possible to implement.