### PR TITLE
Cajita parallel helper functions

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADERS_PUBLIC
   Cajita_LocalMesh.hpp
   Cajita_ManualPartitioner.hpp
   Cajita_MpiTraits.hpp
+  Cajita_Parallel.hpp
   Cajita_Partitioner.hpp
   Cajita_ReferenceStructuredSolver.hpp
   Cajita_Splines.hpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -25,6 +25,7 @@
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_MpiTraits.hpp>
+#include <Cajita_Parallel.hpp>
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_ReferenceStructuredSolver.hpp>
 #include <Cajita_Splines.hpp>

--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -162,12 +162,42 @@ createExecutionPolicy( const IndexSpace<1> &index_space,
 //---------------------------------------------------------------------------//
 /*!
   \brief Create a multi-dimensional execution policy over an index space.
+
+  Rank-1 specialization with a work tag.
+*/
+template <class ExecutionSpace, class WorkTag>
+Kokkos::RangePolicy<ExecutionSpace, WorkTag>
+createExecutionPolicy( const IndexSpace<1> &index_space, const ExecutionSpace &,
+                       const WorkTag & )
+{
+    return Kokkos::RangePolicy<ExecutionSpace, WorkTag>( index_space.min( 0 ),
+                                                         index_space.max( 0 ) );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a multi-dimensional execution policy over an index space.
 */
 template <class IndexSpace_t, class ExecutionSpace>
 Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<IndexSpace_t::Rank>>
 createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace & )
 {
     return Kokkos::MDRangePolicy<ExecutionSpace,
+                                 Kokkos::Rank<IndexSpace_t::Rank>>(
+        index_space.min(), index_space.max() );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a multi-dimensional execution policy over an index space with
+  a work tag.
+*/
+template <class IndexSpace_t, class ExecutionSpace, class WorkTag>
+Kokkos::MDRangePolicy<ExecutionSpace, WorkTag, Kokkos::Rank<IndexSpace_t::Rank>>
+createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace &,
+                       const WorkTag & )
+{
+    return Kokkos::MDRangePolicy<ExecutionSpace, WorkTag,
                                  Kokkos::Rank<IndexSpace_t::Rank>>(
         index_space.min(), index_space.max() );
 }

--- a/cajita/src/Cajita_Parallel.hpp
+++ b/cajita/src/Cajita_Parallel.hpp
@@ -1,0 +1,325 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_PARALLEL_HPP
+#define CAJITA_PARALLEL_HPP
+
+#include <Cajita_IndexSpace.hpp>
+#include <Cajita_LocalGrid.hpp>
+
+#include <string>
+
+namespace Cajita
+{
+//---------------------------------------------------------------------------//
+// Grid Parallel For
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a functor in parallel with a multidimensional execution
+  policy specified by the given index space.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam N The dimension of the index space.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param index_space The index space over which to loop.
+
+  \param functor The functor to execute.
+ */
+template <class FunctorType, class ExecutionSpace, long N>
+inline void grid_parallel_for( const std::string &label,
+                               const ExecutionSpace &exec_space,
+                               const IndexSpace<N> &index_space,
+                               const FunctorType &functor )
+{
+    Kokkos::parallel_for(
+        label, createExecutionPolicy( index_space, exec_space ), functor );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a functor with a work tag in parallel with a multidimensional
+  execution policy specified by the given index space.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam WorkTag The functor execution tag.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam N The dimension of the index space.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param index_space The index space over which to loop.
+
+  \param tag The functor execution tag.
+
+  \param functor The functor to execute.
+ */
+template <class FunctorType, class WorkTag, class ExecutionSpace, long N>
+inline void
+grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
+                   const IndexSpace<N> &index_space, const WorkTag &work_tag,
+                   const FunctorType &functor )
+{
+    Kokkos::parallel_for(
+        label, createExecutionPolicy( index_space, exec_space, work_tag ),
+        functor );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a functor in parallel with a multidimensional execution
+  policy specified by the given local grid, decomposition, and entity
+  type. The loop indices are local.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam MeshType The mesh type of the local grid.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param decomposition The decomposition type of the entities (own,ghost).
+
+  \param entity_type The entity type over which to loop.
+
+  \param functor The functor to execute.
+ */
+template <class FunctorType, class ExecutionSpace, class MeshType,
+          class DecompositionType, class EntityType>
+inline void
+grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
+                   const LocalGrid<MeshType> &local_grid,
+                   const DecompositionType &decomposition,
+                   const EntityType &entity_type, const FunctorType &functor )
+{
+    auto index_space =
+        local_grid.indexSpace( decomposition, entity_type, Local() );
+    grid_parallel_for( label, exec_space, index_space, functor );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a functor with a work tag in parallel with a multidimensional
+  execution policy specified by the given local grid, decomposition, and entity
+  type. The loop indices are local.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam WorkTag The functor work tag.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam MeshType The mesh type of the local grid.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param decomposition The decomposition type of the entities (own,ghost).
+
+  \param entity_type The entity type over which to loop.
+
+  \param functor The functor to execute.
+ */
+template <class FunctorType, class WorkTag, class ExecutionSpace,
+          class MeshType, class DecompositionType, class EntityType>
+inline void
+grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
+                   const LocalGrid<MeshType> &local_grid,
+                   const DecompositionType &decomposition,
+                   const EntityType &entity_type, const WorkTag &work_tag,
+                   const FunctorType &functor )
+{
+    auto index_space =
+        local_grid.indexSpace( decomposition, entity_type, Local() );
+    grid_parallel_for( label, exec_space, index_space, work_tag, functor );
+}
+
+//---------------------------------------------------------------------------//
+// Grid Parallel Reduce
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a reduction functor in parallel with a multidimensional
+  execution policy specified by the given index space.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam N The dimension of the index space.
+
+  \tparam ReduceType The reduction type.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param index_space The index space over which to loop.
+
+  \param functor The functor to execute.
+
+  \param reducer The parallel reduce result.
+ */
+template <class FunctorType, class ExecutionSpace, long N, class ReduceType>
+inline void grid_parallel_reduce( const std::string &label,
+                                  const ExecutionSpace &exec_space,
+                                  const IndexSpace<N> &index_space,
+                                  const FunctorType &functor,
+                                  ReduceType &reducer )
+{
+    Kokkos::parallel_reduce( label,
+                             createExecutionPolicy( index_space, exec_space ),
+                             functor, reducer );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a reduction functor with a work tag in parallel with a
+  multidimensional execution policy specified by the given index space.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam WorkTag The functor execution tag.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam N The dimension of the index space.
+
+  \tparam ReduceType The reduction type.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param index_space The index space over which to loop.
+
+  \param tag The functor execution tag.
+
+  \param functor The functor to execute.
+
+  \param reducer The parallel reduce result.
+ */
+template <class FunctorType, class WorkTag, class ExecutionSpace, long N,
+          class ReduceType>
+inline void
+grid_parallel_reduce( const std::string &label,
+                      const ExecutionSpace &exec_space,
+                      const IndexSpace<N> &index_space, const WorkTag &work_tag,
+                      const FunctorType &functor, ReduceType &reducer )
+{
+    Kokkos::parallel_reduce(
+        label, createExecutionPolicy( index_space, exec_space, work_tag ),
+        functor, reducer );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a reduction functor in parallel with a multidimensional
+  execution policy specified by the given local grid, decomposition, and
+  entity type. The loop indices are local.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam MeshType The mesh type of the local grid.
+
+  \tparam ReduceType The reduction type.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param decomposition The decomposition type of the entities (own,ghost).
+
+  \param entity_type The entity type over which to loop.
+
+  \param functor The functor to execute.
+
+  \param reducer The parallel reduce result.
+ */
+template <class FunctorType, class ExecutionSpace, class MeshType,
+          class DecompositionType, class EntityType, class ReduceType>
+inline void grid_parallel_reduce( const std::string &label,
+                                  const ExecutionSpace &exec_space,
+                                  const LocalGrid<MeshType> &local_grid,
+                                  const DecompositionType &decomposition,
+                                  const EntityType &entity_type,
+                                  const FunctorType &functor,
+                                  ReduceType &reducer )
+{
+    auto index_space =
+        local_grid.indexSpace( decomposition, entity_type, Local() );
+    grid_parallel_reduce( label, exec_space, index_space, functor, reducer );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Execute a reduction functor with a work tag in parallel with a
+  multidimensional execution policy specified by the given local grid,
+  decomposition, and entity type. The loop indices are local.
+
+  \tparam FunctorType The functor type to execute.
+
+  \tparam WorkTag The functor work tag.
+
+  \tparam ExecutionSpace The execution space type.
+
+  \tparam MeshType The mesh type of the local grid.
+
+  \tparam ReduceType The reduction type.
+
+  \param label Parallel region label.
+
+  \param exec_space An execution space instance.
+
+  \param decomposition The decomposition type of the entities (own,ghost).
+
+  \param entity_type The entity type over which to loop.
+
+  \param functor The functor to execute.
+
+  \param reducer The parallel reduce result.
+ */
+template <class FunctorType, class WorkTag, class ExecutionSpace,
+          class MeshType, class DecompositionType, class EntityType,
+          class ReduceType>
+inline void grid_parallel_reduce(
+    const std::string &label, const ExecutionSpace &exec_space,
+    const LocalGrid<MeshType> &local_grid,
+    const DecompositionType &decomposition, const EntityType &entity_type,
+    const WorkTag &work_tag, const FunctorType &functor, ReduceType &reducer )
+{
+    auto index_space =
+        local_grid.indexSpace( decomposition, entity_type, Local() );
+    grid_parallel_reduce( label, exec_space, index_space, work_tag, functor,
+                          reducer );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cajita
+
+#endif // end CAJITA_PARALLEL_HPP

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -73,6 +73,7 @@ endmacro()
 set(SERIAL_TESTS
   GlobalMesh
   IndexSpace
+  Parallel
   Splines
   )
 

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -281,7 +281,7 @@ void executionTest()
                           KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
     auto v1_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v1 );
-    for ( int i = 0; i < is1.extent( 0 ); ++i )
+    for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
             EXPECT_EQ( v1_mirror( i ), 1.0 );
@@ -300,8 +300,8 @@ void executionTest()
         KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
     auto v2_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v2 );
-    for ( int i = 0; i < is2.extent( 0 ); ++i )
-        for ( int j = 0; j < is2.extent( 1 ); ++j )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
         {
             if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
                  j < is2.max( 1 ) )
@@ -323,9 +323,9 @@ void executionTest()
         } );
     auto v3_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v3 );
-    for ( int i = 0; i < is3.extent( 0 ); ++i )
-        for ( int j = 0; j < is3.extent( 1 ); ++j )
-            for ( int k = 0; k < is3.extent( 2 ); ++k )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+            for ( int k = 0; k < size_k; ++k )
             {
                 if ( is3.min( 0 ) <= i && i < is3.max( 0 ) &&
                      is3.min( 1 ) <= j && j < is3.max( 1 ) &&
@@ -350,10 +350,10 @@ void executionTest()
         } );
     auto v4_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v4 );
