### PR TITLE
Cajita CMake variables

### DIFF
--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -12,9 +12,10 @@
 #ifndef CAJITA_HPP
 #define CAJITA_HPP
 
+#include <Cajita_Config.hpp>
+
 #include <Cajita_Array.hpp>
 #include <Cajita_BovWriter.hpp>
-#include <Cajita_Config.hpp>
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_Halo.hpp>

--- a/core/src/CabanaCore_config.hpp.cmakein
+++ b/core/src/CabanaCore_config.hpp.cmakein
@@ -5,6 +5,8 @@
 
 #define Cabana_GIT_COMMIT_HASH "@Cabana_GIT_COMMIT_HASH@"
 
+#cmakedefine Cabana_ENABLE_CAJITA
+
 #cmakedefine Cabana_ENABLE_MPI
 
 #cmakedefine Cabana_ENABLE_ARBORX


### PR DESCRIPTION
- Add Cajita enable variable for downstream runtime checks.
- Ensure Cajita CMake variables are defined before any other files. 
