### PR TITLE
Add extent to local mesh

### DIFF
--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -120,6 +120,19 @@ class LocalMesh<Device, UniformMesh<Scalar>>
         return _ghost_high_corner[dim];
     }
 
+    // Get the extent of a given dimension.
+    KOKKOS_INLINE_FUNCTION
+    Scalar extent( Own, const int dim ) const
+    {
+        return _own_high_corner[dim] - _own_low_corner[dim];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Scalar extent( Ghost, const int dim ) const
+    {
+        return _ghost_high_corner[dim] - _ghost_low_corner[dim];
+    }
+
     // Get the coordinates of an entity of the given type given the local
     // index of the entity. The local indexing is
     // relative to the ghosted decomposition of the mesh block and correlates
@@ -366,6 +379,19 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
     Scalar highCorner( Ghost, const int dim ) const
     {
         return _ghost_high_corner[dim];
+    }
+
+    // Get the extent of a given dimension.
+    KOKKOS_INLINE_FUNCTION
+    Scalar extent( Own, const int dim ) const
+    {
+        return _own_high_corner[dim] - _own_low_corner[dim];
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    Scalar extent( Ghost, const int dim ) const
+    {
+        return _ghost_high_corner[dim] - _ghost_low_corner[dim];
     }
 
     // Get the coordinate of an entity of the given type given the local index

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -121,16 +121,10 @@ class LocalMesh<Device, UniformMesh<Scalar>>
     }
 
     // Get the extent of a given dimension.
-    KOKKOS_INLINE_FUNCTION
-    Scalar extent( Own, const int dim ) const
+    template <typename Decomposition>
+    KOKKOS_FUNCTION Scalar extent( Decomposition d, const int dim ) const
     {
-        return _own_high_corner[dim] - _own_low_corner[dim];
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    Scalar extent( Ghost, const int dim ) const
-    {
-        return _ghost_high_corner[dim] - _ghost_low_corner[dim];
+        return highCorner( d, dim ) - lowCorner( d, dim );
     }
 
     // Get the coordinates of an entity of the given type given the local
@@ -382,16 +376,10 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
     }
 
     // Get the extent of a given dimension.
-    KOKKOS_INLINE_FUNCTION
-    Scalar extent( Own, const int dim ) const
+    template <typename Decomposition>
+    KOKKOS_FUNCTION Scalar extent( Decomposition d, const int dim ) const
     {
-        return _own_high_corner[dim] - _own_low_corner[dim];
-    }
-
-    KOKKOS_INLINE_FUNCTION
-    Scalar extent( Ghost, const int dim ) const
-    {
-        return _ghost_high_corner[dim] - _ghost_low_corner[dim];
+        return highCorner( d, dim ) - lowCorner( d, dim );
     }
 
     // Get the coordinate of an entity of the given type given the local index


### PR DESCRIPTION
Add `extent` of the locally owned mesh (with or without ghosted cells) for convenience. This matches the global mesh `extent` and will be useful for the grid communication features.