### PR TITLE
Empty parameter pack

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HEADERS_PUBLIC
   Cajita_ManualPartitioner.hpp
   Cajita_MpiTraits.hpp
   Cajita_Parallel.hpp
+  Cajita_ParameterPack.hpp
   Cajita_Partitioner.hpp
   Cajita_ReferenceStructuredSolver.hpp
   Cajita_Splines.hpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -26,6 +26,7 @@
 #include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_MpiTraits.hpp>
 #include <Cajita_Parallel.hpp>
+#include <Cajita_ParameterPack.hpp>
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_ReferenceStructuredSolver.hpp>
 #include <Cajita_Splines.hpp>

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -14,6 +14,7 @@
 
 #include <Cajita_Array.hpp>
 #include <Cajita_IndexSpace.hpp>
+#include <Cajita_ParameterPack.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -23,159 +24,10 @@
 #include <array>
 #include <cmath>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace Cajita
 {
-//---------------------------------------------------------------------------//
-// Parameter pack device capture.
-//
-// NOTE: In general this would not be needed but NVCC cannot capture parameter
-// packs in lambda functions hence we need to wrap them in something that can
-// be captured.
-//---------------------------------------------------------------------------//
-// Get the type at the given index of a paremeter pack.
-template <std::size_t N, typename T, typename... Types>
-struct PackTypeAtIndexImpl;
-
-template <typename T, typename... Types>
-struct PackTypeAtIndexImpl<0, T, Types...>
-{
-    using type = T;
-};
-
-template <std::size_t N, typename T, typename... Types>
-struct PackTypeAtIndexImpl
-{
-    using type = typename PackTypeAtIndexImpl<N - 1, Types...>::type;
-};
-
-template <std::size_t N, typename... Types>
-struct PackTypeAtIndex
-{
-    using type = typename PackTypeAtIndexImpl<N, Types...>::type;
-    static_assert( N < sizeof...( Types ), "Type index out of bounds" );
-};
-
-//---------------------------------------------------------------------------//
-// Parameter pack element.
-template <std::size_t N, typename T>
-struct ParameterPackElement
-{
-    T _m;
-};
-
-//---------------------------------------------------------------------------//
-// Capture a parameter pack. All parameter pack elements must be copyable to
-// device.
-template <typename Sequence, typename... Types>
-struct ParameterPackImpl;
-
-template <std::size_t... Indices, typename... Types>
-struct ParameterPackImpl<std::index_sequence<Indices...>, Types...>
-    : ParameterPackElement<Indices, Types>...
-{
-};
-
-template <typename... Types>
-struct ParameterPack
-    : ParameterPackImpl<std::make_index_sequence<sizeof...( Types )>, Types...>
-{
-    template <std::size_t N>
-    using value_type = typename PackTypeAtIndex<N, Types...>::type;
-
-    template <std::size_t N>
-    using const_value_type = typename std::add_const<value_type<N>>::type;
-
-    template <std::size_t N>
-    using element_type = ParameterPackElement<N, value_type<N>>;
-
-    static constexpr std::size_t size = sizeof...( Types );
-};
-
-//---------------------------------------------------------------------------//
-// Static type checker.
-template <class>
-struct is_parameter_pack_impl : public std::false_type
-{
-};
-
-template <typename... Types>
-struct is_parameter_pack_impl<ParameterPack<Types...>> : public std::true_type
-{
-};
-
-template <class T>
-struct is_parameter_pack
-    : public is_parameter_pack_impl<typename std::remove_cv<T>::type>::type
-{
-};
-
-//---------------------------------------------------------------------------//
-// Get an element from a parameter pack.
-template <std::size_t N, class ParameterPack_t>
-KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
-    is_parameter_pack<ParameterPack_t>::value,
-    typename ParameterPack_t::template value_type<N> &>::type
-get( ParameterPack_t &pp )
-{
-    return static_cast<typename ParameterPack_t::template element_type<N> &>(
-               pp )
-        ._m;
-}
-
-template <std::size_t N, class ParameterPack_t>
-KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
-    is_parameter_pack<ParameterPack_t>::value,
-    const typename ParameterPack_t::template value_type<N> &>::type
-get( const ParameterPack_t &pp )
-{
-    return static_cast<
-               const typename ParameterPack_t::template element_type<N> &>( pp )
-        ._m;
-}
-
-//---------------------------------------------------------------------------//
-// Fill a parameter pack. Note the indexing is such that the Nth element of a
-// parameter pack is the Nth element of the tuple.
-template <typename ParameterPack_t, typename T, typename... Types>
-void fillParameterPackImpl( ParameterPack_t &pp,
-                            const std::integral_constant<std::size_t, 0>,
-                            const T &t, const Types &... )
-{
-    get<ParameterPack_t::size - 1>( pp ) = t;
-}
-
-template <typename ParameterPack_t, std::size_t N, typename T,
-          typename... Types>
-void fillParameterPackImpl( ParameterPack_t &pp,
-                            const std::integral_constant<std::size_t, N>,
-                            const T &t, const Types &... ts )
-{
-    get<ParameterPack_t::size - 1 - N>( pp ) = t;
-    fillParameterPackImpl( pp, std::integral_constant<std::size_t, N - 1>(),
-                           ts... );
-}
-
-template <typename ParameterPack_t, typename... Types>
-void fillParameterPack( ParameterPack_t &pp, const Types &... ts )
-{
-    fillParameterPackImpl(
-        pp, std::integral_constant<std::size_t, ParameterPack_t::size - 1>(),
-        ts... );
-}
-
-//---------------------------------------------------------------------------//
-// Create a parameter pack.
-template <typename... Types>
-ParameterPack<Types...> makeParameterPack( const Types &... ts )
-{
-    ParameterPack<Types...> pp;
-    fillParameterPack( pp, ts... );
-    return pp;
-}
-
 //---------------------------------------------------------------------------//
 // Halo exchange patterns.
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_ParameterPack.hpp
+++ b/cajita/src/Cajita_ParameterPack.hpp
@@ -157,6 +157,12 @@ void fillParameterPack( ParameterPack_t &pp, const Types &... ts )
         ts... );
 }
 
