### PR TITLE
Fixup cmake logic to enable packages

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -32,13 +32,13 @@ set(SOURCES_PUBLIC
   Cajita_UniformDimPartitioner.cpp
   )
 
-if(HYPRE_FOUND)
+if(Cabana_ENABLE_HYPRE)
   list(APPEND HEADERS_PUBLIC
     Cajita_HypreStructuredSolver.hpp
     )
 endif()
 
-if(Heffte_FOUND)
+if(Cabana_ENABLE_HEFFTE)
   list(APPEND HEADERS_PUBLIC
     Cajita_FastFourierTransform.hpp
     )
@@ -51,11 +51,11 @@ target_link_libraries(Cajita PUBLIC
   MPI::MPI_CXX
   )
 
-if(HYPRE_FOUND)
+if(Cabana_ENABLE_HYPRE)
   target_link_libraries(Cajita PUBLIC HYPRE::hypre)
 endif()
 
-if(Heffte_FOUND)
+if(Cabana_ENABLE_HEFFTE)
   target_link_libraries(Cajita PUBLIC Heffte::Heffte)
 endif()
 

--- a/core/performance_test/benchmark/CMakeLists.txt
+++ b/core/performance_test/benchmark/CMakeLists.txt
@@ -3,7 +3,7 @@ if(Kokkos_ENABLE_SERIAL)
   target_link_libraries(NeighborListMDPerfTest cabanacore)
 endif()
 
-if(MPI_FOUND AND Kokkos_ENABLE_CUDA AND Kokkos_ENABLE_OPENMP)
+if(Cabana_ENABLE_MPI AND Kokkos_ENABLE_CUDA AND Kokkos_ENABLE_OPENMP)
   add_executable(CommPerformance Cabana_CommPerformance.cpp)
   target_link_libraries(CommPerformance cabanacore)
 endif()

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -18,13 +18,13 @@ set(HEADERS_PUBLIC
   Cabana_Version.hpp
   )
 
-if(ArborX_FOUND)
+if(Cabana_ENABLE_ARBORX)
   list(APPEND HEADERS_PUBLIC
     Cabana_Experimental_NeighborList.hpp
     )
 endif()
 
-if(MPI_FOUND)
+if(Cabana_ENABLE_MPI)
   list(APPEND HEADERS_PUBLIC
     Cabana_CommunicationPlan.hpp
     Cabana_Distributor.hpp
@@ -46,11 +46,11 @@ add_library(cabanacore ${SOURCES_IMPL})
 
 target_link_libraries(cabanacore Kokkos::kokkos)
 
-if(ArborX_FOUND)
+if(Cabana_ENABLE_ARBORX)
   target_link_libraries(cabanacore ArborX::ArborX)
 endif()
 
-if(MPI_FOUND)
+if(Cabana_ENABLE_MPI)
   target_link_libraries(cabanacore MPI::MPI_CXX)
 endif()
 


### PR DESCRIPTION
We should be relying on Cabana_ENABLE_XXX rather than Xxx_FOUND in subdirectories.

I ran into this issue when doing `Cabana_add_dependency( PACKAGE ArborX ) => add_subdirectory(ArborX)`.