-    for ( int i = 0; i < is4.extent( 0 ); ++i )
-        for ( int j = 0; j < is4.extent( 1 ); ++j )
-            for ( int k = 0; k < is4.extent( 2 ); ++k )
-                for ( int l = 0; l < is4.extent( 3 ); ++l )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+            for ( int k = 0; k < size_k; ++k )
+                for ( int l = 0; l < size_l; ++l )
                 {
                     if ( is4.min( 0 ) <= i && i < is4.max( 0 ) &&
                          is4.min( 1 ) <= j && j < is4.max( 1 ) &&
@@ -378,7 +378,7 @@ void subviewTest()
     Kokkos::deep_copy( sv1, 1.0 );
     auto v1_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v1 );
-    for ( int i = 0; i < is1.extent( 0 ); ++i )
+    for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.range( 0 ).first <= i && i < is1.range( 0 ).second )
             EXPECT_EQ( v1_mirror( i ), 1.0 );
@@ -396,8 +396,8 @@ void subviewTest()
     Kokkos::deep_copy( sv2, 1.0 );
     auto v2_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v2 );
-    for ( int i = 0; i < is2.extent( 0 ); ++i )
-        for ( int j = 0; j < is2.extent( 1 ); ++j )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
         {
             if ( is2.range( 0 ).first <= i && i < is2.range( 0 ).second &&
                  is2.range( 1 ).first <= j && j < is2.range( 1 ).second )
@@ -416,9 +416,9 @@ void subviewTest()
     Kokkos::deep_copy( sv3, 1.0 );
     auto v3_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v3 );