+// Empty case.
+template <typename ParameterPack_t>
+void fillParameterPack( ParameterPack_t & )
+{
+}
+
 //---------------------------------------------------------------------------//
 // Create a parameter pack.
 template <typename... Types>

--- a/cajita/src/Cajita_ParameterPack.hpp
+++ b/cajita/src/Cajita_ParameterPack.hpp
@@ -1,0 +1,174 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_PARAMETERPACK_HPP
+#define CAJITA_PARAMETERPACK_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace Cajita
+{
+//---------------------------------------------------------------------------//
+// Parameter pack device capture.
+//
+// NOTE: In general this would not be needed but NVCC cannot capture parameter
+// packs in lambda functions hence we need to wrap them in something that can
+// be captured.
+//---------------------------------------------------------------------------//
+// Get the type at the given index of a paremeter pack.
+template <std::size_t N, typename T, typename... Types>
+struct PackTypeAtIndexImpl;
+
+template <typename T, typename... Types>
+struct PackTypeAtIndexImpl<0, T, Types...>
+{
+    using type = T;
+};
+
+template <std::size_t N, typename T, typename... Types>
+struct PackTypeAtIndexImpl
+{
+    using type = typename PackTypeAtIndexImpl<N - 1, Types...>::type;
+};
+
+template <std::size_t N, typename... Types>
+struct PackTypeAtIndex
+{
+    using type = typename PackTypeAtIndexImpl<N, Types...>::type;
+    static_assert( N < sizeof...( Types ), "Type index out of bounds" );
+};
+
+//---------------------------------------------------------------------------//
+// Parameter pack element.
+template <std::size_t N, typename T>
+struct ParameterPackElement
+{
+    T _m;
+};
+
+//---------------------------------------------------------------------------//
+// Capture a parameter pack. All parameter pack elements must be copyable to
+// device.
+template <typename Sequence, typename... Types>
+struct ParameterPackImpl;
+
+template <std::size_t... Indices, typename... Types>
+struct ParameterPackImpl<std::index_sequence<Indices...>, Types...>
+    : ParameterPackElement<Indices, Types>...
+{
+};
+
+template <typename... Types>
+struct ParameterPack
+    : ParameterPackImpl<std::make_index_sequence<sizeof...( Types )>, Types...>
+{
+    template <std::size_t N>
+    using value_type = typename PackTypeAtIndex<N, Types...>::type;
+
+    template <std::size_t N>
+    using const_value_type = typename std::add_const<value_type<N>>::type;
+
+    template <std::size_t N>
+    using element_type = ParameterPackElement<N, value_type<N>>;
+
+    static constexpr std::size_t size = sizeof...( Types );
+};
+
+//---------------------------------------------------------------------------//
+// Static type checker.
+template <class>
+struct is_parameter_pack_impl : public std::false_type
+{
+};
+
+template <typename... Types>
+struct is_parameter_pack_impl<ParameterPack<Types...>> : public std::true_type
+{
+};
+
+template <class T>
+struct is_parameter_pack
+    : public is_parameter_pack_impl<typename std::remove_cv<T>::type>::type
+{
+};
+
+//---------------------------------------------------------------------------//
+// Get an element from a parameter pack.
+template <std::size_t N, class ParameterPack_t>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    is_parameter_pack<ParameterPack_t>::value,
+    typename ParameterPack_t::template value_type<N> &>::type
+get( ParameterPack_t &pp )
+{
+    return static_cast<typename ParameterPack_t::template element_type<N> &>(
+               pp )
+        ._m;
+}
+
+template <std::size_t N, class ParameterPack_t>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    is_parameter_pack<ParameterPack_t>::value,
+    const typename ParameterPack_t::template value_type<N> &>::type
+get( const ParameterPack_t &pp )
+{
+    return static_cast<
+               const typename ParameterPack_t::template element_type<N> &>( pp )
+        ._m;
+}
+
+//---------------------------------------------------------------------------//
+// Fill a parameter pack. Note the indexing is such that the Nth element of a
+// parameter pack is the Nth element of the tuple.
+template <typename ParameterPack_t, typename T, typename... Types>
+void fillParameterPackImpl( ParameterPack_t &pp,
+                            const std::integral_constant<std::size_t, 0>,
+                            const T &t, const Types &... )
+{
+    get<ParameterPack_t::size - 1>( pp ) = t;
+}
+
+template <typename ParameterPack_t, std::size_t N, typename T,
+          typename... Types>
+void fillParameterPackImpl( ParameterPack_t &pp,
+                            const std::integral_constant<std::size_t, N>,
+                            const T &t, const Types &... ts )
+{
+    get<ParameterPack_t::size - 1 - N>( pp ) = t;
+    fillParameterPackImpl( pp, std::integral_constant<std::size_t, N - 1>(),
+                           ts... );
+}
+
+template <typename ParameterPack_t, typename... Types>
+void fillParameterPack( ParameterPack_t &pp, const Types &... ts )
+{
+    fillParameterPackImpl(
+        pp, std::integral_constant<std::size_t, ParameterPack_t::size - 1>(),
+        ts... );
+}
+
+//---------------------------------------------------------------------------//
+// Create a parameter pack.
+template <typename... Types>
+ParameterPack<Types...> makeParameterPack( const Types &... ts )
+{
+    ParameterPack<Types...> pp;
+    fillParameterPack( pp, ts... );
+    return pp;
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cajita
+
+#endif // end CAJITA_PARAMETERPACK_HPP

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SERIAL_TESTS
   GlobalMesh
   IndexSpace
   Parallel
+  ParameterPack
   Splines
   )
 

--- a/cajita/unit_test/tstParameterPack.hpp
+++ b/cajita/unit_test/tstParameterPack.hpp
@@ -24,41 +24,42 @@ namespace Test
 void captureTest()
 {
     // Make some Kokkos views.
-    Kokkos::View<double[1],TEST_MEMSPACE> dbl_view( "dbl_view" );
-    Kokkos::View<int[1][1],TEST_MEMSPACE> int_view( "int_view" );
+    Kokkos::View<double[1], TEST_MEMSPACE> dbl_view( "dbl_view" );
+    Kokkos::View<int[1][1], TEST_MEMSPACE> int_view( "int_view" );
 
     // Make a parameter pack so we can capture them as a group.
     auto pack = makeParameterPack( dbl_view, int_view );
 
     // Update the pack in a kernel
-    Kokkos::parallel_for(
-        "fill_pack",
-        Kokkos::RangePolicy<TEST_EXECSPACE>(0,1),
-        KOKKOS_LAMBDA( const int ){
-            auto dv = get<0>( pack );
-            auto iv = get<1>( pack );
+    Kokkos::parallel_for( "fill_pack",
+                          Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 1 ),
+                          KOKKOS_LAMBDA( const int ) {
+                              auto dv = get<0>( pack );
+                              auto iv = get<1>( pack );
 
-            dv(0) = 3.14;
-            iv(0,0) = 12;
-        } );
+                              dv( 0 ) = 3.14;
+                              iv( 0, 0 ) = 12;
+                          } );
 
     // Check the capture.
-    auto dbl_host = Kokkos::create_mirror_view_and_copy(
-        Kokkos::HostSpace(), dbl_view );
-    auto int_host = Kokkos::create_mirror_view_and_copy(
-        Kokkos::HostSpace(), int_view );
+    auto dbl_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), dbl_view );
+    auto int_host =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), int_view );
 
