### PR TITLE
Fused Halo

### DIFF
--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -14,7 +14,8 @@
 
 #include <Cajita_Array.hpp>
 #include <Cajita_IndexSpace.hpp>
-#include <Cajita_MpiTraits.hpp>
+
+#include <Kokkos_Core.hpp>
 
 #include <mpi.h>
 
@@ -22,12 +23,159 @@
 #include <array>
 #include <cmath>
 #include <type_traits>
+#include <utility>
 #include <vector>
-
-#include <Kokkos_Core.hpp>
 
 namespace Cajita
 {
+//---------------------------------------------------------------------------//
+// Parameter pack device capture.
+//
+// NOTE: In general this would not be needed but NVCC cannot capture parameter
+// packs in lambda functions hence we need to wrap them in something that can
+// be captured.
+//---------------------------------------------------------------------------//
+// Get the type at the given index of a paremeter pack.
+template <std::size_t N, typename T, typename... Types>
+struct PackTypeAtIndexImpl;
+
+template <typename T, typename... Types>
+struct PackTypeAtIndexImpl<0, T, Types...>
+{
+    using type = T;
+};
+
+template <std::size_t N, typename T, typename... Types>
+struct PackTypeAtIndexImpl
+{
+    using type = typename PackTypeAtIndexImpl<N - 1, Types...>::type;
+};
+
+template <std::size_t N, typename... Types>
+struct PackTypeAtIndex
+{
+    using type = typename PackTypeAtIndexImpl<N, Types...>::type;
+    static_assert( N < sizeof...( Types ), "Type index out of bounds" );
+};
+
+//---------------------------------------------------------------------------//
+// Parameter pack element.
+template <std::size_t N, typename T>
+struct ParameterPackElement
+{
+    T _m;
+};
+
+//---------------------------------------------------------------------------//
+// Capture a parameter pack. All parameter pack elements must be copyable to
+// device.
+template <typename Sequence, typename... Types>
+struct ParameterPackImpl;
+
+template <std::size_t... Indices, typename... Types>
+struct ParameterPackImpl<std::index_sequence<Indices...>, Types...>
+    : ParameterPackElement<Indices, Types>...
+{
+};
+
+template <typename... Types>
+struct ParameterPack
+    : ParameterPackImpl<std::make_index_sequence<sizeof...( Types )>, Types...>
+{
+    template <std::size_t N>
+    using value_type = typename PackTypeAtIndex<N, Types...>::type;
+
+    template <std::size_t N>
+    using const_value_type = typename std::add_const<value_type<N>>::type;
+
+    template <std::size_t N>
+    using element_type = ParameterPackElement<N, value_type<N>>;
+
+    static constexpr std::size_t size = sizeof...( Types );
+};
+
+//---------------------------------------------------------------------------//
+// Static type checker.
+template <class>
+struct is_parameter_pack_impl : public std::false_type
+{
+};
+
+template <typename... Types>
+struct is_parameter_pack_impl<ParameterPack<Types...>> : public std::true_type
+{
+};
+
+template <class T>
+struct is_parameter_pack
+    : public is_parameter_pack_impl<typename std::remove_cv<T>::type>::type
+{
+};
+
+//---------------------------------------------------------------------------//
+// Get an element from a parameter pack.
+template <std::size_t N, class ParameterPack_t>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    is_parameter_pack<ParameterPack_t>::value,
+    typename ParameterPack_t::template value_type<N> &>::type
+get( ParameterPack_t &pp )
+{
+    return static_cast<typename ParameterPack_t::template element_type<N> &>(
+               pp )
+        ._m;
+}
+
+template <std::size_t N, class ParameterPack_t>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    is_parameter_pack<ParameterPack_t>::value,
+    const typename ParameterPack_t::template value_type<N> &>::type
+get( const ParameterPack_t &pp )
+{
+    return static_cast<
+               const typename ParameterPack_t::template element_type<N> &>( pp )
+        ._m;
+}
+
+//---------------------------------------------------------------------------//
+// Fill a parameter pack. Note the indexing is such that the Nth element of a
+// parameter pack is the Nth element of the tuple.
+template <typename ParameterPack_t, typename T, typename... Types>
+void fillParameterPackImpl( ParameterPack_t &pp,
+                            const std::integral_constant<std::size_t, 0>,
+                            const T &t, Types... )
+{
+    get<ParameterPack_t::size - 1>( pp ) = t;
+}
+
+template <typename ParameterPack_t, std::size_t N, typename T,
+          typename... Types>
+void fillParameterPackImpl( ParameterPack_t &pp,
+                            const std::integral_constant<std::size_t, N>,
+                            const T &t, Types... ts )
+{
+    get<ParameterPack_t::size - 1 - N>( pp ) = t;
+    fillParameterPackImpl( pp, std::integral_constant<std::size_t, N - 1>(),
+                           ts... );
+}
+
+template <typename ParameterPack_t, typename... Types>
+void fillParameterPack( ParameterPack_t &pp, Types... ts )
+{
+    fillParameterPackImpl(
+        pp, std::integral_constant<std::size_t, ParameterPack_t::size - 1>(),
+        ts... );
+}
+
+//---------------------------------------------------------------------------//
+// Create a parameter pack.
+template <typename... Types>
+ParameterPack<Types...> makeParameterPack( Types... ts )
+{
+    ParameterPack<Types...> pp;
+    fillParameterPack( pp, ts... );
+    return pp;
+}
+
 //---------------------------------------------------------------------------//
 // Halo exchange patterns.
 //---------------------------------------------------------------------------//
@@ -81,41 +229,18 @@ namespace ScatterReduce
 // Sum values from neighboring ranks into this rank's data.
 struct Sum
 {
-    template <class ViewType, class BufferType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const ViewType &view, const BufferType &buffer, const int i,
-                const int j, const int k, const int l ) const
-    {
-        view( i, j, k, l ) += buffer( i, j, k, l );
-    }
 };
 
 // Assign this rank's data to be the minimum of it and its neighbor ranks'
 // values.
 struct Min
 {
-    template <class ViewType, class BufferType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const ViewType &view, const BufferType &buffer, const int i,
-                const int j, const int k, const int l ) const
-    {
-        if ( view( i, j, k, l ) > buffer( i, j, k, l ) )
-            view( i, j, k, l ) = buffer( i, j, k, l );
-    }
 };
 
 // Assign this rank's data to be the maximum of it and its neighbor ranks'
 // values.
 struct Max
 {
-    template <class ViewType, class BufferType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const ViewType &view, const BufferType &buffer, const int i,
-                const int j, const int k, const int l ) const
-    {
-        if ( view( i, j, k, l ) < buffer( i, j, k, l ) )
-            view( i, j, k, l ) = buffer( i, j, k, l );
-    }
 };
 
 // Replace this rank's data with its neighbor ranks' values. Note that if
@@ -124,52 +249,41 @@ struct Max
 // which neighbor that value will come.
 struct Replace
 {
-    template <class ViewType, class BufferType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const ViewType &view, const BufferType &buffer, const int i,
-                const int j, const int k, const int l ) const
-    {
-        view( i, j, k, l ) = buffer( i, j, k, l );
-    }
 };
 
 } // end namespace ScatterReduce
 
 //---------------------------------------------------------------------------//
-// Halo exchange communication plan for migrating shared data between blocks.
+// General multiple array halo communication plan for migrating shared data
+// between blocks. Arrays may be defined on different entity types and have
+// different data types.
 //---------------------------------------------------------------------------//