-    for ( int i = 0; i < is3.extent( 0 ); ++i )
-        for ( int j = 0; j < is3.extent( 1 ); ++j )
-            for ( int k = 0; k < is3.extent( 2 ); ++k )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+            for ( int k = 0; k < size_k; ++k )
             {
                 if ( is3.range( 0 ).first <= i && i < is3.range( 0 ).second &&
                      is3.range( 1 ).first <= j && j < is3.range( 1 ).second &&
@@ -440,10 +440,10 @@ void subviewTest()
     Kokkos::deep_copy( sv4, 1.0 );
     auto v4_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v4 );
-    for ( int i = 0; i < is4.extent( 0 ); ++i )
-        for ( int j = 0; j < is4.extent( 1 ); ++j )
-            for ( int k = 0; k < is4.extent( 2 ); ++k )
-                for ( int l = 0; l < is4.extent( 3 ); ++l )
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+            for ( int k = 0; k < size_k; ++k )
+                for ( int l = 0; l < size_l; ++l )
                 {
                     if ( is4.range( 0 ).first <= i &&
                          i < is4.range( 0 ).second &&

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -1,0 +1,282 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita_Array.hpp>
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_IndexSpace.hpp>
+#include <Cajita_LocalGrid.hpp>
+#include <Cajita_Parallel.hpp>
+#include <Cajita_Types.hpp>
+#include <Cajita_UniformDimPartitioner.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Cajita;
+
+namespace Test
+{
+
+//---------------------------------------------------------------------------//
+// Tag functor.
+struct ForTag
+{
+};
+struct ReduceTag
+{
+};
+
+struct TestFunctor1
+{
+    Kokkos::View<double *, TEST_DEVICE> v;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ForTag &, const int i ) const { v( i ) = 2.0; }
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ReduceTag &, const int i, double &result ) const
+    {
+        result += v( i );
+    }
+};
+
+struct TestFunctor2
+{
+    Kokkos::View<double **, TEST_DEVICE> v;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ForTag &, const int i, const int j ) const
+    {
+        v( i, j ) = 2.0;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ReduceTag &, const int i, const int j,
+                     double &result ) const
+    {
+        result += v( i, j );
+    }
+};
+
+struct TestFunctorArray
+{
+    Kokkos::View<double ****, TEST_DEVICE> v;
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ForTag &, const int i, const int j,
+                     const int k ) const
+    {
+        for ( int l = 0; l < 4; ++l )
+            v( i, j, k, l ) = 2.0;
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const ReduceTag &, const int i, const int j, const int k,
+                     double &result ) const
+    {
+        for ( int l = 0; l < 4; ++l )
+            result += v( i, j, k, l );
+    }
+};
+
+//---------------------------------------------------------------------------//
+void parallelIndexSpaceTest()
+{
+    // Rank-1 index space without tag.
+    int min_i = 4;
+    int max_i = 8;
+    int size_i = 12;
+    IndexSpace<1> is1( {min_i}, {max_i} );
+    Kokkos::View<double *, TEST_DEVICE> v1( "v1", size_i );
+    grid_parallel_for( "fill_rank_1", TEST_EXECSPACE(), is1,
+                       KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
+    auto v1_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v1 );
+    for ( int i = 0; i < size_i; ++i )
+    {
+        if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
+            EXPECT_EQ( v1_mirror( i ), 1.0 );
+        else
+            EXPECT_EQ( v1_mirror( i ), 0.0 );
+    }
+
+    // check reduction.
+    double sum1 = 0.0;
+    grid_parallel_reduce(
+        "reduce_rank_1", TEST_EXECSPACE(), is1,
+        KOKKOS_LAMBDA( const int i, double &result ) { result += v1( i ); },
+        sum1 );
+    EXPECT_EQ( sum1, is1.size() );
+
+    // Rank-1 index space with tag.
+    TestFunctor1 func1;
+    func1.v = v1;
+    grid_parallel_for( "fill_rank_1", TEST_EXECSPACE(), is1, ForTag(), func1 );
+    Kokkos::deep_copy( v1_mirror, v1 );
+    for ( int i = 0; i < size_i; ++i )
+    {
+        if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
+            EXPECT_EQ( v1_mirror( i ), 2.0 );
+        else
+            EXPECT_EQ( v1_mirror( i ), 0.0 );
+    }
+
+    // check reduction.
+    double sum1_tag = 0.0;
+    grid_parallel_reduce( "reduce_rank_1_tag", TEST_EXECSPACE(), is1,
+                          ReduceTag(), func1, sum1_tag );
+    EXPECT_EQ( sum1_tag, 2.0 * is1.size() );
+
+    // Rank-2 index space without tag.
+    int min_j = 3;
+    int max_j = 9;
+    int size_j = 18;
+    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    Kokkos::View<double **, TEST_DEVICE> v2( "v2", size_i, size_j );
+    grid_parallel_for(
+        "fill_rank_2", TEST_EXECSPACE(), is2,
+        KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
+    auto v2_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), v2 );
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+        {
+            if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
+                 j < is2.max( 1 ) )
+                EXPECT_EQ( v2_mirror( i, j ), 1.0 );
+            else
+                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+        }
+
+    // check reduction.
+    double sum2 = 0.0;
+    grid_parallel_reduce(
+        "reduce_rank_2", TEST_EXECSPACE(), is2,
+        KOKKOS_LAMBDA( const int i, const int j, double &result ) {
+            result += v2( i, j );
+        },
+        sum2 );
+    EXPECT_EQ( sum2, is2.size() );
+
+    // Rank-2 index space with tag.
+    TestFunctor2 func2;
+    func2.v = v2;
+    grid_parallel_for( "fill_rank_2", TEST_EXECSPACE(), is2, ForTag(), func2 );
+    Kokkos::deep_copy( v2_mirror, v2 );
+    for ( int i = 0; i < size_i; ++i )
+        for ( int j = 0; j < size_j; ++j )
+        {
+            if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
+                 j < is2.max( 1 ) )
+                EXPECT_EQ( v2_mirror( i, j ), 2.0 );
+            else
+                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+        }
+
+    // check reduction.
+    double sum2_tag = 0.0;
+    grid_parallel_reduce( "reduce_rank_2_tag", TEST_EXECSPACE(), is2,
+                          ReduceTag(), func2, sum2_tag );
+    EXPECT_EQ( sum2_tag, 2.0 * is2.size() );
+}
+
+//---------------------------------------------------------------------------//
+void parallelLocalGridTest()
+{
+    // Let MPI compute the partitioning for this test.
+    UniformDimPartitioner partitioner;
+
+    // Create the global mesh.
+    double cell_size = 0.23;
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2]};
+    auto global_mesh = createUniformGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Create the global grid.
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Create an array layout on the cells.
+    int halo_width = 2;
+    int dofs_per_cell = 4;
+    auto cell_layout =
+        createArrayLayout( global_grid, halo_width, dofs_per_cell, Cell() );
+    auto local_grid = cell_layout->localGrid();
+
+    // Create an array.
+    std::string label( "test_array" );
+    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+
+    // Assign a value to the entire the array.
+    auto array_view = array->view();
+    grid_parallel_for( "fill_array", TEST_EXECSPACE(), *local_grid, Ghost(),
+                       Cell(),
+                       KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+                           for ( int l = 0; l < 4; ++l )
+                               array_view( i, j, k, l ) = 1.0;
+                       } );
+    auto host_view =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), array_view );
+    auto ghosted_space = array->layout()->indexSpace( Ghost(), Local() );
+    for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
+        for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
+            for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
+                for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
+                    EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
+
+    // check reduction.
+    double sum = 0.0;
+    grid_parallel_reduce(
+        "reduce_array", TEST_EXECSPACE(), *local_grid, Ghost(), Cell(),
+        KOKKOS_LAMBDA( const int i, const int j, const int k, double &result ) {
+            for ( int l = 0; l < 4; ++l )
+                result += array_view( i, j, k, l );
+        },
+        sum );
+    EXPECT_EQ( sum, ghosted_space.size() );
+
+    // Assign a value again using a tag.
+    TestFunctorArray func;
+    func.v = array_view;
+    grid_parallel_for( "fill_array", TEST_EXECSPACE(), *local_grid, Ghost(),
+                       Cell(), ForTag(), func );
+    Kokkos::deep_copy( host_view, array_view );
+    for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
+        for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
+            for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
+                for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
+                    EXPECT_EQ( host_view( i, j, k, l ), 2.0 );
+
+    // check reduction.
+    double sum_tag = 0.0;
+    grid_parallel_reduce( "reduce_array", TEST_EXECSPACE(), *local_grid,
+                          Ghost(), Cell(), ReduceTag(), func, sum_tag );
+    EXPECT_EQ( sum_tag, 2.0 * ghosted_space.size() );
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, parallel_index_space_test ) { parallelIndexSpaceTest(); }
+
+TEST( TEST_CATEGORY, parallel_local_grid_test ) { parallelLocalGridTest(); }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
Adds some convenience functions, namely `Cajita::grid_parallel_for` and `Cajita::grid_parallel_reduce` for `ijk` structured loops over index spaces. These helpers compose the execution policy for a user based on a given index space or a user can simply specify the entity type and decomposition they wish to loop over. Functors with and without work tags are supported. This construct will be useful in simplifying both application code and implementation details.