### PR TITLE
cmake: always set Cabana_ENABLE_*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,8 @@ macro(Cabana_add_dependency)
     "Require Cabana to build with ${CABANA_DEPENDENCY_PACKAGE} support" ${CABANA_DEPENDENCY_PACKAGE}_FOUND)
   if(Cabana_REQUIRE_${CABANA_DEPENDENCY_OPTION})
     find_package( ${CABANA_DEPENDENCY_PACKAGE} REQUIRED )
-    set(Cabana_ENABLE_${CABANA_DEPENDENCY_OPTION} ON)
   endif()
+  set(Cabana_ENABLE_${CABANA_DEPENDENCY_OPTION} ${${CABANA_DEPENDENCY_PACKAGE}_FOUND})
 endmacro()
 
 # find MPI


### PR DESCRIPTION
I realized in https://github.com/ECP-copa/Cabana-fortran-examples/pull/6, that all `Cabana_ENABLE_*` don't get set unless `Cabana_REQUIRE_*` is set to `ON`, fixing that logic.