-    EXPECT_EQ( dbl_host(0), 3.14 );
-    EXPECT_EQ( int_host(0,0), 12 );
+    EXPECT_EQ( dbl_host( 0 ), 3.14 );
+    EXPECT_EQ( int_host( 0, 0 ), 12 );
 }
+
+//---------------------------------------------------------------------------//
+void emptyTest() { std::ignore = makeParameterPack(); }
 
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, parameter_pack_test )
-{
-    captureTest();
-}
+TEST( TEST_CATEGORY, parameter_pack_capture ) { captureTest(); }
+
+TEST( TEST_CATEGORY, parameter_pack_empty ) { emptyTest(); }
 
 //---------------------------------------------------------------------------//
 

--- a/cajita/unit_test/tstParameterPack.hpp
+++ b/cajita/unit_test/tstParameterPack.hpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita_ParameterPack.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Cajita;
+
+namespace Test
+{
+
+//---------------------------------------------------------------------------//
+void captureTest()
+{
+    // Make some Kokkos views.
+    Kokkos::View<double[1],TEST_MEMSPACE> dbl_view( "dbl_view" );
+    Kokkos::View<int[1][1],TEST_MEMSPACE> int_view( "int_view" );
+
+    // Make a parameter pack so we can capture them as a group.
+    auto pack = makeParameterPack( dbl_view, int_view );
+
+    // Update the pack in a kernel
+    Kokkos::parallel_for(
+        "fill_pack",
+        Kokkos::RangePolicy<TEST_EXECSPACE>(0,1),
+        KOKKOS_LAMBDA( const int ){
+            auto dv = get<0>( pack );
+            auto iv = get<1>( pack );
+
+            dv(0) = 3.14;
+            iv(0,0) = 12;
+        } );
+
+    // Check the capture.
+    auto dbl_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), dbl_view );
+    auto int_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), int_view );
+
+    EXPECT_EQ( dbl_host(0), 3.14 );
+    EXPECT_EQ( int_host(0,0), 12 );
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, parameter_pack_test )
+{
+    captureTest();
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
Places the `ParameterPack` in its own header because it has proven useful elsewhere and adds a unit test. Also fix a bug to allow for empty parameter packs to be constructed.