### PR TITLE
Heffte link fix

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -36,7 +36,7 @@ if(HYPRE_FOUND)
     )
 endif()
 
-if(HEFFTE_FOUND)
+if(Heffte_FOUND)
   list(APPEND HEADERS_PUBLIC
     Cajita_FastFourierTransform.hpp
     )

--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 
 if(Heffte_FOUND)
   target_link_libraries(Cajita Heffte::Heffte)
+  target_include_directories(Cajita PUBLIC ${Heffte_INCLUDE_DIR})
 endif()
 
 target_include_directories(Cajita

--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -44,18 +44,17 @@ endif()
 
 add_library(Cajita ${SOURCES_PUBLIC})
 
-target_link_libraries(Cajita
+target_link_libraries(Cajita PUBLIC
   Kokkos::kokkos
   MPI::MPI_CXX
   )
 
 if(HYPRE_FOUND)
-  target_link_libraries(Cajita HYPRE::hypre)
+  target_link_libraries(Cajita PUBLIC HYPRE::hypre)
 endif()
 
 if(Heffte_FOUND)
-  target_link_libraries(Cajita Heffte::Heffte)
-  target_include_directories(Cajita PUBLIC ${Heffte_INCLUDE_DIR})
+  target_link_libraries(Cajita PUBLIC Heffte::Heffte)
 endif()
 
 target_include_directories(Cajita


### PR DESCRIPTION
This involves a simple fix (case change for `HEFFTE_FOUND` to `Heffte_FOUND`), and a change I'm not sure about:

I would like to build CabanaMD without needing to specify the location of a Heffte include directory. I just want to point to Cabana, which will point to Heffte itself. Currently the CMake I've written does not accomplish this. Suggestions?

Fixes #259 