-template <class Scalar, class DeviceType>
-class Halo
+template <class MemorySpace>
+class MultiHalo
 {
   public:
-    // Scalar type.
-    using value_type = Scalar;
-
-    // Device type.
-    using device_type = DeviceType;
-
-    // Execution space.
-    using execution_space = typename device_type::execution_space;
-
     // Memory space.
-    using memory_space = typename device_type::memory_space;
-
-    // View type.
-    using view_type = Kokkos::View<value_type ****, device_type>;
+    using memory_space = MemorySpace;
 
     /*!
       \brief Constructor.
-      \param layout The array layout to build the halo for.
-      \param pattern The halo pattern to use for halo communication
-      \param width An option halo cell width. The default is to use the entire
-      halo width of the block.
+      \tparam The arrays types to construct the halo for.
+      \param pattern The halo pattern to use for halo communication.
+      \param width Halo cell width. Must be less than or equal to the halo
+      width of the block.
+      \param arrays The arrays to build the halo for. These arrays must be
+      provided in the same order
     */
-    template <class ArrayLayout_t>
-    Halo( const ArrayLayout_t &layout, const HaloPattern &pattern,
-          const int width = -1 )
+    template <class... ArrayTypes>
+    MultiHalo( const HaloPattern &pattern, const int width,
+               ArrayTypes... arrays )
     {
-        // Duplicate the communicator so we have our own communication space.
-        MPI_Comm_dup( layout.localGrid()->globalGrid().comm(), &_comm );
+        // Get the MPI communicator. All arrays should have the same
+        // communicator.
+        getComm( arrays... );
+
+        // Get the local grid.
+        auto local_grid = getLocalGrid( arrays... );
 
         // Function to get the local id of the neighbor.
         auto neighbor_id = []( const int i, const int j, const int k ) {
@@ -202,7 +316,7 @@ class Halo
             auto k = n[Dim::K];
 
             // Get the rank of the neighbor.
-            int rank = layout.localGrid()->neighborRank( i, j, k );
+            int rank = local_grid->neighborRank( i, j, k );
 
             // If this is a valid rank add it as a neighbor.
             if ( rank >= 0 )
@@ -210,65 +324,46 @@ class Halo
                 // Add the rank.
                 _neighbor_ranks.push_back( rank );
 
-                // Set the tag we will use to send data to this
-                // neighbor. The receiving rank should have a
-                // matching tag.
+                // Set the tag we will use to send data to this neighbor. The
+                // receiving rank should have a matching tag.
                 _send_tags.push_back( neighbor_id( i, j, k ) );
 
-                // Set the tag we will use to receive data from
-                // this neighbor. The sending rank should have a
-                // matching tag.
+                // Set the tag we will use to receive data from this
+                // neighbor. The sending rank should have a matching tag.
                 _receive_tags.push_back(
                     neighbor_id( flip( i ), flip( j ), flip( k ) ) );
 
-                // Get the owned index space we share with this
-                // neighbor.
-                _owned_spaces.push_back(
-                    layout.sharedIndexSpace( Own(), i, j, k, width ) );
+                // Create communication data for owned entities.
+                buildCommData( Own(), width, i, j, k, _owned_buffers,
+                               _owned_steering, arrays... );
 
-                // Create the buffer of data we own that we share
-                // with this neighbor.
-                _owned_buffers.push_back( createView<value_type, device_type>(
-                    "halo_owned_buffer", _owned_spaces.back() ) );
-
-                // Get the ghosted index space we share with this
-                // neighbor.
-                _ghosted_spaces.push_back(
-                    layout.sharedIndexSpace( Ghost(), i, j, k, width ) );
-
-                // Create the buffer of ghost data that is owned
-                // by our neighbor
-                _ghosted_buffers.push_back( createView<value_type, device_type>(
-                    "halo_ghosted_buffer", _ghosted_spaces.back() ) );
+                // Create communication data for ghosted entities.
+                buildCommData( Ghost(), width, i, j, k, _ghosted_buffers,
+                               _ghosted_steering, arrays... );
             }
         }
     }
 
     // Destructor.
-    ~Halo() { MPI_Comm_free( &_comm ); }
+    ~MultiHalo() { MPI_Comm_free( &_comm ); }
 
     /*!
       \brief Gather data into our ghosts from their owners.
-      \param array The array to gather.
-    */
-    template <class Array_t>
-    void gather( const Array_t &array ) const
-    {
-        // Check that the array type is valid.
-        static_assert(
-            std::is_same<value_type, typename Array_t::value_type>::value,
-            "Array value type does not match halo value type" );
-        static_assert(
-            std::is_same<memory_space, typename Array_t::memory_space>::value,
-            "Array memory space does not match halo memory space" );
 
+      \param exec_space The execution space to use for pack/unpack.
+
+      \param arrays The arrays to gather. NOTE: These arrays must be given in
+      the same order as in the constructor. These could technically be
+      different arrays, they just need to have the same layouts and data types
+      as the input arrays.
+    */
+    template <class ExecutionSpace, class... ArrayTypes>
+    void gather( const ExecutionSpace &exec_space, ArrayTypes... arrays ) const
+    {
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
         if ( 0 == num_n )
             return;
-
-        // Get the array data.
-        auto view = array.view();
 
         // Allocate requests.
         std::vector<MPI_Request> requests( 2 * num_n, MPI_REQUEST_NULL );
@@ -284,9 +379,9 @@ class Halo
             if ( 0 < _ghosted_buffers[n].size() )
             {
                 MPI_Irecv( _ghosted_buffers[n].data(),
-                           _ghosted_buffers[n].size(),
-                           MpiTraits<value_type>::type(), _neighbor_ranks[n],
-                           mpi_tag + _receive_tags[n], _comm, &requests[n] );
+                           _ghosted_buffers[n].size(), MPI_BYTE,
+                           _neighbor_ranks[n], mpi_tag + _receive_tags[n],
+                           _comm, &requests[n] );
             }
         }
 
@@ -297,12 +392,12 @@ class Halo
             if ( 0 < _owned_buffers[n].size() )
             {
                 // Pack the send buffer.
-                auto subview = createSubview( view, _owned_spaces[n] );
-                Kokkos::deep_copy( _owned_buffers[n], subview );
+                packBuffer( exec_space, _owned_buffers[n], _owned_steering[n],
+                            arrays.view()... );
 
                 // Post a send.
                 MPI_Isend( _owned_buffers[n].data(), _owned_buffers[n].size(),
-                           MpiTraits<value_type>::type(), _neighbor_ranks[n],
+                           MPI_BYTE, _neighbor_ranks[n],
                            mpi_tag + _send_tags[n], _comm,
                            &requests[num_n + n] );
             }
@@ -326,9 +421,10 @@ class Halo
             // Otherwise unpack the next buffer.
             else
             {
-                auto subview =
-                    createSubview( view, _ghosted_spaces[unpack_index] );
-                Kokkos::deep_copy( subview, _ghosted_buffers[unpack_index] );
+                unpackBuffer( ScatterReduce::Replace(), exec_space,
+                              _ghosted_buffers[unpack_index],
+                              _ghosted_steering[unpack_index],
+                              arrays.view()... );
             }
         }
 
@@ -337,40 +433,20 @@ class Halo
     }
 
     /*!
-      \brief Scatter data from our ghosts to their owners. Default sum
-      implementation.
-      \param array The array to scatter.
-    */
-    template <class Array_t>
-    void scatter( const Array_t &array ) const
-    {
-        scatter( array, ScatterReduce::Sum() );
-    }
-
-    /*!
       \brief Scatter data from our ghosts to their owners using the given type
       of reduce operation.
-      \param array The array to scatter.
-      \param reduce The functor used to reduce the results.
+      \param reduce_op The functor used to reduce the results.
+      \param exec_space The execution space to use for pack/unpack.
+      \param arrays The arrays to scatter.
     */
-    template <class Array_t, class ReduceFunc>
-    void scatter( const Array_t &array, const ReduceFunc &reduce ) const
+    template <class ExecutionSpace, class ReduceOp, class... ArrayTypes>
+    void scatter( const ExecutionSpace &exec_space, const ReduceOp &reduce_op,
+                  ArrayTypes... arrays ) const
     {
-        // Check that the array type is valid.
-        static_assert(
-            std::is_same<value_type, typename Array_t::value_type>::value,
-            "Array value type does not match halo value type" );
-        static_assert(
-            std::is_same<memory_space, typename Array_t::memory_space>::value,
-            "Array memory space does not match halo memory space" );
-
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
         if ( 0 == num_n )
             return;
-
-        // Get the array data.
-        auto view = array.view();
 
         // Requests.
         std::vector<MPI_Request> requests( 2 * num_n, MPI_REQUEST_NULL );
@@ -386,7 +462,7 @@ class Halo
             if ( 0 < _owned_buffers[n].size() )
             {
                 MPI_Irecv( _owned_buffers[n].data(), _owned_buffers[n].size(),
-                           MpiTraits<value_type>::type(), _neighbor_ranks[n],
+                           MPI_BYTE, _neighbor_ranks[n],
                            mpi_tag + _receive_tags[n], _comm, &requests[n] );
             }
         }
