### PR TITLE
Do not include <iostream> in our library headers

### DIFF
--- a/cajita/src/Cajita_BovWriter.hpp
+++ b/cajita/src/Cajita_BovWriter.hpp
@@ -24,7 +24,6 @@
 #include <array>
 #include <fstream>
 #include <iomanip>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
For one we don't use it.
Also this notoriously can degrade build times downstream.
Kokkos was pretty bad about that but we have been working towards fixing it.