### PR TITLE
Unique communication neighbor ranks

### DIFF
--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -428,7 +428,7 @@ class CommunicationPlan
       \param neighbor_ranks List of ranks this rank will send to and receive
       from. This list can include the calling rank. This is effectively a
       description of the topology of the point-to-point communication
-      plan. The elements in this list must be unique.
+      plan. Only the unique elements in this list are used.
 
       \return The location of each export element in the send buffer for its
       given neighbor.
@@ -451,8 +451,11 @@ class CommunicationPlan
         // Store the number of export elements.
         _num_export_element = element_export_ranks.size();
 
-        // Store the neighbors.
+        // Store the unique neighbors.
         _neighbors = neighbor_ranks;
+        std::sort( _neighbors.begin(), _neighbors.end() );
+        auto unique_end = std::unique( _neighbors.begin(), _neighbors.end() );
+        _neighbors.resize( std::distance( _neighbors.begin(), unique_end ) );
         int num_n = _neighbors.size();
 
         // Get the size of this communicator.

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -231,7 +231,7 @@ void gather( const Halo_t &halo, AoSoA_t &aosoa,
 {
     // Check that the AoSoA is the right size.
     if ( aosoa.size() != halo.numLocal() + halo.numGhost() )
-        throw std::runtime_error( "AoSoA is the wrong size for scatter!" );
+        throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
     // Allocate a send buffer.
     Kokkos::View<typename AoSoA_t::tuple_type *, typename Halo_t::memory_space>
@@ -352,7 +352,7 @@ void gather( const Halo_t &halo, Slice_t &slice,
 {
     // Check that the Slice is the right size.
     if ( slice.size() != halo.numLocal() + halo.numGhost() )
-        throw std::runtime_error( "Slice is the wrong size for scatter!" );
+        throw std::runtime_error( "Slice is the wrong size for gather!" );
 
     // Get the number of components in the slice.
     std::size_t num_comp = 1;

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -642,14 +642,12 @@ void test8( const bool use_topology )
     Kokkos::RangePolicy<TEST_EXECSPACE> range_policy( 0, 1 );
     Kokkos::parallel_for( range_policy, fill_ranks );
     Kokkos::fence();
+
+    // Neighbors made unique internally.
     std::vector<int> neighbor_ranks( 3 );
     neighbor_ranks[0] = ( my_rank == 0 ) ? my_size - 1 : my_rank - 1;
     neighbor_ranks[1] = my_rank;
     neighbor_ranks[2] = ( my_rank == my_size - 1 ) ? 0 : my_rank + 1;
-    std::sort( neighbor_ranks.begin(), neighbor_ranks.end() );
-    auto unique_it =
-        std::unique( neighbor_ranks.begin(), neighbor_ranks.end() );
-    neighbor_ranks.resize( std::distance( neighbor_ranks.begin(), unique_it ) );
 
     // Create the plan.
     if ( use_topology )


### PR DESCRIPTION
Enforce unique neighbor ranks with `CommunicationPlan` rather than requiring it from users.