@@ -398,14 +474,14 @@ class Halo
             if ( 0 < _ghosted_buffers[n].size() )
             {
                 // Pack the send buffer.
-                auto subview = createSubview( view, _ghosted_spaces[n] );
-                Kokkos::deep_copy( _ghosted_buffers[n], subview );
+                packBuffer( exec_space, _ghosted_buffers[n],
+                            _ghosted_steering[n], arrays.view()... );
 
                 // Post a send.
-                MPI_Isend(
-                    _ghosted_buffers[n].data(), _ghosted_buffers[n].size(),
-                    MpiTraits<value_type>::type(), _neighbor_ranks[n],
-                    mpi_tag + _send_tags[n], _comm, &requests[num_n + n] );
+                MPI_Isend( _ghosted_buffers[n].data(),
+                           _ghosted_buffers[n].size(), MPI_BYTE,
+                           _neighbor_ranks[n], mpi_tag + _send_tags[n], _comm,
+                           &requests[num_n + n] );
             }
         }
 
@@ -427,21 +503,9 @@ class Halo
             // Otherwise unpack the next buffer and apply the reduce operation.
             else
             {
-                auto subview =
-                    createSubview( view, _owned_spaces[unpack_index] );
-                auto owned_buffer = _owned_buffers[unpack_index];
-                IndexSpace<4> scatter_space(
-                    {static_cast<long>( subview.extent( 0 ) ),
-                     static_cast<long>( subview.extent( 1 ) ),
-                     static_cast<long>( subview.extent( 2 ) ),
-                     static_cast<long>( subview.extent( 3 ) )} );
-                Kokkos::parallel_for(
-                    "Cajita::Halo::scatterOwned",
-                    createExecutionPolicy( scatter_space, execution_space() ),
-                    KOKKOS_LAMBDA( const int i, const int j, const int k,
-                                   const int l ) {
-                        reduce( subview, owned_buffer, i, j, k, l );
-                    } );
+                unpackBuffer( reduce_op, exec_space,
+                              _owned_buffers[unpack_index],
+                              _owned_steering[unpack_index], arrays.view()... );
             }
 
             // Wait on send requests.
@@ -449,15 +513,478 @@ class Halo
         }
     }
 
