### PR TITLE
Update Interpolation

### DIFF
--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -48,7 +48,7 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "G2P::value requires spline weight values" );
 
     result = 0.0;
@@ -77,7 +77,7 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "G2P::value requires spline weight values" );
 
     for ( int d = 0; d < 3; ++d )
@@ -108,9 +108,9 @@ gradient( const ViewType &view, const SplineDataType &sd,
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                   void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "G2P::gradient requires spline weight values" );
-    static_assert( SplineDataType::has_weight_physical_gradients::value,
+    static_assert( SplineDataType::has_weight_physical_gradients,
                    "G2P::gradient requires spline weight physical gradients" );
 
     for ( int d = 0; d < 3; ++d )
@@ -152,9 +152,9 @@ gradient( const ViewType &view, const SplineDataType &sd,
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                   void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "G2P::gradient requires spline weight values" );
-    static_assert( SplineDataType::has_weight_physical_gradients::value,
+    static_assert( SplineDataType::has_weight_physical_gradients,
                    "G2P::gradient requires spline weight physical gradients" );
 
     for ( int d0 = 0; d0 < 3; ++d0 )
@@ -196,10 +196,10 @@ divergence( const ViewType &view, const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "G2P::divergence requires spline weight values" );
     static_assert(
-        SplineDataType::has_weight_physical_gradients::value,
+        SplineDataType::has_weight_physical_gradients,
         "G2P::divergence requires spline weight physical gradients" );
 
     result = 0.0;
@@ -267,7 +267,7 @@ value( const PointDataType &point_data, const SplineDataType &sd,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
 
     static_assert( is_scatter_view<ViewType>::value,
@@ -296,7 +296,7 @@ value( const PointDataType point_data[3], const SplineDataType &sd,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
 
     static_assert( is_scatter_view<ViewType>::value,
@@ -327,9 +327,9 @@ KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
                                       const SplineDataType &sd,
                                       const ViewType &view )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "P2G::gradient requires spline weight values" );
-    static_assert( SplineDataType::has_weight_physical_gradients::value,
+    static_assert( SplineDataType::has_weight_physical_gradients,
                    "P2G::gradient requires spline weight physical gradients" );
 
     static_assert( is_scatter_view<ViewType>::value,
@@ -370,10 +370,10 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "P2G::divergence requires spline weight values" );
     static_assert(
-        SplineDataType::has_weight_physical_gradients::value,
+        SplineDataType::has_weight_physical_gradients,
         "P2G::divergence requires spline weight physical gradients" );
 
     static_assert( is_scatter_view<ViewType>::value,
@@ -414,10 +414,10 @@ divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
-    static_assert( SplineDataType::has_weight_values::value,
+    static_assert( SplineDataType::has_weight_values,
                    "P2G::divergence requires spline weight values" );
     static_assert(
-        SplineDataType::has_weight_physical_gradients::value,
+        SplineDataType::has_weight_physical_gradients,
         "P2G::divergence requires spline weight physical gradients" );
 
     static_assert( is_scatter_view<ViewType>::value,

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -30,14 +30,15 @@ namespace Cajita
 //---------------------------------------------------------------------------//
 
 //---------------------------------------------------------------------------//
-// local grid-to-point.
+// Local grid-to-point.
 //---------------------------------------------------------------------------//
 namespace G2P
 {
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a scalar value to a point.
-  \param view The view of scalar grid data from which to interpolate.
+  \param view A functor with view semantics of scalar grid data from which to
+  interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The scalar value at the point.
 */
@@ -60,7 +61,10 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a vector value to a point.
-  \param view The view of vector grid data from which to interpolate.
+  \param view A functor with view semantics of vector grid data from which to
+  interpolate.
+  \param view A functor with view semantics of scalar grid data from which to
+  interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The vector value at the point.
 */
@@ -86,7 +90,8 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a scalar gradient to a point.
-  \param view The view of scalar grid data from which to interpolate.
+  \param view A functor with view semantics of scalar grid data from which to
+  interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The scalar gradient at the point.
 */
@@ -124,7 +129,8 @@ gradient( const ViewType &view, const SplineDataType &sd,
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a vector gradient to a point.
-  \param view The view of vector grid data from which to interpolate.
+  \param view A functor with view sematics of vector grid data from which to
+  interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The vector gradient at the point.
 */
@@ -162,7 +168,8 @@ gradient( const ViewType &view, const SplineDataType &sd,
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a vector divergence to a point.
-  \param view The view of vector grid data from which to interpolate.
+  \param view A functor with view semantics of vector grid data from which to
+  interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The vector divergence at the point.
 */
@@ -229,7 +236,7 @@ struct is_scatter_view<const Kokkos::Experimental::ScatterView<
   \brief Interpolate a scalar value to the grid.
   \param point_data The scalar value to at the point interpolate to the grid.
   \param sd The spline data to use for the interpolation.
-  \param view The view of scalar grid data to interpolate to.
+  \param view The scatter view of scalar grid data to interpolate to.
 */
 template <class PointDataType, class ViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
@@ -255,7 +262,7 @@ value( const PointDataType &point_data, const SplineDataType &sd,
   \brief Interpolate a vector value to the grid.
   \param point_data The vector value at the point to interpolate to the grid.
   \param sd The spline data to use for the interpolation.
-  \param view The view of vector grid data to interpolate to.
+  \param view The scatter view of vector grid data to interpolate to.
 */
 template <class PointDataType, class ViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
@@ -281,9 +288,11 @@ value( const PointDataType point_data[3], const SplineDataType &sd,
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate the gradient of a scalar to the grid.
-  \param point_data The scalar at the point who's gradient to interpolate to the
-  grid. \param sd The spline data to use for the interpolation. \param view The
-  view of scalar gradient grid data to interpolate to.
+  \param point_data The scalar at the point who's gradient to interpolate to
+  the grid.
+  \param sd The spline data to use for the interpolation.
+  \param view The scatter view of scalar gradient grid data to interpolate
+  to.
 */
 template <class PointDataType, class ViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
@@ -316,8 +325,10 @@ KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
 /*!
   \brief Interpolate the divergence of a vector to the grid.
   \param point_data The vector at the point who's divergence to interpolate to
-  the grid. \param sd The spline data to use for the interpolation. \param view
-  The view of vector divergence grid data to interpolate to.
+  the grid.
+  \param sd The spline data to use for the interpolation.
+  \param view The scatter view of vector divergence grid data to interpolate
+  to.
 */
 template <class PointDataType, class ViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
@@ -352,8 +363,10 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
 /*!
   \brief Interpolate the divergence of a tensor to the grid.
   \param point_data The tensor at the point who's divergence to interpolate to
-  the grid. \param sd The spline data to use for the interpolation. \param view
-  The view of tensor divergence grid data to interpolate to.
+  the grid.
+  \param sd The spline data to use for the interpolation.
+  \param view The scatter view of tensor divergence grid data to interpolate
+  to.
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
@@ -397,7 +410,7 @@ divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
 // Global grid-to-Point
 //---------------------------------------------------------------------------//
 /*
- \brief Local Grid-to-Point interpolation.
+ \brief Global Grid-to-Point interpolation.
 
   \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
   for a given point at a given entity.
@@ -703,7 +716,7 @@ createVectorDivergenceG2P( const ViewType &x,
 // Global point-to-grid
 //---------------------------------------------------------------------------//
 /*!
-  \brief Local Point-to-Grid interpolation.
+  \brief Global Point-to-Grid interpolation.
 
   \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
   for a given point at a given entity.

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -48,6 +48,9 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "G2P::value requires spline weight values" );
+
     result = 0.0;
 
     for ( int i = 0; i < SplineDataType::num_knot; ++i )
@@ -74,6 +77,9 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "G2P::value requires spline weight values" );
+
     for ( int d = 0; d < 3; ++d )
         result[d] = 0.0;
 
@@ -102,6 +108,11 @@ gradient( const ViewType &view, const SplineDataType &sd,
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                   void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "G2P::gradient requires spline weight values" );
+    static_assert( SplineDataType::has_weight_physical_gradients::value,
+                   "G2P::gradient requires spline weight physical gradients" );
+
     for ( int d = 0; d < 3; ++d )
         result[d] = 0.0;
 
@@ -129,7 +140,7 @@ gradient( const ViewType &view, const SplineDataType &sd,
 //---------------------------------------------------------------------------//
 /*!
   \brief Interpolate a vector gradient to a point.
-  \param view A functor with view sematics of vector grid data from which to
+  \param view A functor with view semantics of vector grid data from which to
   interpolate. A value_type type alias is required.
   \param sd The spline data to use for the interpolation.
   \param result The vector gradient at the point.
@@ -141,6 +152,11 @@ gradient( const ViewType &view, const SplineDataType &sd,
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                   void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "G2P::gradient requires spline weight values" );
+    static_assert( SplineDataType::has_weight_physical_gradients::value,
+                   "G2P::gradient requires spline weight physical gradients" );
+
     for ( int d0 = 0; d0 < 3; ++d0 )
         for ( int d1 = 0; d1 < 3; ++d1 )
             result[d0][d1] = 0.0;
@@ -180,6 +196,12 @@ divergence( const ViewType &view, const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "G2P::divergence requires spline weight values" );
+    static_assert(
+        SplineDataType::has_weight_physical_gradients::value,
+        "G2P::divergence requires spline weight physical gradients" );
+
     result = 0.0;
 
     for ( int i = 0; i < SplineDataType::num_knot; ++i )
@@ -245,6 +267,9 @@ value( const PointDataType &point_data, const SplineDataType &sd,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "P2G::value requires spline weight values" );
+
     static_assert( is_scatter_view<ViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
@@ -271,6 +296,9 @@ value( const PointDataType point_data[3], const SplineDataType &sd,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "P2G::value requires spline weight values" );
+
     static_assert( is_scatter_view<ViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
@@ -299,6 +327,11 @@ KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
                                       const SplineDataType &sd,
                                       const ViewType &view )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "P2G::gradient requires spline weight values" );
+    static_assert( SplineDataType::has_weight_physical_gradients::value,
+                   "P2G::gradient requires spline weight physical gradients" );
+
     static_assert( is_scatter_view<ViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
@@ -337,6 +370,12 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "P2G::divergence requires spline weight values" );
+    static_assert(
+        SplineDataType::has_weight_physical_gradients::value,
+        "P2G::divergence requires spline weight physical gradients" );
+
     static_assert( is_scatter_view<ViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
@@ -375,6 +414,12 @@ divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
+    static_assert( SplineDataType::has_weight_values::value,
+                   "P2G::divergence requires spline weight values" );
+    static_assert(
+        SplineDataType::has_weight_physical_gradients::value,
+        "P2G::divergence requires spline weight physical gradients" );
+
     static_assert( is_scatter_view<ViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -260,17 +260,17 @@ struct is_scatter_view<const Kokkos::Experimental::ScatterView<
   \param sd The spline data to use for the interpolation.
   \param view The scatter view of scalar grid data to interpolate to.
 */
-template <class PointDataType, class ViewType, class SplineDataType>
+template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
 value( const PointDataType &point_data, const SplineDataType &sd,
-       const ViewType &view,
+       const ScatterViewType &view,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
 
-    static_assert( is_scatter_view<ViewType>::value,
+    static_assert( is_scatter_view<ScatterViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
 
@@ -289,17 +289,17 @@ value( const PointDataType &point_data, const SplineDataType &sd,
   \param sd The spline data to use for the interpolation.
   \param view The scatter view of vector grid data to interpolate to.
 */
-template <class PointDataType, class ViewType, class SplineDataType>
+template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
 value( const PointDataType point_data[3], const SplineDataType &sd,
-       const ViewType &view,
+       const ScatterViewType &view,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                void *>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
 
-    static_assert( is_scatter_view<ViewType>::value,
+    static_assert( is_scatter_view<ScatterViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
 
@@ -322,17 +322,17 @@ value( const PointDataType point_data[3], const SplineDataType &sd,
   \param view The scatter view of scalar gradient grid data to interpolate
   to.
 */
-template <class PointDataType, class ViewType, class SplineDataType>
+template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
                                       const SplineDataType &sd,
-                                      const ViewType &view )
+                                      const ScatterViewType &view )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::gradient requires spline weight values" );
     static_assert( SplineDataType::has_weight_physical_gradients,
                    "P2G::gradient requires spline weight physical gradients" );
 
-    static_assert( is_scatter_view<ViewType>::value,
+    static_assert( is_scatter_view<ScatterViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
 
@@ -363,10 +363,10 @@ KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
   \param view The scatter view of vector divergence grid data to interpolate
   to.
 */
-template <class PointDataType, class ViewType, class SplineDataType>
+template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
 divergence( const PointDataType point_data[3], const SplineDataType &sd,
-            const ViewType &view,
+            const ScatterViewType &view,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
@@ -376,7 +376,7 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
         SplineDataType::has_weight_physical_gradients,
         "P2G::divergence requires spline weight physical gradients" );
 
-    static_assert( is_scatter_view<ViewType>::value,
+    static_assert( is_scatter_view<ScatterViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
 
@@ -407,10 +407,10 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
   \param view The scatter view of tensor divergence grid data to interpolate
   to.
 */
-template <class ViewType, class SplineDataType, class PointDataType>
+template <class ScatterViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
 divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
-            const ViewType &view,
+            const ScatterViewType &view,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
                                     void *>::type = 0 )
 {
@@ -420,7 +420,7 @@ divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
         SplineDataType::has_weight_physical_gradients,
         "P2G::divergence requires spline weight physical gradients" );
 
-    static_assert( is_scatter_view<ViewType>::value,
+    static_assert( is_scatter_view<ScatterViewType>::value,
                    "P2G requires a Kokkos::ScatterView" );
     auto view_access = view.access();
 

--- a/cajita/src/Cajita_Splines.hpp
+++ b/cajita/src/Cajita_Splines.hpp
@@ -558,11 +558,11 @@ struct SplineData<Scalar, Order, EntityType, void>
     static constexpr int num_knot = spline_type::num_knot;
     using entity_type = EntityType;
 
-    using has_physical_cell_size = std::true_type;
-    using has_logical_position = std::true_type;
-    using has_physical_distance = std::true_type;
-    using has_weight_values = std::true_type;
-    using has_weight_physical_gradients = std::true_type;
+    static constexpr bool has_physical_cell_size = true;
+    static constexpr bool has_logical_position = true;
+    static constexpr bool has_physical_distance = true;
+    static constexpr bool has_weight_values = true;
+    static constexpr bool has_weight_physical_gradients = true;
 
     // Local interpolation stencil.
     int s[3][num_knot];
@@ -581,15 +581,16 @@ struct SplineData<Scalar, Order, EntityType, SplineDataMemberTypes<Tags...>>
 
     using member_tags = SplineDataMemberTypes<Tags...>;
 
-    using has_physical_cell_size =
-        has_spline_tag<SplinePhysicalCellSize, member_tags>;
-    using has_logical_position =
-        has_spline_tag<SplineLogicalPosition, member_tags>;
-    using has_physical_distance =
-        has_spline_tag<SplinePhysicalDistance, member_tags>;
-    using has_weight_values = has_spline_tag<SplineWeightValues, member_tags>;
-    using has_weight_physical_gradients =
-        has_spline_tag<SplineWeightPhysicalGradients, member_tags>;
+    static constexpr bool has_physical_cell_size =
+        has_spline_tag<SplinePhysicalCellSize, member_tags>::value;
+    static constexpr bool has_logical_position =
+        has_spline_tag<SplineLogicalPosition, member_tags>::value;
+    static constexpr bool has_physical_distance =
+        has_spline_tag<SplinePhysicalDistance, member_tags>::value;
+    static constexpr bool has_weight_values =
+        has_spline_tag<SplineWeightValues, member_tags>::value;
+    static constexpr bool has_weight_physical_gradients =
+        has_spline_tag<SplineWeightPhysicalGradients, member_tags>::value;
 
     // Local interpolation stencil.
     int s[3][num_knot];
@@ -597,8 +598,9 @@ struct SplineData<Scalar, Order, EntityType, SplineDataMemberTypes<Tags...>>
 
 // Assign physical cell size to the spline data.
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::true_type, SplinePhysicalCellSize,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    SplineData<Scalar, Order, EntityType, DataTags>::has_physical_cell_size>
+setSplineData( SplinePhysicalCellSize,
                SplineData<Scalar, Order, EntityType, DataTags> &data,
                const int d, const Scalar dx )
 {
@@ -606,8 +608,9 @@ setSplineData( std::true_type, SplinePhysicalCellSize,
 }
 
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::false_type, SplinePhysicalCellSize,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    !SplineData<Scalar, Order, EntityType, DataTags>::has_physical_cell_size>
+setSplineData( SplinePhysicalCellSize,
                SplineData<Scalar, Order, EntityType, DataTags> &, const int,
                const Scalar )
 {
@@ -615,8 +618,9 @@ setSplineData( std::false_type, SplinePhysicalCellSize,
 
 // Assign logical position to the spline data.
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::true_type, SplineLogicalPosition,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    SplineData<Scalar, Order, EntityType, DataTags>::has_logical_position>
+setSplineData( SplineLogicalPosition,
                SplineData<Scalar, Order, EntityType, DataTags> &data,
                const int d, const Scalar x )
 {
@@ -624,8 +628,9 @@ setSplineData( std::true_type, SplineLogicalPosition,
 }
 
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::false_type, SplineLogicalPosition,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    !SplineData<Scalar, Order, EntityType, DataTags>::has_logical_position>
+setSplineData( SplineLogicalPosition,
                SplineData<Scalar, Order, EntityType, DataTags> &, const int,
                const Scalar )
 {
@@ -633,8 +638,9 @@ setSplineData( std::false_type, SplineLogicalPosition,
 
 // Assign weight values to the spline data.
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::true_type, SplineWeightValues,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    SplineData<Scalar, Order, EntityType, DataTags>::has_weight_values>
+setSplineData( SplineWeightValues,
                SplineData<Scalar, Order, EntityType, DataTags> &data,
                const Scalar x[3] )
 
@@ -646,8 +652,9 @@ setSplineData( std::true_type, SplineWeightValues,
 }
 
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::false_type, SplineWeightValues,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    !SplineData<Scalar, Order, EntityType, DataTags>::has_weight_values>
+setSplineData( SplineWeightValues,
                SplineData<Scalar, Order, EntityType, DataTags> &,
                const Scalar[3] )
 
@@ -656,10 +663,12 @@ setSplineData( std::false_type, SplineWeightValues,
 
 // Assign weight physical gradients to the spline data.
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::true_type, SplineWeightPhysicalGradients,
-               SplineData<Scalar, Order, EntityType, DataTags> &data,
-               const Scalar x[3], const Scalar rdx[3] )
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<SplineData<Scalar, Order, EntityType,
+                                DataTags>::has_weight_physical_gradients>
+    setSplineData( SplineWeightPhysicalGradients,
+                   SplineData<Scalar, Order, EntityType, DataTags> &data,
+                   const Scalar x[3], const Scalar rdx[3] )
 
 {
     using spline_type =
@@ -669,18 +678,21 @@ setSplineData( std::true_type, SplineWeightPhysicalGradients,
 }
 
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::false_type, SplineWeightPhysicalGradients,
-               SplineData<Scalar, Order, EntityType, DataTags> &,
-               const Scalar[3], const Scalar[3] )
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<!SplineData<Scalar, Order, EntityType,
+                                 DataTags>::has_weight_physical_gradients>
+    setSplineData( SplineWeightPhysicalGradients,
+                   SplineData<Scalar, Order, EntityType, DataTags> &,
+                   const Scalar[3], const Scalar[3] )
 
 {
 }
 
 // Assign physical distance to the spline data.
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::true_type, SplinePhysicalDistance,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    SplineData<Scalar, Order, EntityType, DataTags>::has_physical_distance>
+setSplineData( SplinePhysicalDistance,
                SplineData<Scalar, Order, EntityType, DataTags> &data,
                const Scalar low_x[3], const Scalar p[3], const Scalar dx[3] )
 
@@ -697,8 +709,9 @@ setSplineData( std::true_type, SplinePhysicalDistance,
 }
 
 template <typename Scalar, int Order, class EntityType, class DataTags>
-KOKKOS_INLINE_FUNCTION void
-setSplineData( std::false_type, SplinePhysicalDistance,
+KOKKOS_INLINE_FUNCTION std::enable_if_t<
+    !SplineData<Scalar, Order, EntityType, DataTags>::has_physical_distance>
+setSplineData( SplinePhysicalDistance,
                SplineData<Scalar, Order, EntityType, DataTags> &,
                const Scalar[3], const Scalar[3], const Scalar[3] )
 {
@@ -728,8 +741,7 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     for ( int d = 0; d < 3; ++d )
     {
         dx[d] = local_mesh.measure( Edge<Dim::I>(), low_id );
-        setSplineData( typename sd_type::has_physical_cell_size(),
-                       SplinePhysicalCellSize(), data, d, dx[d] );
+        setSplineData( SplinePhysicalCellSize(), data, d, dx[d] );
     }
 
     // Compute the inverse physicall cell size.
@@ -742,8 +754,7 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     for ( int d = 0; d < 3; ++d )
     {
         x[d] = sd_type::spline_type::mapToLogicalGrid( p[d], rdx[d], low_x[d] );
-        setSplineData( typename sd_type::has_logical_position(),
-                       SplineLogicalPosition(), data, d, x[d] );
+        setSplineData( SplineLogicalPosition(), data, d, x[d] );
     }
 
     // Compute the stencil.
@@ -753,16 +764,13 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     }
 
     // Compute the weight values.
-    setSplineData( typename sd_type::has_weight_values(), SplineWeightValues(),
-                   data, x );
+    setSplineData( SplineWeightValues(), data, x );
 
     // Compute the weight gradients.
-    setSplineData( typename sd_type::has_weight_physical_gradients(),
-                   SplineWeightPhysicalGradients(), data, x, rdx );
+    setSplineData( SplineWeightPhysicalGradients(), data, x, rdx );
 
     // Compute the physical distance.
-    setSplineData( typename sd_type::has_physical_distance(),
-                   SplinePhysicalDistance(), data, low_x, p, dx );
+    setSplineData( SplinePhysicalDistance(), data, low_x, p, dx );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_Splines.hpp
+++ b/cajita/src/Cajita_Splines.hpp
@@ -449,51 +449,68 @@ struct Spline<3>
 // Spline Data
 //---------------------------------------------------------------------------//
 // Spline data tags.
-struct SplinePhysicalCellSize {};
-struct SplineLogicalPosition {};
-struct SplinePhysicalDistance {};
-struct SplineWeightValues {};
-struct SplineWeightPhysicalGradients{};
+struct SplinePhysicalCellSize
+{
+};
+struct SplineLogicalPosition
+{
+};
+struct SplinePhysicalDistance
+{
+};
+struct SplineWeightValues
+{
+};
+struct SplineWeightPhysicalGradients
+{
+};
 
 // Data members holder
-template<class ... DataTags>
-struct SplineDataMemberTypes {};
+template <class... DataTags>
+struct SplineDataMemberTypes
+{
+};
 
 // Determine if a given tag is present.
-template<typename T, typename SplineDataMemberTypes_t>
+template <typename T, typename SplineDataMemberTypes_t>
 struct has_spline_tag;
 
-template<typename T>
-struct has_spline_tag<T,SplineDataMemberTypes<>> : std::false_type {};
+template <typename T>
+struct has_spline_tag<T, SplineDataMemberTypes<>> : std::false_type
+{
+};
 
-template<typename T, typename U, typename ... Tags>
-struct has_spline_tag<T,SplineDataMemberTypes<U,Tags...>>
-    : has_spline_tag<T,SplineDataMemberTypes<Tags...>> {};
+template <typename T, typename U, typename... Tags>
+struct has_spline_tag<T, SplineDataMemberTypes<U, Tags...>>
+    : has_spline_tag<T, SplineDataMemberTypes<Tags...>>
+{
+};
 
-template<typename T, typename ... Tags>
-struct has_spline_tag<T,SplineDataMemberTypes<T,Tags...>>
-    : std::true_type {};
+template <typename T, typename... Tags>
+struct has_spline_tag<T, SplineDataMemberTypes<T, Tags...>> : std::true_type
+{
+};
 
 // Spline data members.
-template<typename Scalar, int Order, class Tag>
+template <typename Scalar, int Order, class Tag>
 struct SplineDataMember;
 
-template<typename Scalar, int Order>
-struct SplineDataMember<Scalar,Order,SplinePhysicalCellSize>
+template <typename Scalar, int Order>
+struct SplineDataMember<Scalar, Order, SplinePhysicalCellSize>
 {
     // Physical cell size.
     Scalar dx[3];
 };
 
-template<typename Scalar, int Order>
-struct SplineDataMember<Scalar,Order,SplineLogicalPosition>
+template <typename Scalar, int Order>
+struct SplineDataMember<Scalar, Order, SplineLogicalPosition>
 {
     // Logical position.
     Scalar x[3];
 };
 
-template<typename Scalar, int Order>
-struct SplineDataMember<Scalar,Order,SplinePhysicalDistance>
+template <typename Scalar, int Order>
+struct SplineDataMember<Scalar, Order, SplinePhysicalDistance>
 {
     using spline_type = Spline<Order>;
     static constexpr int num_knot = spline_type::num_knot;
@@ -502,8 +519,8 @@ struct SplineDataMember<Scalar,Order,SplinePhysicalDistance>
     Scalar d[3][num_knot];
 };
 
-template<typename Scalar, int Order>
-struct SplineDataMember<Scalar,Order,SplineWeightValues>
+template <typename Scalar, int Order>
+struct SplineDataMember<Scalar, Order, SplineWeightValues>
 {
     using spline_type = Spline<Order>;
     static constexpr int num_knot = spline_type::num_knot;
@@ -512,8 +529,8 @@ struct SplineDataMember<Scalar,Order,SplineWeightValues>
     Scalar w[3][num_knot];
 };
 
-template<typename Scalar, int Order>
-struct SplineDataMember<Scalar,Order,SplineWeightPhysicalGradients>
+template <typename Scalar, int Order>
+struct SplineDataMember<Scalar, Order, SplineWeightPhysicalGradients>
 {
     using spline_type = Spline<Order>;
     static constexpr int num_knot = spline_type::num_knot;
@@ -528,12 +545,12 @@ struct SplineData;
 
 // Default of void has all data members.
 template <typename Scalar, int Order, class EntityType>
-struct SplineData<Scalar,Order,EntityType,void>
-    : SplineDataMember<Scalar,Order,SplinePhysicalCellSize>
-    , SplineDataMember<Scalar,Order,SplineLogicalPosition>
-    , SplineDataMember<Scalar,Order,SplinePhysicalDistance>
-    , SplineDataMember<Scalar,Order,SplineWeightValues>
-    , SplineDataMember<Scalar,Order,SplineWeightPhysicalGradients>
+struct SplineData<Scalar, Order, EntityType, void>
+    : SplineDataMember<Scalar, Order, SplinePhysicalCellSize>,
+      SplineDataMember<Scalar, Order, SplineLogicalPosition>,
+      SplineDataMember<Scalar, Order, SplinePhysicalDistance>,
+      SplineDataMember<Scalar, Order, SplineWeightValues>,
+      SplineDataMember<Scalar, Order, SplineWeightPhysicalGradients>
 {
     using scalar_type = Scalar;
     static constexpr int order = Order;
@@ -552,9 +569,9 @@ struct SplineData<Scalar,Order,EntityType,void>
 };
 
 // Specify each data member individually through tags.
-template <typename Scalar, int Order, class EntityType, class ... Tags>
-struct SplineData<Scalar,Order,EntityType,SplineDataMemberTypes<Tags...>>
-    : SplineDataMember<Scalar,Order,Tags>...
+template <typename Scalar, int Order, class EntityType, class... Tags>
+struct SplineData<Scalar, Order, EntityType, SplineDataMemberTypes<Tags...>>
+    : SplineDataMember<Scalar, Order, Tags>...
 {
     using scalar_type = Scalar;
     static constexpr int order = Order;
@@ -564,80 +581,62 @@ struct SplineData<Scalar,Order,EntityType,SplineDataMemberTypes<Tags...>>
 
     using member_tags = SplineDataMemberTypes<Tags...>;
 
-    using has_physical_cell_size = has_spline_tag<SplinePhysicalCellSize,member_tags>;
-    using has_logical_position = has_spline_tag<SplineLogicalPosition,member_tags>;
-    using has_physical_distance = has_spline_tag<SplinePhysicalDistance,member_tags>;
-    using has_weight_values = has_spline_tag<SplineWeightValues,member_tags>;
-    using has_weight_physical_gradients = has_spline_tag<SplineWeightPhysicalGradients,member_tags>;
+    using has_physical_cell_size =
+        has_spline_tag<SplinePhysicalCellSize, member_tags>;
+    using has_logical_position =
+        has_spline_tag<SplineLogicalPosition, member_tags>;
+    using has_physical_distance =
+        has_spline_tag<SplinePhysicalDistance, member_tags>;
+    using has_weight_values = has_spline_tag<SplineWeightValues, member_tags>;
+    using has_weight_physical_gradients =
+        has_spline_tag<SplineWeightPhysicalGradients, member_tags>;
 
     // Local interpolation stencil.
     int s[3][num_knot];
 };
 
 // Assign physical cell size to the spline data.
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::true_type,
-                    SplinePhysicalCellSize,
-                    SplineData<Scalar, Order, EntityType, DataTags> &data,
-                    const int d,
-                    const Scalar dx )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::true_type, SplinePhysicalCellSize,
+               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               const int d, const Scalar dx )
 {
     data.dx[d] = dx;
 }
 
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::false_type,
-                    SplinePhysicalCellSize,
-                    SplineData<Scalar, Order, EntityType, DataTags> &,
-                    const int ,
-                    const Scalar  )
-{}
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::false_type, SplinePhysicalCellSize,
+               SplineData<Scalar, Order, EntityType, DataTags> &, const int,
+               const Scalar )
+{
+}
 
 // Assign logical position to the spline data.
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::true_type,
-                    SplineLogicalPosition,
-                    SplineData<Scalar, Order, EntityType, DataTags> &data,
-                    const int d,
-                    const Scalar x )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::true_type, SplineLogicalPosition,
+               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               const int d, const Scalar x )
 {
     data.x[d] = x;
 }
 
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::false_type,
-                    SplineLogicalPosition,
-                    SplineData<Scalar, Order, EntityType, DataTags> &,
-                    const int ,
-                    const Scalar  )
-{}
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::false_type, SplineLogicalPosition,
+               SplineData<Scalar, Order, EntityType, DataTags> &, const int,
+               const Scalar )
+{
+}
 
 // Assign weight values to the spline data.
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::true_type,
-                    SplineWeightValues,
-                    SplineData<Scalar, Order, EntityType, DataTags> &data,
-                    const Scalar x[3] )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::true_type, SplineWeightValues,
+               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               const Scalar x[3] )
 
 {
     using spline_type =
@@ -646,29 +645,21 @@ void setSplineData( std::true_type,
         spline_type::value( x[d], data.w[d] );
 }
 
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::false_type,
-                    SplineWeightValues,
-                    SplineData<Scalar, Order, EntityType, DataTags> &,
-                    const Scalar[3] )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::false_type, SplineWeightValues,
+               SplineData<Scalar, Order, EntityType, DataTags> &,
+               const Scalar[3] )
 
-{}
+{
+}
 
 // Assign weight physical gradients to the spline data.
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::true_type,
-                    SplineWeightPhysicalGradients,
-                    SplineData<Scalar, Order, EntityType, DataTags> &data,
-                    const Scalar x[3],
-                    const Scalar rdx[3] )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::true_type, SplineWeightPhysicalGradients,
+               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               const Scalar x[3], const Scalar rdx[3] )
 
 {
     using spline_type =
@@ -677,31 +668,21 @@ void setSplineData( std::true_type,
         spline_type::gradient( x[d], rdx[d], data.g[d] );
 }
 
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::false_type,
-                    SplineWeightPhysicalGradients,
-                    SplineData<Scalar, Order, EntityType, DataTags> &,
-                    const Scalar[3],
-                    const Scalar[3] )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::false_type, SplineWeightPhysicalGradients,
+               SplineData<Scalar, Order, EntityType, DataTags> &,
+               const Scalar[3], const Scalar[3] )
 
-{}
+{
+}
 
 // Assign physical distance to the spline data.
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::true_type,
-                    SplinePhysicalDistance,
-                    SplineData<Scalar, Order, EntityType, DataTags> &data,
-                    const Scalar low_x[3],
-                    const Scalar p[3],
-                    const Scalar dx[3] )
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::true_type, SplinePhysicalDistance,
+               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               const Scalar low_x[3], const Scalar p[3], const Scalar dx[3] )
 
 {
     using spline_type =
@@ -715,26 +696,18 @@ void setSplineData( std::true_type,
     }
 }
 
-template <typename Scalar,
-          int Order,
-          class EntityType,
-          class  DataTags>
-KOKKOS_INLINE_FUNCTION
-void setSplineData( std::false_type,
-                    SplinePhysicalDistance,
-                    SplineData<Scalar, Order, EntityType, DataTags> &,
-                    const Scalar[3],
-                    const Scalar[3],
-                    const Scalar[3] )
-{}
+template <typename Scalar, int Order, class EntityType, class DataTags>
+KOKKOS_INLINE_FUNCTION void
+setSplineData( std::false_type, SplinePhysicalDistance,
+               SplineData<Scalar, Order, EntityType, DataTags> &,
+               const Scalar[3], const Scalar[3], const Scalar[3] )
+{
+}
 
 //---------------------------------------------------------------------------//
 // Evaluate spline data at a point in a uniform mesh.
-template <typename Scalar,
-          int Order,
-          class Device,
-          class EntityType,
-          class  DataTags>
+template <typename Scalar, int Order, class Device, class EntityType,
+          class DataTags>
 KOKKOS_INLINE_FUNCTION void
 evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
                 const Scalar p[3],
@@ -755,9 +728,8 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     for ( int d = 0; d < 3; ++d )
     {
         dx[d] = local_mesh.measure( Edge<Dim::I>(), low_id );
-        setSplineData(
-            typename sd_type::has_physical_cell_size(),
-            SplinePhysicalCellSize(), data, d, dx[d] );
+        setSplineData( typename sd_type::has_physical_cell_size(),
+                       SplinePhysicalCellSize(), data, d, dx[d] );
     }
 
     // Compute the inverse physicall cell size.
@@ -781,8 +753,8 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     }
 
     // Compute the weight values.
-    setSplineData(
-        typename sd_type::has_weight_values(), SplineWeightValues(), data, x );
+    setSplineData( typename sd_type::has_weight_values(), SplineWeightValues(),
+                   data, x );
 
     // Compute the weight gradients.
     setSplineData( typename sd_type::has_weight_physical_gradients(),

--- a/cajita/unit_test/tstSplineEvaluation.hpp
+++ b/cajita/unit_test/tstSplineEvaluation.hpp
@@ -123,15 +123,15 @@ void updatePointSet( const LocalMeshType &local_mesh, EntityType,
         SplineData<scalar_type, Basis::order, EntityType, spline_data_tags>;
 
     // Check members.
-    static_assert( sd_type::has_physical_cell_size::value,
+    static_assert( sd_type::has_physical_cell_size,
                    "spline data missing physical cell size" );
-    static_assert( sd_type::has_logical_position::value,
+    static_assert( sd_type::has_logical_position,
                    "spline data missing logical position" );
-    static_assert( sd_type::has_physical_distance::value,
+    static_assert( sd_type::has_physical_distance,
                    "spline data missing physical distance" );
-    static_assert( sd_type::has_weight_values::value,
+    static_assert( sd_type::has_weight_values,
                    "spline data missing weight values" );
-    static_assert( sd_type::has_weight_physical_gradients::value,
+    static_assert( sd_type::has_weight_physical_gradients,
                    "spline data missing weight physical gradients" );
 
     // Update the size.

--- a/cajita/unit_test/tstSplineEvaluation.hpp
+++ b/cajita/unit_test/tstSplineEvaluation.hpp
@@ -32,7 +32,8 @@ using namespace Cajita;
 namespace Test
 {
 //---------------------------------------------------------------------------//
-template <class Scalar, class EntityType, int SplineOrder, class DeviceType>
+template <class Scalar, class EntityType, int SplineOrder, class DeviceType,
+          class DataTags>
 struct PointSet
 {
     // Scalar type for geometric operations.
@@ -48,6 +49,9 @@ struct PointSet
     // Number of basis values in each dimension.
     static constexpr int ns = basis_type::num_knot;
 
+    // Spline data tags.
+    using spline_data_tags = DataTags;
+
     // Kokkos types.
     using device_type = DeviceType;
     using execution_space = typename device_type::execution_space;
@@ -58,6 +62,9 @@ struct PointSet
 
     // Number of allocated points.
     std::size_t num_alloc;
+
+    // Physical cell size. (point,dim)
+    Kokkos::View<Scalar * [3], device_type> cell_size;
 
     // Point logical position. (point,dim)
     Kokkos::View<Scalar * [3], device_type> logical_coords;
@@ -108,6 +115,25 @@ void updatePointSet( const LocalMeshType &local_mesh, EntityType,
     using Basis = typename PointSetType::basis_type;
     static constexpr int ns = PointSetType::ns;
 
+    // Spline data tags.
+    using spline_data_tags = typename PointSetType::spline_data_tags;
+
+    // spline data type
+    using sd_type =
+        SplineData<scalar_type, Basis::order, EntityType, spline_data_tags>;
+
+    // Check members.
+    static_assert( sd_type::has_physical_cell_size::value,
+                   "spline data missing physical cell size" );
+    static_assert( sd_type::has_logical_position::value,
+                   "spline data missing logical position" );
+    static_assert( sd_type::has_physical_distance::value,
+                   "spline data missing physical distance" );
+    static_assert( sd_type::has_weight_values::value,
+                   "spline data missing weight values" );
+    static_assert( sd_type::has_weight_physical_gradients::value,
+                   "spline data missing weight physical gradients" );
+
     // Update the size.
     if ( num_point > point_set.num_alloc )
         throw std::logic_error(
@@ -123,8 +149,12 @@ void updatePointSet( const LocalMeshType &local_mesh, EntityType,
             // actually testing in this test.
             scalar_type px[3] = {points( p, Dim::I ), points( p, Dim::J ),
                                  points( p, Dim::K )};
-            SplineData<scalar_type, Basis::order, EntityType> sd;
+            sd_type sd;
             evaluateSpline( local_mesh, px, sd );
+
+            // Get the cell size.
+            for ( int d = 0; d < 3; ++d )
+                point_set.cell_size( p, d ) = sd.dx[d];
 
             // Map the point coordinates to the logical space of the spline.
             for ( int d = 0; d < 3; ++d )
@@ -162,9 +192,11 @@ void updatePointSet( const LocalMeshType &local_mesh, EntityType,
         } );
 }
 
-template <class PointCoordinates, class EntityType, int SplineOrder>
+//---------------------------------------------------------------------------//
+template <class DataTags, class PointCoordinates, class EntityType,
+          int SplineOrder>
 PointSet<typename PointCoordinates::value_type, EntityType, SplineOrder,
-         typename PointCoordinates::device_type>
+         typename PointCoordinates::device_type, DataTags>
 createPointSet(
     const PointCoordinates &points, const std::size_t num_point,
     const std::size_t num_alloc,
@@ -177,7 +209,7 @@ createPointSet(
     using device_type = typename PointCoordinates::device_type;
 
     using set_type =
-        PointSet<scalar_type, EntityType, SplineOrder, device_type>;
+        PointSet<scalar_type, EntityType, SplineOrder, device_type, DataTags>;
 
     set_type point_set;
 
@@ -188,6 +220,10 @@ createPointSet(
             "Attempted to create point set with more points than allocation" );
     point_set.num_point = num_point;
     point_set.num_alloc = num_alloc;
+
+    point_set.cell_size = Kokkos::View<scalar_type * [3], device_type>(
+        Kokkos::ViewAllocateWithoutInitializing( "PointSet::cell_size" ),
+        num_alloc );
 
     point_set.logical_coords = Kokkos::View<scalar_type * [3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::logical_coords" ),
@@ -226,6 +262,7 @@ createPointSet(
 }
 
 //---------------------------------------------------------------------------//
+template <class DataTags>
 void splineEvaluationTest()
 {
     // Create the global mesh.
@@ -268,8 +305,8 @@ void splineEvaluationTest()
         } );
 
     // Create a point set with linear spline interpolation to the nodes.
-    auto point_set = createPointSet( points, num_point, num_point, *local_grid,
-                                     Node(), Spline<1>() );
+    auto point_set = createPointSet<DataTags>(
+        points, num_point, num_point, *local_grid, Node(), Spline<1>() );
 
     // Check the point set data.
     EXPECT_EQ( point_set.num_point, num_point );
@@ -280,6 +317,25 @@ void splineEvaluationTest()
     local_mesh.coordinates( Node(), idx_low, xn_low );
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( point_set.low_corner[d], xn_low[d] );
+
+    // Check cell size
+    auto cell_size_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), point_set.cell_size );
+    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
+        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+              ++j )
+            for ( int k = cell_space.min( Dim::K );
+                  k < cell_space.max( Dim::K ); ++k )
+            {
+                int pi = i - halo_width;
+                int pj = j - halo_width;
+                int pk = k - halo_width;
+                int pid = pi + cell_space.extent( Dim::I ) *
+                                   ( pj + cell_space.extent( Dim::J ) * pk );
+                EXPECT_FLOAT_EQ( cell_size_host( pid, Dim::I ), 0.05 );
+                EXPECT_FLOAT_EQ( cell_size_host( pid, Dim::J ), 0.05 );
+                EXPECT_FLOAT_EQ( cell_size_host( pid, Dim::K ), 0.05 );
+            }
 
     // Check logical coordinates
     auto logical_coords_host = Kokkos::create_mirror_view_and_copy(
@@ -446,7 +502,16 @@ void splineEvaluationTest()
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
-TEST( splines, eval_test ) { splineEvaluationTest(); }
+TEST( splines, eval_test )
+{
+    // Check with default data members on spline data.
+    splineEvaluationTest<void>();
+
+    // Set each spline data member individually.
+    splineEvaluationTest<SplineDataMemberTypes<
+        SplinePhysicalCellSize, SplineLogicalPosition, SplinePhysicalDistance,
+        SplineWeightValues, SplineWeightPhysicalGradients>>();
+}
 
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
This PR does the following:

1. Cleans up comments in interpolation to clarify that a functor with view-like semantics may be used as the source of grid data in G2P interpolation functors. Just a `value_type` type alias and `Scalar operator()(const int i, const int j, const int k, const int d) const` is needed for accessing the data. 

2. Adds the ability to control which elements of `SplineData` are computed and/or stored. At a minimum, the stencil is always computed which requires generation of the cell size, inverse cell size, and logical position. A user can optionally store these parameters. A user can also optional compute (and store) the spline weight values, gradient values in the physical frame, and distance in the physical frame. The code is backwards compatible in that the default behavior is to compute and store all data components so existing user code won't need to be changed. The optional values are added with additional template parameters.

3. Static assertions are added to all interpolation classes to ensure the `SplineData` given to an interpolation functor has all of the requisite data. For power users that choose to control what parts of spline data get computed/stored, this will allow a clear way for them to see at compile time if they specified the right data values in their kernel required to compute the desired interpolant. This is also useful when writing your own interpolants as you can specify at compile time which data dependencies you have.