+  public:
+    // Get the byte sizes of the array value types.
+    template <class Array_t>
+    void getByteSizes( std::vector<int> &byte_sizes, const int array_idx,
+                       const Array_t & )
+    {
+        byte_sizes[array_idx] = sizeof( typename Array_t::value_type );
+    }
+
+    template <class Array_t, class... ArrayTypes>
+    void getByteSizes( std::vector<int> &byte_sizes, const int array_idx,
+                       const Array_t &, ArrayTypes... arrays )
+    {
+        byte_sizes[array_idx] = sizeof( typename Array_t::value_type );
+        getByteSizes( byte_sizes, array_idx + 1, arrays... );
+    }
+
+    // Get the communicator.
+    template <class Array_t, class... ArrayTypes>
+    void getComm( const Array_t &array, ArrayTypes... )
+    {
+        // Duplicate the communicator so we have our own communication space.
+        MPI_Comm_dup( array.layout()->localGrid()->globalGrid().comm(),
+                      &_comm );
+    }
+
+    // Get the local grid from the arrays.
+    template <class Array_t, class... ArrayTypes>
+    auto getLocalGrid( const Array_t &array, ArrayTypes... )
+    {
+        return array.layout()->localGrid();
+    }
+
+    // Get the shared index space of an array for a given neighbor in the
+    // given decomposition.
+    template <class DecompositionTag, class Array_t>
+    void getSharedSpace( std::vector<IndexSpace<4>> &shared_spaces,
+                         DecompositionTag, const int i, const int j,
+                         const int k, const int width, const int array_idx,
+                         const Array_t &array )
+    {
+        shared_spaces[array_idx] = array.layout()->sharedIndexSpace(
+            DecompositionTag(), i, j, k, width );
+    }
+
+    template <class DecompositionTag, class Array_t, class... ArrayTypes>
+    void getSharedSpace( std::vector<IndexSpace<4>> &shared_spaces,
+                         DecompositionTag decomposition_tag, const int i,
+                         const int j, const int k, const int width,
+                         const int array_idx, const Array_t &array,
+                         ArrayTypes... arrays )
+    {
+        shared_spaces[array_idx] = array.layout()->sharedIndexSpace(
+            decomposition_tag, i, j, k, width );
+        getSharedSpace( shared_spaces, decomposition_tag, i, j, k, width,
+                        array_idx + 1, arrays... );
+    }
+
+    // Build communication data.
+    template <class DecompositionTag, class... ArrayTypes>
+    void
+    buildCommData( DecompositionTag decomposition_tag, const int width,
+                   const int ni, const int nj, const int nk,
+                   std::vector<Kokkos::View<char *, memory_space>> &buffers,
+                   std::vector<Kokkos::View<int * [6], memory_space>> &steering,
+                   ArrayTypes... arrays )
+    {
+        // Number of arrays.
+        int num_array = sizeof...( ArrayTypes );
+
+        // Get the byte sizes of array value types.
+        std::vector<int> value_byte_sizes( num_array );
+        getByteSizes( value_byte_sizes, 0, arrays... );
+
+        // Get the index spaces we share with this neighbor. We
+        // get a shared index space for each array.
+        std::vector<IndexSpace<4>> spaces( num_array );
+        getSharedSpace( spaces, decomposition_tag, ni, nj, nk, width, 0,
+                        arrays... );
+
+        // Compute the buffer size of this neighbor and the
+        // number of elements in the buffer.
+        int buffer_bytes = 0;
+        int buffer_num_element = 0;
+        for ( int a = 0; a < num_array; ++a )
+        {
+            buffer_bytes += value_byte_sizes[a] * spaces[a].size();
+            buffer_num_element += spaces[a].size();
+        }
+
+        // Allocate the buffer of data that we share with this neighbor. All
+        // arrays will be packed into a single buffer.
+        buffers.push_back(
+            Kokkos::View<char *, memory_space>( "halo_buffer", buffer_bytes ) );
+
+        // Allocate the steering vector for building the buffer.
+        steering.push_back( Kokkos::View<int * [6], memory_space>(
+            "steering", buffer_num_element ) );
+
+        // Create the steering vector. For each element in the buffer it gives
+        // the starting byte location of the element, the array the element is
+        // in, and the ijkl structured index in the array of the element.
+        auto host_steering =
+            Kokkos::create_mirror_view( Kokkos::HostSpace(), steering.back() );
+        int elem_counter = 0;
+        int byte_counter = 0;
+        for ( int a = 0; a < num_array; ++a )
+        {
+            for ( int i = spaces[a].min( 0 ); i < spaces[a].max( 0 ); ++i )
+            {
+                for ( int j = spaces[a].min( 1 ); j < spaces[a].max( 1 ); ++j )
+                {
+                    for ( int k = spaces[a].min( 2 ); k < spaces[a].max( 2 );
+                          ++k )
+                    {
+                        for ( int l = spaces[a].min( 3 );
+                              l < spaces[a].max( 3 ); ++l )
+                        {
+                            // Byte starting location in buffer.
+                            host_steering( elem_counter, 0 ) = byte_counter;
+
+                            // Array location of element.
+                            host_steering( elem_counter, 1 ) = a;
+
+                            // Structured index in array of element.
+                            host_steering( elem_counter, 2 ) = i;
+                            host_steering( elem_counter, 3 ) = j;
+                            host_steering( elem_counter, 4 ) = k;
+                            host_steering( elem_counter, 5 ) = l;
+
+                            // Update element id.
+                            ++elem_counter;
+
+                            // Update buffer position.
+                            byte_counter += value_byte_sizes[a];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check that all elements and bytes are accounted for.
+        if ( byte_counter != buffer_bytes )
+            throw std::logic_error( "Steering vector contains different number "
+                                    "of bytes than buffer" );
+        if ( elem_counter != buffer_num_element )
+            throw std::logic_error( "Steering vector contains different number "
+                                    "of elements than buffer" );
+
+        // Copy steering vector to device.
+        Kokkos::deep_copy( steering.back(), host_steering );
+    }
+
+    // Pack an element into the buffer. Pack by bytes to avoid casting across
+    // alignment boundaries.
+    template <class ArrayView>
+    KOKKOS_INLINE_FUNCTION void
+    packElement( const Kokkos::View<char *, memory_space> &buffer,
+                 const Kokkos::View<int * [6], memory_space> &steering,
+                 const int element_idx, const ArrayView &array_view ) const
+    {
+        const char *elem_ptr = reinterpret_cast<const char *>( &array_view(
+            steering( element_idx, 2 ), steering( element_idx, 3 ),
+            steering( element_idx, 4 ), steering( element_idx, 5 ) ) );
+        for ( std::size_t b = 0; b < sizeof( typename ArrayView::value_type );
+              ++b )
+        {
+            buffer( steering( element_idx, 0 ) + b ) = *( elem_ptr + b );
+        }
+    }
+
+    // Pack an array into a buffer.
+    template <class... ArrayViews>
+    KOKKOS_INLINE_FUNCTION void
+    packArray( const Kokkos::View<char *, memory_space> &buffer,
+               const Kokkos::View<int * [6], memory_space> &steering,
+               const int element_idx,
+               const std::integral_constant<std::size_t, 0>,
+               const ParameterPack<ArrayViews...> &array_views ) const
+    {
+        // If the pack element_idx is in the current array, pack it.
+        if ( 0 == steering( element_idx, 1 ) )
+            packElement( buffer, steering, element_idx, get<0>( array_views ) );
+    }
+
+    // Pack an array into a buffer.
+    template <std::size_t N, class... ArrayViews>
+    KOKKOS_INLINE_FUNCTION void
+    packArray( const Kokkos::View<char *, memory_space> &buffer,
+               const Kokkos::View<int * [6], memory_space> &steering,
+               const int element_idx,
+               const std::integral_constant<std::size_t, N>,
+               const ParameterPack<ArrayViews...> &array_views ) const
+    {
+        // If the pack element_idx is in the current array, pack it.
+        if ( N == steering( element_idx, 1 ) )
+            packElement( buffer, steering, element_idx, get<N>( array_views ) );
+
+        // Recurse.
+        packArray( buffer, steering, element_idx,
+                   std::integral_constant<std::size_t, N - 1>(), array_views );
+    }
+
+    // Pack arrays into a buffer.
+    template <class ExecutionSpace, class... ArrayViews>
+    void packBuffer( const ExecutionSpace &exec_space,
+                     const Kokkos::View<char *, memory_space> &buffer,
+                     const Kokkos::View<int * [6], memory_space> &steering,
+                     ArrayViews... array_views ) const
+    {
+        auto pp = makeParameterPack( array_views... );
+        Kokkos::parallel_for(
+            "pack_buffer",
+            Kokkos::RangePolicy<ExecutionSpace>( exec_space, 0,
+                                                 steering.extent( 0 ) ),
+            KOKKOS_LAMBDA( const int i ) {
+                packArray(
+                    buffer, steering, i,
+                    std::integral_constant<std::size_t,
+                                           sizeof...( ArrayViews ) - 1>(),
+                    pp );
+            } );
+        exec_space.fence();
+    }
+
+    // Reduce an element into the buffer. Sum reduction.
+    template <class T>
+    KOKKOS_INLINE_FUNCTION void
+    unpackOp( ScatterReduce::Sum, const T &buffer_val, T &array_val ) const
+    {
+        array_val += buffer_val;
+    }
+
+    // Reduce an element into the buffer. Min reduction.
+    template <class T>
+    KOKKOS_INLINE_FUNCTION void
+    unpackOp( ScatterReduce::Min, const T &buffer_val, T &array_val ) const
+    {
+        if ( buffer_val < array_val )
+            array_val = buffer_val;
+    }
+
+    // Reduce an element into the buffer. Max reduction.
+    template <class T>
+    KOKKOS_INLINE_FUNCTION void
+    unpackOp( ScatterReduce::Max, const T &buffer_val, T &array_val ) const
+    {
+        if ( buffer_val > array_val )
+            array_val = buffer_val;
+    }
+
+    // Reduce an element into the buffer. Replace reduction.
+    template <class T>
+    KOKKOS_INLINE_FUNCTION void
+    unpackOp( ScatterReduce::Replace, const T &buffer_val, T &array_val ) const
+    {
+        array_val = buffer_val;
+    }
+
+    // Unpack an element from the buffer. Unpack by bytes to avoid casting
+    // across alignment boundaries.
+    template <class ReduceOp, class ArrayView>
+    KOKKOS_INLINE_FUNCTION void
+    unpackElement( const ReduceOp &reduce_op,
+                   const Kokkos::View<char *, memory_space> &buffer,
+                   const Kokkos::View<int * [6], memory_space> &steering,
+                   const int element_idx, const ArrayView &array_view ) const
+    {
+        typename ArrayView::value_type elem;
+        char *elem_ptr = reinterpret_cast<char *>( &elem );
+        for ( std::size_t b = 0; b < sizeof( typename ArrayView::value_type );
+              ++b )
+        {
+            *( elem_ptr + b ) = buffer( steering( element_idx, 0 ) + b );
+        }
+        unpackOp( reduce_op, elem,
+                  array_view( steering( element_idx, 2 ),
+                              steering( element_idx, 3 ),
+                              steering( element_idx, 4 ),
+                              steering( element_idx, 5 ) ) );
+    }
+
+    // Unpack an array from a buffer.
+    template <class ReduceOp, class... ArrayViews>
+    KOKKOS_INLINE_FUNCTION void
+    unpackArray( const ReduceOp &reduce_op,
+                 const Kokkos::View<char *, memory_space> &buffer,
+                 const Kokkos::View<int * [6], memory_space> &steering,
+                 const int element_idx,
+                 const std::integral_constant<std::size_t, 0>,
+                 const ParameterPack<ArrayViews...> &array_views ) const
+    {
+        // If the unpack element_idx is in the current array, unpack it.
+        if ( 0 == steering( element_idx, 1 ) )
+            unpackElement( reduce_op, buffer, steering, element_idx,
+                           get<0>( array_views ) );
+    }
+
+    // Unpack an array from a buffer.
+    template <class ReduceOp, std::size_t N, class... ArrayViews>
+    KOKKOS_INLINE_FUNCTION void
+    unpackArray( const ReduceOp reduce_op,
+                 const Kokkos::View<char *, memory_space> &buffer,
+                 const Kokkos::View<int * [6], memory_space> &steering,
+                 const int element_idx,
+                 const std::integral_constant<std::size_t, N>,
+                 const ParameterPack<ArrayViews...> &array_views ) const
+    {
+        // If the unpack element_idx is in the current array, unpack it.
+        if ( N == steering( element_idx, 1 ) )
+            unpackElement( reduce_op, buffer, steering, element_idx,
+                           get<N>( array_views ) );
+
+        // Recurse.
+        unpackArray( reduce_op, buffer, steering, element_idx,
+                     std::integral_constant<std::size_t, N - 1>(),
+                     array_views );
+    }
+
+    // Unpack arrays from a buffer.
+    template <class ExecutionSpace, class ReduceOp, class... ArrayViews>
+    void unpackBuffer( const ReduceOp &reduce_op,
+                       const ExecutionSpace &exec_space,
+                       const Kokkos::View<char *, memory_space> &buffer,
+                       const Kokkos::View<int * [6], memory_space> &steering,
+                       ArrayViews... array_views ) const
+    {
+        auto pp = makeParameterPack( array_views... );
+        Kokkos::parallel_for(
+            "unpack_buffer",
+            Kokkos::RangePolicy<ExecutionSpace>( exec_space, 0,
+                                                 steering.extent( 0 ) ),
+            KOKKOS_LAMBDA( const int i ) {
+                unpackArray(
+                    reduce_op, buffer, steering, i,
+                    std::integral_constant<std::size_t,
+                                           sizeof...( ArrayViews ) - 1>(),
+                    pp );
+            } );
+    }
+
   private:
+    // MPI communicator.
     MPI_Comm _comm;
+
+    // The ranks we will send/receive from.
     std::vector<int> _neighbor_ranks;
+
+    // The tag we use for sending to each neighbor.
     std::vector<int> _send_tags;
+
+    // The tag we use for receiveing from each neighbor.
     std::vector<int> _receive_tags;
-    std::vector<IndexSpace<4>> _owned_spaces;
-    std::vector<view_type> _owned_buffers;
-    std::vector<IndexSpace<4>> _ghosted_spaces;
-    std::vector<view_type> _ghosted_buffers;
+
+    // For each neighbor, send/receive buffers for data we own.
+    std::vector<Kokkos::View<char *, memory_space>> _owned_buffers;
+
+    // For each neighbor, send/receive buffers for data we ghost.
+    std::vector<Kokkos::View<char *, memory_space>> _ghosted_buffers;
+
+    // For each neighbor, steering vector for the owned buffer.
+    std::vector<Kokkos::View<int * [6], memory_space>> _owned_steering;
+
+    // For each neighbor, steering vector for the ghosted buffer.
+    std::vector<Kokkos::View<int * [6], memory_space>> _ghosted_steering;
+};
+
+//---------------------------------------------------------------------------//
+// Infer array memory space.
+template <class ArrayT, class... Types>
+struct ArrayPackMemorySpace
+{
+    using type = typename ArrayT::memory_space;
+};
+
+//---------------------------------------------------------------------------//
+// Creation function.
+template <class... ArrayTypes>
+auto createMultiHalo( const HaloPattern &pattern, const int width,
+                      ArrayTypes... arrays )
+{
+    using memory_space = typename ArrayPackMemorySpace<ArrayTypes...>::type;
+    return std::make_shared<MultiHalo<memory_space>>( pattern, width,
+                                                      arrays... );
+}
+
+//---------------------------------------------------------------------------//
+// Single array halo exchange communication plan for migrating shared data
+// between blocks.
+// ---------------------------------------------------------------------------//
+template <class Scalar, class DeviceType>
+class Halo
+{
+  public:
+    // Scalar type.
+    using value_type = Scalar;
+
+    // Device type.
+    using device_type = DeviceType;
+
+    // Execution space.
+    using execution_space = typename device_type::execution_space;
+
+    // Memory space.
+    using memory_space = typename device_type::memory_space;
+
+    // View type.
+    using view_type = Kokkos::View<value_type ****, device_type>;
+
+    // Array-like container to hold layout and data information.
+    template <class ScalarT, class MemorySpaceT, class ArrayLayoutT>
+    struct LayoutContainer
+    {
+        using value_type = ScalarT;
+        using memory_space = MemorySpaceT;
+        const ArrayLayoutT &array_layout;
+        const ArrayLayoutT *layout() const { return &array_layout; }
+    };
+
+    /*!
+      \brief Constructor.
+      \param layout The array layout to build the halo for.
+      \param pattern The halo pattern to use for halo communication
+      \param width An option halo cell width. The default is to use the entire
+      halo width of the block.
+    */
+    template <class ArrayLayout_t>
+    Halo( const ArrayLayout_t &layout, const HaloPattern &pattern,
+          const int width = -1 )
+    {
+        // Wrap data in an array-like container.
+        LayoutContainer<Scalar, memory_space, ArrayLayout_t> container{layout};
+
+        // Create a multi-halo.
+        _mhalo = createMultiHalo( pattern, width, container );
+    }
+
+    /*!
+      \brief Gather data into our ghosts from their owners.
+      \param array The array to gather.
+    */
+    template <class Array_t>
+    void gather( const Array_t &array ) const
+    {
+        _mhalo->gather( execution_space(), array );
+    }
+
+    /*!
+      \brief Scatter data from our ghosts to their owners. Default sum
+      implementation.
+      \param array The array to scatter.
+    */
+    template <class Array_t>
+    void scatter( const Array_t &array ) const
+    {
+        scatter( array, ScatterReduce::Sum() );
+    }
+
+    /*!
+      \brief Scatter data from our ghosts to their owners using the given type
+      of reduce operation.
+      \param array The array to scatter.
+      \param reduce_op The functor used to reduce the results.
+    */
+    template <class Array_t, class ReduceOp>
+    void scatter( const Array_t &array, const ReduceOp &reduce_op ) const
+    {
+        _mhalo->scatter( execution_space(), reduce_op, array );
+    }
+
+  private:
+    std::shared_ptr<MultiHalo<memory_space>> _mhalo;
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -142,7 +142,7 @@ get( const ParameterPack_t &pp )
 template <typename ParameterPack_t, typename T, typename... Types>
 void fillParameterPackImpl( ParameterPack_t &pp,
                             const std::integral_constant<std::size_t, 0>,
-                            const T &t, Types... )
+                            const T &t, const Types&... )
 {
     get<ParameterPack_t::size - 1>( pp ) = t;
 }
@@ -151,7 +151,7 @@ template <typename ParameterPack_t, std::size_t N, typename T,
           typename... Types>
 void fillParameterPackImpl( ParameterPack_t &pp,
                             const std::integral_constant<std::size_t, N>,
-                            const T &t, Types... ts )
+                            const T &t, const Types&... ts )
 {
     get<ParameterPack_t::size - 1 - N>( pp ) = t;
     fillParameterPackImpl( pp, std::integral_constant<std::size_t, N - 1>(),
@@ -159,7 +159,7 @@ void fillParameterPackImpl( ParameterPack_t &pp,
 }
 
 template <typename ParameterPack_t, typename... Types>
-void fillParameterPack( ParameterPack_t &pp, Types... ts )
+void fillParameterPack( ParameterPack_t &pp, const Types&... ts )
 {
     fillParameterPackImpl(
         pp, std::integral_constant<std::size_t, ParameterPack_t::size - 1>(),
@@ -169,7 +169,7 @@ void fillParameterPack( ParameterPack_t &pp, Types... ts )
 //---------------------------------------------------------------------------//
 // Create a parameter pack.
 template <typename... Types>
-ParameterPack<Types...> makeParameterPack( Types... ts )
+ParameterPack<Types...> makeParameterPack( const Types&... ts )
 {
     ParameterPack<Types...> pp;
     fillParameterPack( pp, ts... );
@@ -276,7 +276,7 @@ class MultiHalo
     */
     template <class... ArrayTypes>
     MultiHalo( const HaloPattern &pattern, const int width,
-               ArrayTypes... arrays )
+               const ArrayTypes&... arrays )
     {
         // Get the MPI communicator. All arrays should have the same
         // communicator.
@@ -358,7 +358,7 @@ class MultiHalo
       as the input arrays.
     */
     template <class ExecutionSpace, class... ArrayTypes>
-    void gather( const ExecutionSpace &exec_space, ArrayTypes... arrays ) const
+    void gather( const ExecutionSpace &exec_space, const ArrayTypes&... arrays ) const
     {
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
@@ -441,7 +441,7 @@ class MultiHalo
     */
     template <class ExecutionSpace, class ReduceOp, class... ArrayTypes>
     void scatter( const ExecutionSpace &exec_space, const ReduceOp &reduce_op,
-                  ArrayTypes... arrays ) const
+                  const ArrayTypes&... arrays ) const
     {
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
@@ -524,7 +524,7 @@ class MultiHalo
 
     template <class Array_t, class... ArrayTypes>
     void getByteSizes( std::vector<int> &byte_sizes, const int array_idx,
-                       const Array_t &, ArrayTypes... arrays )
+                       const Array_t &, const ArrayTypes&... arrays )
     {
         byte_sizes[array_idx] = sizeof( typename Array_t::value_type );
         getByteSizes( byte_sizes, array_idx + 1, arrays... );
@@ -532,7 +532,7 @@ class MultiHalo
 
     // Get the communicator.
     template <class Array_t, class... ArrayTypes>
-    void getComm( const Array_t &array, ArrayTypes... )
+    void getComm( const Array_t &array, const ArrayTypes&... )
     {
         // Duplicate the communicator so we have our own communication space.
         MPI_Comm_dup( array.layout()->localGrid()->globalGrid().comm(),
@@ -541,7 +541,7 @@ class MultiHalo
 
     // Get the local grid from the arrays.
     template <class Array_t, class... ArrayTypes>
-    auto getLocalGrid( const Array_t &array, ArrayTypes... )
+    auto getLocalGrid( const Array_t &array, const ArrayTypes&... )
     {
         return array.layout()->localGrid();
     }
@@ -563,7 +563,7 @@ class MultiHalo
                          DecompositionTag decomposition_tag, const int i,
                          const int j, const int k, const int width,
                          const int array_idx, const Array_t &array,
-                         ArrayTypes... arrays )
+                         const ArrayTypes&... arrays )
     {
         shared_spaces[array_idx] = array.layout()->sharedIndexSpace(
             decomposition_tag, i, j, k, width );
@@ -578,7 +578,7 @@ class MultiHalo
                    const int ni, const int nj, const int nk,
                    std::vector<Kokkos::View<char *, memory_space>> &buffers,
                    std::vector<Kokkos::View<int * [6], memory_space>> &steering,
-                   ArrayTypes... arrays )
+                   const ArrayTypes&... arrays )
     {
         // Number of arrays.
         int num_array = sizeof...( ArrayTypes );
@@ -892,7 +892,7 @@ struct ArrayPackMemorySpace
 // Creation function.
 template <class... ArrayTypes>
 auto createMultiHalo( const HaloPattern &pattern, const int width,
-                      ArrayTypes... arrays )
+                      const ArrayTypes&... arrays )
 {
     using memory_space = typename ArrayPackMemorySpace<ArrayTypes...>::type;
     return std::make_shared<MultiHalo<memory_space>>( pattern, width,

--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -307,7 +307,8 @@ createView( const IndexSpace<4> &index_space, Scalar *data )
   Rank-1 specialization.
 */
 template <class ViewType>
-auto createSubview( const ViewType &view, const IndexSpace<1> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
+                                           const IndexSpace<1> &index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ) ) )
 {
     static_assert( 1 == ViewType::Rank, "Incorrect view rank" );
@@ -321,7 +322,8 @@ auto createSubview( const ViewType &view, const IndexSpace<1> &index_space )
   Rank-2 specialization.
 */
 template <class ViewType>
-auto createSubview( const ViewType &view, const IndexSpace<2> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
+                                           const IndexSpace<2> &index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ) ) )
 {
@@ -337,7 +339,8 @@ auto createSubview( const ViewType &view, const IndexSpace<2> &index_space )
   Rank-3 specialization.
 */
 template <class ViewType>
-auto createSubview( const ViewType &view, const IndexSpace<3> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
+                                           const IndexSpace<3> &index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ),
                                   index_space.range( 2 ) ) )
@@ -354,7 +357,8 @@ auto createSubview( const ViewType &view, const IndexSpace<3> &index_space )
   Rank-4 specialization.
 */
 template <class ViewType>
-auto createSubview( const ViewType &view, const IndexSpace<4> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
+                                           const IndexSpace<4> &index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ),
                                   index_space.range( 2 ),

--- a/cajita/src/Cajita_ReferenceStructuredSolver.hpp
+++ b/cajita/src/Cajita_ReferenceStructuredSolver.hpp
@@ -41,6 +41,8 @@ class ReferenceStructuredSolver
     // Types.
     using entity_type = EntityType;
     using device_type = DeviceType;
+    using memory_space = typename device_type::memory_space;
+    using execution_space = typename device_type::execution_space;
     using value_type = Scalar;
     using Array_t = Array<Scalar, EntityType, MeshType, DeviceType>;
 
@@ -131,7 +133,18 @@ class ReferenceConjugateGradient
     using device_type = DeviceType;
     using value_type = Scalar;
     using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
     using Array_t = Array<Scalar, EntityType, MeshType, DeviceType>;
+
+    // Array-like container to hold layout and data information.
+    template <class ScalarT, class MemorySpaceT, class ArrayLayoutT>
+    struct LayoutContainer
+    {
+        using value_type = ScalarT;
+        using memory_space = MemorySpaceT;
+        const ArrayLayoutT &array_layout;
+        const ArrayLayoutT *layout() const { return &array_layout; }
+    };
 
     /*!
       \brief Constructor.
@@ -267,7 +280,7 @@ class ReferenceConjugateGradient
         Kokkos::deep_copy( p_old_view, x_view );
 
         // Gather the LHS through gatheing p and z.
-        _A_halo->gather( *A_halo_vectors );
+        _A_halo->gather( execution_space(), *A_halo_vectors );
 
         // Compute the initial residual and norm.
         _residual_norm = 0.0;
@@ -313,11 +326,10 @@ class ReferenceConjugateGradient
             return;
 
         // r and q.
-        _M_halo->gather( *M_halo_vectors );
+        _M_halo->gather( execution_space(), *M_halo_vectors );
 
         // Compute the initial preconditioned residual.
         Scalar zTr_old = 0.0;
-        _M_halo->gather( *M_halo_vectors );
         Kokkos::parallel_reduce(
             "compute_z0",
             createExecutionPolicy( entity_space, execution_space() ),
@@ -348,7 +360,7 @@ class ReferenceConjugateGradient
                        MPI_SUM, local_grid->globalGrid().comm() );
 
         // Gather the LHS through gatheing p and z.
-        _A_halo->gather( *A_halo_vectors );
+        _A_halo->gather( execution_space(), *A_halo_vectors );
 
         // Compute A*p and pT*A*p.
         Scalar pTAp = 0.0;
@@ -389,7 +401,7 @@ class ReferenceConjugateGradient
         while ( _residual_norm > _tol && _num_iter < _max_iter )
         {
             // Gather r and q.
-            _M_halo->gather( *M_halo_vectors );
+            _M_halo->gather( execution_space(), *M_halo_vectors );
 
             // Kernel 1: Compute x, r, residual norm, and zTr
             alpha = zTr_old / pTAp;
@@ -461,7 +473,7 @@ class ReferenceConjugateGradient
             }
 
             // Gather p and z.
-            _A_halo->gather( *A_halo_vectors );
+            _A_halo->gather( execution_space(), *A_halo_vectors );
 
             // Kernel 2: Compute p, A*p, and p^T*A*p
             beta = zTr_new / zTr_old;
@@ -535,7 +547,7 @@ class ReferenceConjugateGradient
     void setStencil( const std::vector<std::array<int, 3>> &stencil,
                      const bool is_symmetric,
                      Kokkos::View<int * [3], DeviceType> &device_stencil,
-                     std::shared_ptr<Halo<Scalar, DeviceType>> &halo,
+                     std::shared_ptr<Halo<memory_space>> &halo,
                      std::shared_ptr<Array_t> &matrix )
     {
         // For now we don't support symmetry.
@@ -601,8 +613,8 @@ class ReferenceConjugateGradient
     int _diag_entry;
     Kokkos::View<int * [3], DeviceType> _A_stencil;
     Kokkos::View<int * [3], DeviceType> _M_stencil;
-    std::shared_ptr<Halo<Scalar, DeviceType>> _A_halo;
-    std::shared_ptr<Halo<Scalar, DeviceType>> _M_halo;
+    std::shared_ptr<Halo<memory_space>> _A_halo;
+    std::shared_ptr<Halo<memory_space>> _M_halo;
     std::shared_ptr<Array_t> _A;
     std::shared_ptr<Array_t> _M;
     std::shared_ptr<Array_t> _vectors;

--- a/cajita/unit_test/tstHalo.hpp
+++ b/cajita/unit_test/tstHalo.hpp
@@ -172,19 +172,19 @@ void gatherScatterTest( const ManualPartitioner &partitioner,
         auto halo = createHalo( *array, FullHaloPattern(), halo_width );
 
         // Gather into the ghosts.
-        halo->gather( *array );
+        halo->gather( TEST_EXECSPACE(), *array );
 
         // Check the gather.
         checkGather( halo_width, *array );
 
         // Scatter from the ghosts back to owned.
-        halo->scatter( *array );
+        halo->scatter( TEST_EXECSPACE(), ScatterReduce::Sum(), *array );
 
         // Check the scatter.
         checkScatter( is_dim_periodic, halo_width, *array );
     }
 
-    // Repeat the process but this time with multiple arrays in a MultiHalo
+    // Repeat the process but this time with multiple arrays in a Halo
     for ( unsigned halo_width = 1; halo_width <= array_halo_width;
           ++halo_width )
     {
@@ -255,10 +255,10 @@ void gatherScatterTest( const ManualPartitioner &partitioner,
         ArrayOp::assign( *edge_k_array, 1.0, Own() );
 
         // Create a multihalo.
-        auto halo = createMultiHalo( FullHaloPattern(), halo_width, *cell_array,
-                                     *node_array, *face_i_array, *face_j_array,
-                                     *face_k_array, *edge_i_array,
-                                     *edge_j_array, *edge_k_array );
+        auto halo =
+            createHalo( FullHaloPattern(), halo_width, *cell_array, *node_array,
+                        *face_i_array, *face_j_array, *face_k_array,
+                        *edge_i_array, *edge_j_array, *edge_k_array );
 
         // Gather into the ghosts.
         halo->gather( TEST_EXECSPACE(), *cell_array, *node_array, *face_i_array,
@@ -380,7 +380,7 @@ void scatterReduceTest( const ReduceFunc &reduce )
     auto halo = createHalo( *array, pattern );
 
     // Scatter.
-    halo->scatter( *array, reduce );
+    halo->scatter( TEST_EXECSPACE(), reduce, *array );
 
     // Check the reduction.
     auto host_array = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),

--- a/cajita/unit_test/tstHalo.hpp
+++ b/cajita/unit_test/tstHalo.hpp
@@ -31,6 +31,109 @@ using namespace Cajita;
 namespace Test
 {
 //---------------------------------------------------------------------------//
+// Halo padding in each dimension for different entity types.
+int haloPad( Cell, int ) { return 0; }
+
+int haloPad( Node, int ) { return 1; }
+
+template <int D>
+int haloPad( Face<D>, int d )
+{
+    return ( d == D ) ? 1 : 0;
+}
+
+template <int D>
+int haloPad( Edge<D>, int d )
+{
+    return ( d == D ) ? 0 : 1;
+}
+
+//---------------------------------------------------------------------------//
+// Check initial array gather. We should get 1 everywhere in the array now
+// where there was ghost overlap. Otherwise there will still be 0.
+template <class Array>
+void checkGather( const int halo_width, const Array &array )
+{
+    auto owned_space = array.layout()->indexSpace( Own(), Local() );
+    auto ghosted_space = array.layout()->indexSpace( Ghost(), Local() );
+    auto host_view = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
+                                                          array.view() );
+    auto pad_i = haloPad( typename Array::entity_type(), Dim::I );
+    auto pad_j = haloPad( typename Array::entity_type(), Dim::J );
+    auto pad_k = haloPad( typename Array::entity_type(), Dim::K );
+    for ( unsigned i = 0; i < ghosted_space.extent( 0 ); ++i )
+        for ( unsigned j = 0; j < ghosted_space.extent( 1 ); ++j )
+            for ( unsigned k = 0; k < ghosted_space.extent( 2 ); ++k )
+                for ( unsigned l = 0; l < ghosted_space.extent( 3 ); ++l )
+                    if ( i < owned_space.min( Dim::I ) - halo_width ||
+                         i >= owned_space.max( Dim::I ) + halo_width + pad_i ||
+                         j < owned_space.min( Dim::J ) - halo_width ||
+                         j >= owned_space.max( Dim::J ) + halo_width + pad_j ||
+                         k < owned_space.min( Dim::K ) - halo_width ||
+                         k >= owned_space.max( Dim::K ) + halo_width + pad_k )
+                        EXPECT_EQ( host_view( i, j, k, l ), 0.0 );
+                    else
+                        EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
+}
+
+//---------------------------------------------------------------------------//
+// Check array scatter. The value of the cell should be a function of how many
+// neighbors it has. Corner neighbors get 8, edge neighbors get 4, face
+// neighbors get 2, and no neighbors remain at 1.
+template <class Array>
+void checkScatter( const std::array<bool, 3> &is_dim_periodic,
+                   const int halo_width, const Array &array )
+{
+    // Get data.
+    auto owned_space = array.layout()->indexSpace( Own(), Local() );
+    auto host_view = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
+                                                          array.view() );
+    const auto &global_grid = array.layout()->localGrid()->globalGrid();
+
+    // This function checks if an index is in the halo of a low neighbor in
+    // the given dimension
+    auto in_dim_min_halo = [&]( const int i, const int dim ) {
+        if ( is_dim_periodic[dim] || global_grid.dimBlockId( dim ) > 0 )
+            return i < ( owned_space.min( dim ) + halo_width +
+                         haloPad( typename Array::entity_type(), dim ) );
+        else
+            return false;
+    };
+
+    // This function checks if an index is in the halo of a high neighbor in
+    // the given dimension
+    auto in_dim_max_halo = [&]( const int i, const int dim ) {
+        if ( is_dim_periodic[dim] || global_grid.dimBlockId( dim ) <
+                                         global_grid.dimNumBlock( dim ) - 1 )
+            return i >= ( owned_space.max( dim ) - halo_width );
+        else
+            return false;
+    };
+
+    // Check results. Use the halo functions to figure out how many neighbor
+    // a given cell was ghosted to.
+    for ( unsigned i = owned_space.min( 0 ); i < owned_space.max( 0 ); ++i )
+        for ( unsigned j = owned_space.min( 1 ); j < owned_space.max( 1 ); ++j )
+            for ( unsigned k = owned_space.min( 2 ); k < owned_space.max( 2 );
+                  ++k )
+            {
+                int num_n = 0;
+                if ( in_dim_min_halo( i, Dim::I ) ||
+                     in_dim_max_halo( i, Dim::I ) )
+                    ++num_n;
+                if ( in_dim_min_halo( j, Dim::J ) ||
+                     in_dim_max_halo( j, Dim::J ) )
+                    ++num_n;
+                if ( in_dim_min_halo( k, Dim::K ) ||
+                     in_dim_max_halo( k, Dim::K ) )
+                    ++num_n;
+                double scatter_val = std::pow( 2.0, num_n );
+                for ( unsigned l = 0; l < owned_space.extent( 3 ); ++l )
+                    EXPECT_EQ( host_view( i, j, k, l ), scatter_val );
+            }
+}
+
+//---------------------------------------------------------------------------//
 void gatherScatterTest( const ManualPartitioner &partitioner,
                         const std::array<bool, 3> &is_dim_periodic )
 {
@@ -49,18 +152,19 @@ void gatherScatterTest( const ManualPartitioner &partitioner,
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
-    // Create an array on the cells.
+    // Array parameters.
     unsigned array_halo_width = 3;
-    int dofs_per_cell = 4;
-    auto cell_layout = createArrayLayout( global_grid, array_halo_width,
-                                          dofs_per_cell, Cell() );
 
     // Loop over halo sizes up to the size of the array halo width.
     for ( unsigned halo_width = 1; halo_width <= array_halo_width;
           ++halo_width )
     {
+        // Create a cell array.
+        auto layout =
+            createArrayLayout( global_grid, array_halo_width, 4, Cell() );
+        auto array = createArray<double, TEST_DEVICE>( "array", layout );
+
         // Assign the owned cells a value of 1 and the rest 0.
-        auto array = createArray<double, TEST_DEVICE>( "array", cell_layout );
         ArrayOp::assign( *array, 0.0, Ghost() );
         ArrayOp::assign( *array, 1.0, Own() );
 
@@ -70,76 +174,121 @@ void gatherScatterTest( const ManualPartitioner &partitioner,
         // Gather into the ghosts.
         halo->gather( *array );
 
-        // Check the gather. We should get 1 everywhere in the array now where
-        // there was ghost overlap. Otherwise there will still be 0.
-        auto owned_space = cell_layout->indexSpace( Own(), Local() );
-        auto ghosted_space = cell_layout->indexSpace( Ghost(), Local() );
-        auto host_view = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), array->view() );
-        for ( unsigned i = 0; i < ghosted_space.extent( 0 ); ++i )
-            for ( unsigned j = 0; j < ghosted_space.extent( 1 ); ++j )
-                for ( unsigned k = 0; k < ghosted_space.extent( 2 ); ++k )
-                    for ( unsigned l = 0; l < ghosted_space.extent( 3 ); ++l )
-                        if ( i < owned_space.min( Dim::I ) - halo_width ||
-                             i >= owned_space.max( Dim::I ) + halo_width ||
-                             j < owned_space.min( Dim::J ) - halo_width ||
-                             j >= owned_space.max( Dim::J ) + halo_width ||
-                             k < owned_space.min( Dim::K ) - halo_width ||
-                             k >= owned_space.max( Dim::K ) + halo_width )
-                            EXPECT_EQ( host_view( i, j, k, l ), 0.0 );
-                        else
-                            EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
+        // Check the gather.
+        checkGather( halo_width, *array );
 
         // Scatter from the ghosts back to owned.
         halo->scatter( *array );
 
-        // Check the scatter. The value of the cell should be a function of how
-        // many neighbors it has. Corner neighbors get 8, edge neighbors get 4,
-        // face neighbors get 2, and no neighbors remain at 1.
+        // Check the scatter.
+        checkScatter( is_dim_periodic, halo_width, *array );
+    }
 
-        // This function checks if an index is in the halo of a low neighbor in
-        // the given dimension
-        auto in_dim_min_halo = [=]( const int i, const int dim ) {
-            if ( is_dim_periodic[dim] || global_grid->dimBlockId( dim ) > 0 )
-                return i < ( owned_space.min( dim ) + halo_width );
-            else
-                return false;
-        };
+    // Repeat the process but this time with multiple arrays in a MultiHalo
+    for ( unsigned halo_width = 1; halo_width <= array_halo_width;
+          ++halo_width )
+    {
+        // Create arrays of different layouts and dof counts.
+        auto cell_layout =
+            createArrayLayout( global_grid, array_halo_width, 4, Cell() );
+        auto cell_array =
+            createArray<double, TEST_DEVICE>( "cell_array", cell_layout );
 
-        // This function checks if an index is in the halo of a high neighbor in
-        // the given dimension
-        auto in_dim_max_halo = [=]( const int i, const int dim ) {
-            if ( is_dim_periodic[dim] ||
-                 global_grid->dimBlockId( dim ) <
-                     global_grid->dimNumBlock( dim ) - 1 )
-                return i >= ( owned_space.max( dim ) - halo_width );
-            else
-                return false;
-        };
+        auto node_layout =
+            createArrayLayout( global_grid, array_halo_width, 3, Node() );
+        auto node_array =
+            createArray<float, TEST_DEVICE>( "node_array", node_layout );
 
-        // Check results. Use the halo functions to figure out how many neighbor
-        // a given cell was ghosted to.
-        Kokkos::deep_copy( host_view, array->view() );
-        for ( unsigned i = owned_space.min( 0 ); i < owned_space.max( 0 ); ++i )
-            for ( unsigned j = owned_space.min( 1 ); j < owned_space.max( 1 );
-                  ++j )
-                for ( unsigned k = owned_space.min( 2 );
-                      k < owned_space.max( 2 ); ++k )
-                {
-                    int num_n = 0;
-                    if ( in_dim_min_halo( i, Dim::I ) ||
-                         in_dim_max_halo( i, Dim::I ) )
-                        ++num_n;
-                    if ( in_dim_min_halo( j, Dim::J ) ||
-                         in_dim_max_halo( j, Dim::J ) )
-                        ++num_n;
-                    if ( in_dim_min_halo( k, Dim::K ) ||
-                         in_dim_max_halo( k, Dim::K ) )
-                        ++num_n;
-                    double scatter_val = std::pow( 2.0, num_n );
-                    for ( unsigned l = 0; l < owned_space.extent( 3 ); ++l )
-                        EXPECT_EQ( host_view( i, j, k, l ), scatter_val );
-                }
+        auto face_i_layout = createArrayLayout( global_grid, array_halo_width,
+                                                4, Face<Dim::I>() );
+        auto face_i_array =
+            createArray<double, TEST_DEVICE>( "face_i_array", face_i_layout );
+
+        auto face_j_layout = createArrayLayout( global_grid, array_halo_width,
+                                                1, Face<Dim::J>() );
+        auto face_j_array =
+            createArray<double, TEST_DEVICE>( "face_j_array", face_j_layout );
+
+        auto face_k_layout = createArrayLayout( global_grid, array_halo_width,
+                                                2, Face<Dim::K>() );
+        auto face_k_array =
+            createArray<float, TEST_DEVICE>( "face_k_array", face_k_layout );
+
+        auto edge_i_layout = createArrayLayout( global_grid, array_halo_width,
+                                                3, Edge<Dim::I>() );
+        auto edge_i_array =
+            createArray<float, TEST_DEVICE>( "edge_i_array", edge_i_layout );
+
+        auto edge_j_layout = createArrayLayout( global_grid, array_halo_width,
+                                                2, Edge<Dim::J>() );
+        auto edge_j_array =
+            createArray<float, TEST_DEVICE>( "edge_j_array", edge_j_layout );
+
+        auto edge_k_layout = createArrayLayout( global_grid, array_halo_width,
+                                                1, Edge<Dim::K>() );
+        auto edge_k_array =
+            createArray<double, TEST_DEVICE>( "edge_k_array", edge_k_layout );
+
+        // Assign the owned cells a value of 1 and the rest 0.
+        ArrayOp::assign( *cell_array, 0.0, Ghost() );
+        ArrayOp::assign( *cell_array, 1.0, Own() );
+
+        ArrayOp::assign( *node_array, 0.0, Ghost() );
+        ArrayOp::assign( *node_array, 1.0, Own() );
+
+        ArrayOp::assign( *face_i_array, 0.0, Ghost() );
+        ArrayOp::assign( *face_i_array, 1.0, Own() );
+
+        ArrayOp::assign( *face_j_array, 0.0, Ghost() );
+        ArrayOp::assign( *face_j_array, 1.0, Own() );
+
+        ArrayOp::assign( *face_k_array, 0.0, Ghost() );
+        ArrayOp::assign( *face_k_array, 1.0, Own() );
+
+        ArrayOp::assign( *edge_i_array, 0.0, Ghost() );
+        ArrayOp::assign( *edge_i_array, 1.0, Own() );
+
+        ArrayOp::assign( *edge_j_array, 0.0, Ghost() );
+        ArrayOp::assign( *edge_j_array, 1.0, Own() );
+
+        ArrayOp::assign( *edge_k_array, 0.0, Ghost() );
+        ArrayOp::assign( *edge_k_array, 1.0, Own() );
+
+        // Create a multihalo.
+        auto halo = createMultiHalo( FullHaloPattern(), halo_width, *cell_array,
+                                     *node_array, *face_i_array, *face_j_array,
+                                     *face_k_array, *edge_i_array,
+                                     *edge_j_array, *edge_k_array );
+
+        // Gather into the ghosts.
+        halo->gather( TEST_EXECSPACE(), *cell_array, *node_array, *face_i_array,
+                      *face_j_array, *face_k_array, *edge_i_array,
+                      *edge_j_array, *edge_k_array );
+
+        // Check the gather.
+        checkGather( halo_width, *cell_array );
+        checkGather( halo_width, *node_array );
+        checkGather( halo_width, *face_i_array );
+        checkGather( halo_width, *face_j_array );
+        checkGather( halo_width, *face_k_array );
+        checkGather( halo_width, *edge_i_array );
+        checkGather( halo_width, *edge_j_array );
+        checkGather( halo_width, *edge_k_array );
+
+        // Scatter from the ghosts back to owned.
+        halo->scatter( TEST_EXECSPACE(), ScatterReduce::Sum(), *cell_array,
+                       *node_array, *face_i_array, *face_j_array, *face_k_array,
+                       *edge_i_array, *edge_j_array, *edge_k_array );
+
+        // Check the scatter.
+        checkScatter( is_dim_periodic, halo_width, *cell_array );
+        checkScatter( is_dim_periodic, halo_width, *node_array );
+        checkScatter( is_dim_periodic, halo_width, *face_i_array );
+        checkScatter( is_dim_periodic, halo_width, *face_j_array );
+        checkScatter( is_dim_periodic, halo_width, *face_k_array );
+        checkScatter( is_dim_periodic, halo_width, *edge_i_array );
+        checkScatter( is_dim_periodic, halo_width, *edge_j_array );
+        checkScatter( is_dim_periodic, halo_width, *edge_k_array );
     }
 }
 

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -84,7 +84,7 @@ void testConversion( const std::array<bool, 3> &is_dim_periodic )
 
     // Gather to get the ghosted global indices.
     auto halo = createHalo( *global_index_array, FullHaloPattern() );
-    halo->gather( *global_index_array );
+    halo->gather( TEST_EXECSPACE(), *global_index_array );
 
     // Do a loop over ghosted local indices and fill with the index
     // conversion.


### PR DESCRIPTION
Generalizes `Cajita::Halo` to allow for the halo operations of an arbitrary number of arrays to be fused together. The original `Halo` creation functions remain but the interface is now slightly different:

- The class has a single template `MemorySpace` instead of two (was `Scalar` and `DeviceType`)
- Construction happens from arrays so we can get the value types of the arrays for byte computations
- `gather()` and `scatter()` now require an execution space instance be passed for the buffer pack/unpack
- `scatter()` requires the user to explicitly say which `ScatterReduce` operation they would like performed

NOTE: This PR breaks backwards compatibility as part of the work towards the 1.0 release so downstream packages using the `Cajita::Halo` will likely need to be updated to reflect the interface changes. 