### PR TITLE
sparse grid

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS_PUBLIC
   Cajita_Halo.hpp
   Cajita_IndexConversion.hpp
   Cajita_IndexSpace.hpp
+  Cajita_SparseIndexSpace.hpp
   Cajita_Interpolation.hpp
   Cajita_LocalMesh.hpp
   Cajita_ManualPartitioner.hpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -30,6 +30,7 @@
 #include <Cajita_ParameterPack.hpp>
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_ReferenceStructuredSolver.hpp>
+#include <Cajita_SparseIndexSpace.hpp>
 #include <Cajita_Splines.hpp>
 #include <Cajita_Types.hpp>
 #include <Cajita_UniformDimPartitioner.hpp>

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -1,0 +1,878 @@
+#ifndef CAJITA_SPARSE_INDEXSPACE_HPP
+#define CAJITA_SPARSE_INDEXSPACE_HPP
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_UnorderedMap.hpp>
+
+#include <array>
+#include <string>
+
+//---------------------------------------------------------------------------//
+// Naming convension:
+//  Tile ID / Tile ijk = 3D tile indexing, i.e., (i, j, k)
+//  Tile No. = 1D number indicating the tile position in the allocated array
+//  Tile key / Hash key = 1D number, computed with the given indexing method and
+//  used as hash key
+//---------------------------------------------------------------------------//
+
+namespace Cajita
+{
+
+//---------------------------------------------------------------------------//
+// Hash table type tag.
+//---------------------------------------------------------------------------//
+enum class HashTypes : unsigned char
+{
+    Naive = 0, // Lexicographical Order
+    Morton = 1 // Morton Curve
+};
+
+//---------------------------------------------------------------------------//
+// bit operations for Morton Code computing
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Compute the least bit number/length needed to represent
+  the given input integer
+*/
+template <typename Integer>
+KOKKOS_INLINE_FUNCTION constexpr Integer bitLength( Integer input_int ) noexcept
+{
+    if ( input_int )
+        return bitLength( input_int >> 1 ) + static_cast<Integer>( 1 );
+    else
+        return 0;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Compute the lease bit number needed to index input
+  integer
+*/
+template <typename Integer>
+KOKKOS_INLINE_FUNCTION constexpr Integer bitCount( Integer input_int ) noexcept
+{
+    return bitLength( input_int - 1 );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Given a integer, reverse the corresponding binary string,
+  return the resulting integer.
+*/
+template <typename Integer>
+KOKKOS_INLINE_FUNCTION constexpr Integer
+binaryReverse( Integer input_int, char loc = sizeof( Integer ) * 8 - 1 )
+{
+    if ( input_int == 0 )
+        return 0;
+    return ( ( input_int & 1 ) << loc ) |
+           binaryReverse( input_int >> 1, loc - 1 );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Count the leading zeros in the corresponding binary
+  string of the input integer
+*/
+template <typename Integer>
+KOKKOS_INLINE_FUNCTION constexpr unsigned countLeadingZeros( Integer input_int )
+{
+    unsigned res{ 0 };
+    input_int = binaryReverse( input_int );
+    if ( input_int == 0 )
+        return sizeof( Integer ) * 8;
+    while ( ( input_int & 1 ) == 0 )
+        res++, input_int >>= 1;
+    return res;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Pack up the data bits where the corresponding bit of the
+  mask is 1
+*/
+KOKKOS_INLINE_FUNCTION
+constexpr int bitPack( const uint64_t mask, const uint64_t data )
+{
+    uint64_t slresult = 0;
+    uint64_t& ulresult{ slresult };
+    uint64_t uldata = data;
+    int count = 0;
+    ulresult = 0;
+
+    uint64_t rmask = binaryReverse( mask );
+    unsigned char lz{ 0 };
+
+    while ( rmask )
+    {
+        lz = countLeadingZeros( rmask );
+        uldata >>= lz;
+        ulresult <<= 1;
+        count++;
+        ulresult |= ( uldata & 1 );
+        uldata >>= 1;
+        rmask <<= lz + 1;
+    }
+    ulresult <<= 64 - count; // 64 bits (maybe not use a constant 64 ...?)
+    ulresult = binaryReverse( ulresult );
+    return (int)slresult;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief (Host/Device) Spread out the data bits where the corresponding bit of
+  the mask is 1
+*/
+KOKKOS_INLINE_FUNCTION
+constexpr uint64_t bitSpread( const uint64_t mask, const int data )
+{
+    uint64_t rmask = binaryReverse( mask );
+    int dat = data;
+    uint64_t result = 0;
+    unsigned char lz{ 0 };
+    while ( rmask )
+    {
+        lz = countLeadingZeros( rmask ) + 1;
+        result = result << lz | ( dat & 1 );
+        dat >>= 1, rmask <<= lz;
+    }
+    result = binaryReverse( result ) >> countLeadingZeros( mask );
+    return result;
+}
+
+//---------------------------------------------------------------------------//
+// Tile Hash Key (hash) <=> TileID.
+//---------------------------------------------------------------------------//
+template <typename Key, HashTypes HashT>
+struct TileID2HashKey;
+
+template <typename Key, HashTypes HashT>
+struct HashKey2TileID;
+
+/*!
+  \struct TileID2HashKey
+  \brief Compute the hash key from the 3D tile ijk
+
+  Lexicographical order specialization
+  Can be rewrite in a recursive way
+*/
+template <typename Key>
+struct TileID2HashKey<Key, HashTypes::Naive>
+{
+    using tid_to_key_type = TileID2HashKey<Key, HashTypes::Naive>;
+    static constexpr HashTypes hash_type = HashTypes::Naive;
+
+    //! Constructor (Host) from a given initializer list
+    TileID2HashKey( std::initializer_list<int> tnum )
+    {
+        std::copy( tnum.begin(), tnum.end(), _tile_num.data() );
+        _tile_num_j_mul_k = _tile_num[1] * _tile_num[2];
+    }
+    //! Constructor (Host) from three integers
+    TileID2HashKey( int i, int j, int k )
+    {
+        _tile_num[0] = i;
+        _tile_num[1] = j;
+        _tile_num[2] = k;
+        _tile_num_j_mul_k = j * k;
+    }
+
+    /*!
+    \brief (Device) Compute the 1D hash key of tile in a lexicographical way
+    */
+    KOKKOS_INLINE_FUNCTION
+    Key operator()( int tile_i, int tile_j, int tile_k ) const
+    {
+        return tile_i * _tile_num_j_mul_k + tile_j * _tile_num[2] + tile_k;
+    }
+
+  private:
+    // The index bounds of the tiles on the current MPI rank
+    Kokkos::Array<int, 3> _tile_num;
+    int _tile_num_j_mul_k;
+};
+
+/*!
+  \struct TileID2HashKey
+  \brief Compute the hash key from the 3D tile ijk
+
+  Morton code specialization
+*/
+template <typename Key>
+struct TileID2HashKey<Key, HashTypes::Morton>
+{
+    using tid_to_key_type = TileID2HashKey<Key, HashTypes::Morton>;
+    static constexpr HashTypes hash_type = HashTypes::Morton;
+
+    //! Constructor (Host) from a given initializer list
+    TileID2HashKey( std::initializer_list<int> tnum )
+    {
+        std::copy( tnum.begin(), tnum.end(), _tile_num.data() );
+    }
+    //! Constructor (Host) from three integers
+    TileID2HashKey( int i, int j, int k )
+    {
+
+        _tile_num[0] = i;
+        _tile_num[1] = j;
+        _tile_num[2] = k;
+    }
+    //! Page mask used for computing the morton code
+    enum : uint64_t
+    { // hand-coded now, can be improved by iterative func
+        page_kmask = ( 0x9249249249249249UL ),
+        page_jmask = ( 0x2492492492492492UL ),
+        page_imask = ( 0x4924924924924924UL )
+    };
+
+    /*!
+    \brief (Device) Compute the 1D hash key of tile in a morton way
+    */
+    KOKKOS_INLINE_FUNCTION
+    Key operator()( int tile_i, int tile_j, int tile_k ) const
+    {
+        return bitSpread( page_kmask, tile_k ) |
+               bitSpread( page_jmask, tile_j ) |
+               bitSpread( page_imask, tile_i );
+    }
+
+  private:
+    // The index bounds of the tiles on the current MPI rank
+    Kokkos::Array<int, 3> _tile_num;
+};
+
+/*!
+  \struct HashKey2TileID
+  \brief Compute the 3D tile ijk from the hash key
+
+  Lexicographical order specialization
+  Can be rewrite in a recursive way
+*/
+template <typename Key>
+struct HashKey2TileID<Key, HashTypes::Naive>
+{
+    using key_to_tid_type = HashKey2TileID<Key, HashTypes::Naive>;
+    static constexpr HashTypes hash_type = HashTypes::Naive;
+
+    //! Constructor (Host) from a given initializer list
+    HashKey2TileID( std::initializer_list<int> tnum )
+        : _tile_num()
+    {
+        std::copy( tnum.begin(), tnum.end(), _tile_num.data() );
+    }
+    //! Constructor (Host) from three integers
+    HashKey2TileID( int i, int j, int k )
+    {
+        _tile_num[0] = i;
+        _tile_num[1] = j;
+        _tile_num[2] = k;
+    }
+
+    /*!
+    \brief (Device) Compute the tile ijk from the lexicographical tile hash key
+    */
+    KOKKOS_INLINE_FUNCTION
+    void operator()( Key tile_key, int& tile_i, int& tile_j, int& tile_k ) const
+    {
+        tile_k = tile_key % _tile_num[2];
+        tile_j = static_cast<Key>( tile_key / _tile_num[2] ) % _tile_num[1];
+        tile_i = static_cast<Key>( tile_key / _tile_num[2] / _tile_num[1] ) %
+                 _tile_num[0];
+    }
+
+  private:
+    // The index bounds of the tiles on the current MPI rank
+    Kokkos::Array<int, 3> _tile_num;
+};
+
+/*!
+  \struct HashKey2TileID
+  \brief Compute the 3D tile ijk from the hash key
+
+  Morton code specialization
+*/
+template <typename Key>
+struct HashKey2TileID<Key, HashTypes::Morton>
+{
+    using key_to_tid_type = HashKey2TileID<Key, HashTypes::Morton>;
+    static constexpr HashTypes hash_type = HashTypes::Morton;
+
+    //! Constructor (Host) from a given initializer list
+    HashKey2TileID( std::initializer_list<int> tnum )
+    {
+        std::copy( tnum.begin(), tnum.end(), _tile_num.data() );
+    }
+    //! Constructor (Host) from three integers
+    HashKey2TileID( int i, int j, int k )
+    {
+        _tile_num[0] = i;
+        _tile_num[1] = j;
+        _tile_num[2] = k;
+    }
+    //! Page mask used for computing the morton code
+    enum : uint64_t
+    { // hand-coded now, can be improved by iterative func
+        page_kmask = ( 0x9249249249249249UL ),
+        page_jmask = ( 0x2492492492492492UL ),
+        page_imask = ( 0x4924924924924924UL )
+    };
+
+    /*!
+    \brief (Device) Compute the tile ijk from the lexicographical tile hash key
+    */
+    KOKKOS_INLINE_FUNCTION
+    void operator()( Key tile_key, int& tile_i, int& tile_j, int& tile_k ) const
+    {
+        tile_k = bitPack( page_kmask, tile_key );
+        tile_j = bitPack( page_jmask, tile_key );
+        tile_i = bitPack( page_imask, tile_key );
+    }
+
+  private:
+    // The index bounds of the tiles on the current MPI rank
+    Kokkos::Array<int, 3> _tile_num;
+};
+
+//---------------------------------------------------------------------------//
+// Hierarchical index spaces
+// SparseIndexSpace <- BlockIndexSpace <- TileIndexSpace
+// Naming:
+//      Block = MPI Rank
+//      Tile = Sub-block with several cells
+//      Cell = Basic grid unit
+//---------------------------------------------------------------------------//
+
+//! Declaration of BlockIndexSpace
+template <typename MemorySpace, unsigned long long CBits,
+          unsigned long long CNumPerDim, unsigned long long CNumPerTile,
+          HashTypes Hash, typename Key, typename Value>
+class BlockIndexSpace;
+
+//! Declaration of TileIndexSpace
+template <int CBits, int CNumPerDim, int CNumPerTile>
+class TileIndexSpace;
+
+/*!
+  \class SparseIndexSpace
+  \brief Sparse index space, with a hierarchical structure (cell->tile->block)
+  \tparam MemorySpace Memory space to store the IndexSpace(Hash Table)
+  \tparam CellPerTileDim Cell number inside each tile per dimension
+  \tparam Hash Hash type (lexicographical or morton)
+  \tparam Key Type of the tile/cell hash key
+  \tparam Value Type of the tile/cell No.
+ */
+template <typename MemorySpace, unsigned long long CellPerTileDim = 4,
+          HashTypes Hash = HashTypes::Naive, typename Key = uint64_t,
+          typename Value = uint64_t>
+class SparseIndexSpace
+{
+  public:
+    //! Number of dimensions, 3 = ijk
+    static constexpr int rank = 3;
+    //! Number of bits (per dimension) needed to index the cells inside a tile
+    static constexpr unsigned long long cell_bits_per_tile_dim =
+        bitCount( CellPerTileDim );
+    //! Number of cells inside each tile (per dimension), tile size reset to
+    //! power of 2
+    static constexpr unsigned long long cell_num_per_tile_dim =
+        1 << cell_bits_per_tile_dim;
+    //! Cell mask (per dimension), indicating which part of the tile
+    //! address(binary bits) will index the cells inside each tile
+    static constexpr unsigned long long cell_mask_per_tile_dim =
+        ( 1 << cell_bits_per_tile_dim ) - 1;
+    //! Number of bits (total) needed to index the cells inside a tile
+    static constexpr unsigned long long cell_bits_per_tile =
+        cell_bits_per_tile_dim + cell_bits_per_tile_dim +
+        cell_bits_per_tile_dim;
+    //! Number of cells (total) inside each tile
+    static constexpr unsigned long long cell_num_per_tile =
+        cell_num_per_tile_dim * cell_num_per_tile_dim * cell_num_per_tile_dim;
+    //! Types
+    using key_type = Key;                        // tile hash key
+    using value_type = Value;                    // tile No.
+    static constexpr HashTypes hash_type = Hash; // hash table
+
+    /*!
+      \brief (Host) Constructor
+      \param size The size of the block (MPI rank) (Unit: cell)
+      \param capacity Expected capacity of the allocator to store the tiles
+      when tile nums exceed the capacity
+    */
+    SparseIndexSpace( const std::array<int, rank> size,
+                      const unsigned int capacity )
+        : _block_id_space( size[0] >> cell_bits_per_tile_dim,
+                           size[1] >> cell_bits_per_tile_dim,
+                           size[2] >> cell_bits_per_tile_dim,
+                           1 << bitCount( capacity ) )
+    {
+        std::fill( _min.data(), _min.data() + rank, 0 );
+        std::copy( size.begin(), size.end(), _max.data() );
+    }
+
+    /*!
+      \brief (Device) Insert a cell (given a cell ijk, insert the tile where the
+      cell reside in to hash table)
+      \param cell_i cell id in dim-x
+      \param cell_j cell id in dim-y
+      \param cell_k cell id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    void insertCell( int cell_i, int cell_j, int cell_k ) const
+    {
+        insertTile( cell_i >> cell_bits_per_tile_dim,
+                    cell_j >> cell_bits_per_tile_dim,
+                    cell_k >> cell_bits_per_tile_dim );
+    }
+
+    /*!
+      \brief (Device) Insert a tile (to hash table)
+      \param tile_i tile id in dim-x
+      \param tile_j tile id in dim-y
+      \param tile_k tile id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    void insertTile( int tile_i, int tile_j, int tile_k ) const
+    {
+        _block_id_space.insert( tile_i, tile_j, tile_k );
+    }
+
+    /*!
+      \brief (Device) Query the 1D tile key from the 3D cell ijk
+      \param cell_i cell id in dim-x
+      \param cell_j cell id in dim-y
+      \param cell_k cell id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    value_type queryTile( int cell_i, int cell_j, int cell_k ) const
+    {
+        // query the tile No.
+        auto tile_id = _block_id_space.find( cell_i >> cell_bits_per_tile_dim,
+                                             cell_j >> cell_bits_per_tile_dim,
+                                             cell_k >> cell_bits_per_tile_dim );
+        return tile_id;
+    }
+
+    /*!
+      \brief (Device) Query the 1D cell key from the 3D cell ijk
+      \param cell_i cell id in dim-x
+      \param cell_j cell id in dim-y
+      \param cell_k cell id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    value_type queryCell( int cell_i, int cell_j, int cell_k ) const
+    {
+        // query the tile No.
+        auto tile_id = queryTile( cell_i, cell_j, cell_k );
+        auto cell_id = _tile_id_space.coordToOffset(
+            cell_i & cell_mask_per_tile_dim, cell_j & cell_mask_per_tile_dim,
+            cell_k & cell_mask_per_tile_dim );
+        return static_cast<value_type>( ( tile_id << cell_bits_per_tile ) |
+                                        cell_id );
+    }
+
+    /*!
+      \brief (Host) Clear tile hash table (Host, required by unordered map
+      clear())
+    */
+    void clear() { _block_id_space.clear(); }
+
+    /*!
+      \brief Set new capacity lower bound on the unordered map (Host)
+      \param capacity New capacity lower bound
+    */
+    bool reserve( const value_type capacity )
+    {
+        return _block_id_space.reserve( capacity );
+    }
+
+    /*!
+     \brief (Host/Device) Require capacity of the index hash table
+    */
+    KOKKOS_INLINE_FUNCTION
+    uint32_t capacity() const { return _block_id_space.capacity(); }
+
+    /*!
+      \brief (Host) Valid tile number inside current block (MPI rank)
+    */
+    value_type size() const { return _block_id_space.validTileNumHost(); }
+
+  private:
+    //! block index space, map tile ijk to tile
+    BlockIndexSpace<MemorySpace, cell_bits_per_tile_dim, cell_num_per_tile_dim,
+                    cell_num_per_tile, hash_type, key_type, value_type>
+        _block_id_space;
+    //! tile index space, map cell ijk to cell local No inside a tile
+    TileIndexSpace<cell_bits_per_tile_dim, cell_num_per_tile_dim,
+                   cell_num_per_tile>
+        _tile_id_space;
+    //! space size (global), channel size
+    Kokkos::Array<int, rank> _min;
+    Kokkos::Array<int, rank> _max;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+  \class BlockIndexSpace
+  \brief Block index space, mapping tile ijks to tile No. through a hash table
+  (Kokkos unordered map)
+  \tparam CBits Bits number (per dimension) neded to
+  index cells inside each tile
+  \tparam CNumPerDim Cell number (per dimension)
+  inside each tile
+  \tparam CNumPerTile Cel number (total) inside each tile
+  \tparam MemorySpace Mem space to store unordered map
+  \tparam CBits Number of bits (per dimension) needed to index the cells inside
+  a tile \tparam CNumPerDim Number of cells (per dimension) inside each tile
+  \tparam CNumPerTile Number of cells (total) inside each tile
+  \tparam Hash Hash type (lexicographical or morton)
+  \tparam Key Type of the tile/cell hash key
+  \tparam Value Type of the tile/cell No.
+*/
+template <typename MemorySpace, unsigned long long CBits,
+          unsigned long long CNumPerDim, unsigned long long CNumPerTile,
+          HashTypes Hash, typename Key, typename Value>
+class BlockIndexSpace
+{
+  public:
+    //! Number of bits (per dimension) needed to index the cells inside a tile
+    static constexpr unsigned long long cell_bits_per_tile_dim = CBits;
+    //! Number of cells (per dimension) inside each tile
+    static constexpr unsigned long long cell_num_per_tile_dim = CNumPerDim;
+    //! Number of cells (total) inside each tile
+    static constexpr unsigned long long cell_num_per_tile = CNumPerTile;
+    //! Types
+    using key_type = Key;                        // tile hash key
+    using value_type = Value;                    // tile No.
+    static constexpr HashTypes hash_type = Hash; // hash table
+    using bis_Type = BlockIndexSpace<MemorySpace, cell_bits_per_tile_dim,
+                                     cell_num_per_tile_dim, cell_num_per_tile,
+                                     hash_type, key_type, value_type>; // itself
+
+    /*!
+      \brief (Host) Constructor
+      \param size_x The size of the block (MPI rank) in dim-x (Unit: tile)
+      \param size_y The size of the block (MPI rank) in dim-y (Unit: tile)
+      \param size_z The size of the block (MPI rank) in dim-z (Unit: tile)
+      \param capacity Expected capacity of the allocator to store the tiles
+      when tile nums exceed the capcity
+    */
+    BlockIndexSpace( const int size_x, const int size_y, const int size_z,
+                     const value_type capacity )
+        : _tile_table_info( "hash_table_info" )
+        , _tile_table( size_x * size_y * size_z )
+        , _op_ijk2key( size_x, size_y, size_z )
+        , _op_key2ijk( size_x, size_y, size_z )
+    {
+        // hash table related init
+        auto tile_table_info_mirror =
+            Kokkos::create_mirror_view( Kokkos::HostSpace(), _tile_table_info );
+        tile_table_info_mirror( 0 ) = 0;
+        tile_table_info_mirror( 1 ) = capacity;
+        Kokkos::deep_copy( _tile_table_info, tile_table_info_mirror );
+
+        // size related init
+        _block_size[0] = size_x;
+        _block_size[1] = size_y;
+        _block_size[2] = size_z;
+    }
+
+    /*!
+      \brief (Host) Clear tile hash table (Host, required by unordered map
+      clear())
+    */
+    void clear()
+    {
+        _tile_table.clear(); // clear hash table
+        auto tile_table_info_mirror = Kokkos::create_mirror_view_and_copy(
+            Kokkos::HostSpace(), _tile_table_info );
+        tile_table_info_mirror( 0 ) = 0;
+        Kokkos::deep_copy( _tile_table_info,
+                           tile_table_info_mirror ); // clear valid size record
+    }
+
+    /*!
+      \brief (Host) Set new capacity lower bound on the unordered map
+             (Only for hash table, not for capacity of allocation)
+      \param capacity New capacity lower bound of the unordered map
+    */
+    bool reserve( const value_type capacity )
+    {
+        return _tile_table.rehash( capacity );
+    }
+
+    /*!
+     \brief (Host/Device) Require capacity of the index hash table
+    */
+    KOKKOS_INLINE_FUNCTION
+    uint32_t capacity() const
+    {
+        return _tile_table.capacity(); // hash_table capacity
+    }
+
+    /*!
+      \brief (Device) Valid tile number inside current block (MPI rank)
+    */
+    KOKKOS_INLINE_FUNCTION
+    value_type validTileNumDev() const { return _tile_table_info( 0 ); }
+
+    /*!
+      \brief (Host) Valid tile number inside current block (MPI rank)
+    */
+    value_type validTileNumHost() const
+    {
+        auto tile_table_info_mirror = Kokkos::create_mirror_view_and_copy(
+            Kokkos::HostSpace(), _tile_table_info );
+        return tile_table_info_mirror( 0 );
+    }
+
+    /*!
+      \brief (Device) Insert a tile into the hash table
+      \param tile_i Tile Id in dim-x
+      \param tile_j Tile Id in dim-y
+      \param tile_k Tile Id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    void insert( int tile_i, int tile_j, int tile_k ) const
+    {
+        // Note: reallocation will be performed after insert
+        // tile ijk => tile key
+        key_type tile_key = ijk2key( tile_i, tile_j, tile_k );
+        // Try to insert the tile key into the map. Give it a dummy value for
+        // now.
+        auto insert_result = _tile_table.insert( tile_key, 0 );
+        // If the tile key was actually inserted, atomically increment the
+        // counter Only threads that actually did a successful insert will call
+        // it
+        if ( !insert_result.existing() )
+            _tile_table.value_at( insert_result.index() ) =
+                Kokkos::atomic_fetch_add( &( _tile_table_info( 0 ) ), 1 );
+    }
+
+    /*!
+      \brief (Device) Query the tile No. from the hash table
+      \param tile_i Tile Id in dim-x
+      \param tile_j Tile Id in dim-y
+      \param tile_k Tile Id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    value_type find( int tile_i, int tile_j, int tile_k ) const
+    {
+        return _tile_table.value_at(
+            _tile_table.find( ijk2key( tile_i, tile_j, tile_k ) ) );
+    }
+
+    /*!
+      \brief (Device) Transfer tile ijk to tile hash key
+      \param tile_i Tile Id in dim-x
+      \param tile_j Tile Id in dim-y
+      \param tile_k Tile Id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    key_type ijk2key( int tile_i, int tile_j, int tile_k ) const
+    {
+        return _op_ijk2key( tile_i, tile_j, tile_k );
+    }
+
+    /*!
+      \brief (Device) Transfer tile hash key to tile ijk
+      \param key Tile hash key
+      \param tile_i Tile Id in dim-x
+      \param tile_j Tile Id in dim-y
+      \param tile_k Tile Id in dim-z
+    */
+    KOKKOS_INLINE_FUNCTION
+    void key2ijk( key_type& key, int& tile_i, int& tile_j, int& tile_k ) const
+    {
+        return _op_key2ijk( key, tile_i, tile_j, tile_k );
+    }
+
+  private:
+    //! [0] current valid table size, [1] preserved for pre-allocated tile size
+    Kokkos::View<int[2], MemorySpace> _tile_table_info;
+    //! current number of tiles inserted to the hash table
+    Kokkos::Array<int, 3> _block_size;
+    //! hash table (tile hash key => tile No)
+    Kokkos::UnorderedMap<key_type, value_type, MemorySpace> _tile_table;
+    //! Ops: transfer between tile ijk <=> tile hash key
+    TileID2HashKey<key_type, hash_type> _op_ijk2key;
+    HashKey2TileID<key_type, hash_type> _op_key2ijk;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+  \class TileIndexSpace
+  \brief Tile index space, inside each local tile, mapping cell ijks to cell
+  No.(Lexicographical Order) \tparam CBits Bits number (per dimension) neded to
+  index cells inside each tile
+  \tparam Cbits Number of bits (per dimension) needed to index the cells inside
+  a tile \tparam CNumPerDim Cell number (per dimension) inside each tile \tparam
+  CNumPerTile Cel number (total) inside each tile
+*/
+template <int CBits, int CNumPerDim, int CNumPerTile>
+class TileIndexSpace
+{
+  public:
+    //! Number of bits (per dimension) needed to index the cells inside a tile
+    static constexpr int cell_bits_per_tile_dim = CBits;
+    //! Number of cells (per dimension) inside each tile
+    static constexpr int cell_num_per_tile_dim = CNumPerDim;
+    //! Number of cells (total) inside each tile
+    static constexpr int cell_num_per_tile = CNumPerTile;
+    //! Indexing dimension, currently only serves 3D representations
+    static constexpr int rank = 3;
+
+    //! Cell ijk <=> Cell Id
+    /*!
+      \brief (Host/Device) Compute from coordinate to offset
+    */
+    template <typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr auto
+    coordToOffset( Coords&&... coords ) -> uint64_t
+    {
+        return fromCoord<Coord2OffsetDim>( std::forward<Coords>( coords )... );
+    }
+
+    /*!
+      \brief (Host/Device) Compute from offset to coordinates
+    */
+    template <typename Key, typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr void
+    offsetToCoord( Key&& key, Coords&... coords )
+    {
+        toCoord<Offset2CoordDim>( std::forward<Key>( key ), coords... );
+    }
+
+  private:
+    //! Coord  <=> Offset Computations
+    /*!
+      \brief Transfer function: tile ijk to tile key
+    */
+    struct Coord2OffsetDim
+    {
+        template <typename Coord>
+        KOKKOS_INLINE_FUNCTION constexpr auto operator()( int dim_no,
+                                                          Coord&& i )
+            -> uint64_t
+        {
+            uint64_t result = static_cast<uint64_t>( i );
+            for ( int i = 0; i < dim_no; i++ )
+                result *= cell_num_per_tile_dim;
+            return result;
+        }
+    };
+
+    /*!
+      \brief Transfer function: tile key to tile ijk
+    */
+    struct Offset2CoordDim
+    {
+        template <typename Coord, typename Key>
+        KOKKOS_INLINE_FUNCTION constexpr auto operator()( Coord& i,
+                                                          Key&& offset )
+            -> uint64_t
+        {
+            i = offset % cell_num_per_tile_dim;
+            return ( offset / cell_num_per_tile_dim );
+        }
+    };
+
+    /*!
+      \brief Compute a single number from given coordinates
+      \tparam Func Transfer fuctions from coords to the single number
+      \param coords Input coordinates
+    */
+    template <typename Func, typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr auto fromCoord( Coords&&... coords )
+        -> uint64_t
+    {
+        static_assert( sizeof...( Coords ) == rank,
+                       "Dimension of coordinate mismatch" );
+        using integer = std::common_type_t<Coords...>;
+        static_assert( std::is_integral<integer>::value,
+                       "Coordinate should be integral type" );
+        return fromCoordImpl<Func>( 0, coords... );
+    }
+
+    /*!
+      \brief Compute the coordinates from a given single number;
+             The dimension of the coordinate is determined by the input param
+      number \tparam Func Transfer fuctions from the single number to coords
+      \param key The given single number
+      \param coords The output coordinates
+    */
+    template <typename Func, typename Key, typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr void toCoord( Key&& key,
+                                                          Coords&... coords )
+    {
+        static_assert( sizeof...( Coords ) == rank,
+                       "Dimension of coordinate mismatch" );
+        using integer = std::common_type_t<Coords...>;
+        static_assert( std::is_integral<integer>::value,
+                       "Coordinate should be integral type" );
+        return toCoordImpl<Func>( 0, std::forward<Key>( key ), coords... );
+    }
+
+    /*!
+      \brief Implementation (coords => single number)
+      \param dim_no Current coord dimension
+      \param i The coord value
+    */
+    template <typename Func, typename Coord>
+    KOKKOS_INLINE_FUNCTION static constexpr auto fromCoordImpl( int&& dim_no,
+                                                                Coord&& i )
+    {
+        return Func()( dim_no, std::forward<Coord>( i ) );
+    }
+
+    /*!
+      \brief Implementation (coords => single number)
+      \param dim_no Current coord dimension
+      \param i The coord value
+      \param is The rest of the coord values
+    */
+    template <typename Func, typename Coord, typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr auto
+    fromCoordImpl( int&& dim_no, Coord&& i, Coords&&... is )
+    {
+        auto result = Func()( dim_no, std::forward<Coord>( i ) );
+        if ( dim_no + 1 < rank )
+            result += fromCoordImpl<Func>( dim_no + 1,
+                                           std::forward<Coords>( is )... );
+        return result;
+    }
+
+    /*!
+      \brief Implementation (single number => coords)
+      \param dim_no Current coord dimension
+      \param key The input single number
+      \param i The output coord value
+    */
+    template <typename Func, typename Key, typename Coord>
+    KOKKOS_INLINE_FUNCTION static constexpr void
+    toCoordImpl( int&& dim_no, Key&& key, Coord& i ) noexcept
+    {
+        if ( dim_no < rank )
+            Func()( i, std::forward<Key>( key ) );
+    }
+
+    /*!
+      \brief Implementation (single number => coords)
+      \param dim_no Current coord dimension
+      \param key The input single number
+      \param i The output coord value
+      \param is The rest of the coord values
+    */
+    template <typename Func, typename Key, typename Coord, typename... Coords>
+    KOKKOS_INLINE_FUNCTION static constexpr void
+    toCoordImpl( int&& dim_no, Key&& key, Coord& i, Coords&... is ) noexcept
+    {
+        auto new_key = Func()( i, std::forward<Key>( key ) );
+        if ( dim_no + 1 < rank )
+            toCoordImpl<Func>( dim_no + 1, new_key, is... );
+    }
+};
+
+} // end namespace Cajita
+#endif ///< !CAJITA_SPARSE_INDEXSPACE_HPP

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SERIAL_TESTS
   IndexSpace
   Parallel
   ParameterPack
+  SparseIndexSpace
   Splines
   )
 

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -1,0 +1,609 @@
+#include <Cajita_SparseIndexSpace.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace Cajita;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+void testAtomicOr()
+{
+    constexpr int size = 64;
+
+    Kokkos::View<int*** [2], TEST_MEMSPACE> tile_insert_record(
+        "hash_record", size, size, size );
+
+    auto tile_insert_record_mirror =
+        Kokkos::create_mirror_view( Kokkos::HostSpace(), tile_insert_record );
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+                for ( int d = 0; d < 2; d++ )
+                {
+                    tile_insert_record_mirror( i, j, k, d ) = false;
+                }
+    Kokkos::deep_copy( tile_insert_record, tile_insert_record_mirror );
+
+    Kokkos::View<bool[size][size][size], TEST_DEVICE> tile_label( "label" );
+
+    TEST_EXECSPACE().fence();
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ),
+        KOKKOS_LAMBDA( int tile_i ) {
+            for ( int tile_j = 0; tile_j < size; tile_j++ )
+                for ( int tile_k = 0; tile_k < size; tile_k++ )
+                {
+                    if ( Kokkos::atomic_fetch_or(
+                             &( tile_insert_record( tile_i, tile_j, tile_k,
+                                                    0 ) ),
+                             1 ) == 0 )
+                    {
+                        tile_label( tile_i, tile_j, tile_k ) = true;
+                    }
+                }
+        } );
+    TEST_EXECSPACE().fence();
+
+    auto tile_label_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), tile_label );
+
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+            {
+                EXPECT_EQ( tile_label_mirror( i, j, k ), true );
+            }
+}
+
+void testAtomicOrPro()
+{
+    constexpr int size = 64;
+
+    Kokkos::View<int*** [2], TEST_MEMSPACE> tile_insert_record(
+        "hash_record", size, size, size );
+
+    auto tile_insert_record_mirror =
+        Kokkos::create_mirror_view( Kokkos::HostSpace(), tile_insert_record );
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+                for ( int d = 0; d < 2; d++ )
+                {
+                    tile_insert_record_mirror( i, j, k, d ) = false;
+                }
+    Kokkos::deep_copy( tile_insert_record, tile_insert_record_mirror );
+
+    Kokkos::View<bool[size][size][size], TEST_DEVICE> tile_label( "label" );
+
+    TEST_EXECSPACE().fence();
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ),
+        KOKKOS_LAMBDA( int tile_i ) {
+            for ( int tile_j = 0; tile_j < size; tile_j++ )
+                for ( int tile_k = 0; tile_k < size; tile_k++ )
+                {
+                    if ( Kokkos::atomic_fetch_or(
+                             &( tile_insert_record( 0, 0, 0, 0 ) ), 1 ) == 0 )
+                    {
+                        tile_label( tile_i, tile_j, tile_k ) = true;
+                    }
+                }
+        } );
+    TEST_EXECSPACE().fence();
+
+    auto tile_label_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), tile_label );
+    int count = 0;
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+            {
+                if ( tile_label_mirror( i, j, k ) == 1 )
+                    count++;
+            }
+
+    EXPECT_EQ( count, 1 );
+}
+
+template <int SizeBit = 2, int Size = 4>
+void testTileSpace()
+{
+    // size 4x4x4
+    constexpr int size_bit = SizeBit;
+    constexpr int size = Size;
+    using TIS = TileIndexSpace<size_bit, size, size * size>;
+    Kokkos::View<int[size][size][size], TEST_DEVICE> offset_res( "offset" );
+    Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
+    Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
+    Kokkos::View<int[size][size][size], TEST_DEVICE> k_res( "k" );
+    TIS tis;
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ),
+        KOKKOS_LAMBDA( const int k ) {
+            for ( int j = 0; j < size; j++ )
+                for ( int i = 0; i < size; i++ )
+                {
+                    auto idx = tis.coordToOffset( i, j, k );
+                    offset_res( i, j, k ) = idx;
+                    int ci, cj, ck;
+                    tis.offsetToCoord( idx, ci, cj, ck );
+                    i_res( i, j, k ) = ci;
+                    j_res( i, j, k ) = cj;
+                    k_res( i, j, k ) = ck;
+                }
+        } );
+    auto offset_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), offset_res );
+    auto i_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), i_res );
+    auto j_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), j_res );
+    auto k_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), k_res );
+    for ( int k = 0; k < size; k++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int i = 0; i < size; i++ )
+            {
+                EXPECT_EQ( offset_mirror( i, j, k ),
+                           k * size * size + j * size + i );
+                EXPECT_EQ( i_mirror( i, j, k ), i );
+                EXPECT_EQ( j_mirror( i, j, k ), j );
+                EXPECT_EQ( k_mirror( i, j, k ), k );
+            }
+}
+
+template <HashTypes HashType>
+void testBlockSpace()
+{
+    constexpr unsigned long long cell_bits_per_tile_dim = 2;
+    constexpr unsigned long long cell_num_per_tile_dim = 4;
+    constexpr unsigned long long cell_num_per_tile =
+        cell_num_per_tile_dim * cell_num_per_tile_dim * cell_num_per_tile_dim;
+    using key_type = uint64_t;
+    using value_type = uint32_t;
+    constexpr int size = 64;
+    int capacity = size * size;
+    BlockIndexSpace<TEST_MEMSPACE, cell_bits_per_tile_dim,
+                    cell_num_per_tile_dim, cell_num_per_tile, HashType,
+                    key_type, value_type>
+        bis( size, size, size, capacity );
+
+    Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
+    Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
+    Kokkos::View<int[size][size][size], TEST_DEVICE> k_res( "k" );
+    TEST_EXECSPACE().fence();
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ), KOKKOS_LAMBDA( int i ) {
+            for ( int j = 0; j < size; j++ )
+                for ( int k = 0; k < size; k++ )
+                {
+                    bis.insert( i, j, k );
+                    auto tile_key = bis.ijk2key( i, j, k );
+                    int ti, tj, tk;
+                    bis.key2ijk( tile_key, ti, tj, tk );
+                    i_res( i, j, k ) = ti;
+                    j_res( i, j, k ) = tj;
+                    k_res( i, j, k ) = tk;
+                }
+        } );
+    TEST_EXECSPACE().fence();
+    auto i_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), i_res );
+    auto j_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), j_res );
+    auto k_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), k_res );
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+            {
+                EXPECT_EQ( i_mirror( i, j, k ), i );
+                EXPECT_EQ( j_mirror( i, j, k ), j );
+                EXPECT_EQ( k_mirror( i, j, k ), k );
+            }
+    bool test[size * size * size];
+
+    Kokkos::View<int[size * size * size], TEST_DEVICE> id_find_res( "id_find" );
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ), KOKKOS_LAMBDA( int i ) {
+            for ( int j = 0; j < size; j++ )
+                for ( int k = 0; k < size; k++ )
+                    id_find_res( i * size * size + j * size + k ) =
+                        bis.find( i, j, k );
+        } );
+    ;
+    auto id_find_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), id_find_res );
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+                test[i * size * size + j * size + k] = false;
+
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+                test[id_find_mirror( i * size * size + j * size + k )] = true;
+
+    for ( int i = 0; i < size; i++ )
+        for ( int j = 0; j < size; j++ )
+            for ( int k = 0; k < size; k++ )
+            {
+                auto id = i * size * size + j * size + k;
+                EXPECT_EQ( test[id], true );
+            }
+}
+
+void testSparseIndexSpaceFullInsert()
+{
+    constexpr int dim_n = 3;
+    constexpr int size_tile_per_dim = 16;
+    constexpr int size_per_dim = size_tile_per_dim * 4;
+
+    std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
+    int capacity = size_per_dim * size_per_dim;
+    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+
+    auto cbd = sis.cell_bits_per_tile_dim;
+    EXPECT_EQ( cbd, 2 );
+
+    auto cnd = sis.cell_num_per_tile_dim;
+    EXPECT_EQ( cnd, 4 );
+
+    auto cmd = sis.cell_mask_per_tile_dim;
+    EXPECT_EQ( cmd, 3 );
+
+    auto cbt = sis.cell_bits_per_tile;
+    EXPECT_EQ( cbt, 6 );
+
+    auto cnt = sis.cell_num_per_tile;
+    EXPECT_EQ( cnt, 64 );
+
+    Kokkos::View<int***, TEST_DEVICE> qid_res( "query_id", size[0], size[1],
+                                               size[2] );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size_per_dim ),
+        KOKKOS_LAMBDA( int i ) {
+            for ( int j = 0; j < size_per_dim; j++ )
+                for ( int k = 0; k < size_per_dim; k++ )
+                {
+                    sis.insertCell( i, j, k );
+                }
+        } );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size_per_dim ),
+        KOKKOS_LAMBDA( int i ) {
+            for ( int j = 0; j < size_per_dim; j++ )
+                for ( int k = 0; k < size_per_dim; k++ )
+                {
+                    qid_res( i, j, k ) = sis.queryCell( i, j, k );
+                }
+        } );
+
+    bool test[size_per_dim * size_per_dim * size_per_dim];
+    auto qid_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qid_res );
+
+    for ( int i = 0; i < size[0]; i++ )
+        for ( int j = 0; j < size[1]; j++ )
+            for ( int k = 0; k < size[2]; k++ )
+                test[i * size[1] * size[2] + j * size[2] + k] = false;
+
+    for ( int i = 0; i < size[0]; i++ )
+        for ( int j = 0; j < size[1]; j++ )
+            for ( int k = 0; k < size[2]; k++ )
+                test[qid_mirror( i, j, k )] = true;
+
+    for ( int i = 0; i < size[0]; i++ )
+        for ( int j = 0; j < size[1]; j++ )
+            for ( int k = 0; k < size[2]; k++ )
+            {
+                EXPECT_EQ( test[i * size[2] * size[1] + j * size[2] + k],
+                           true );
+            }
+
+    constexpr int total_tile_num =
+        size_tile_per_dim * size_tile_per_dim * size_tile_per_dim;
+
+    uint32_t cap = sis.capacity();
+    EXPECT_EQ( cap >= total_tile_num, true );
+
+    auto s = sis.size();
+    EXPECT_EQ( s, total_tile_num );
+
+    uint32_t new_set_cap = total_tile_num * 10;
+    sis.reserve( new_set_cap );
+    uint32_t new_cap = sis.capacity();
+    EXPECT_EQ( new_cap >= new_set_cap, true );
+
+    auto new_s = sis.size();
+    EXPECT_EQ( new_s, total_tile_num );
+}
+
+void testSparseIndexSpaceSparseInsert()
+{
+    constexpr int dim_n = 3;
+    constexpr int size_tile_per_dim = 16;
+    constexpr int size_per_dim = size_tile_per_dim * 4;
+    constexpr int total_size = size_per_dim * size_per_dim * size_per_dim;
+
+    std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
+    int capacity = size_per_dim * size_per_dim;
+    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+
+    auto cbd = sis.cell_bits_per_tile_dim;
+    EXPECT_EQ( cbd, 2 );
+
+    auto cnd = sis.cell_num_per_tile_dim;
+    EXPECT_EQ( cnd, 4 );
+
+    auto cmd = sis.cell_mask_per_tile_dim;
+    EXPECT_EQ( cmd, 3 );
+
+    auto cbt = sis.cell_bits_per_tile;
+    EXPECT_EQ( cbt, 6 );
+
+    auto cnt = sis.cell_num_per_tile;
+    EXPECT_EQ( cnt, 64 );
+
+    constexpr int insert_cell_num = 100;
+    Kokkos::View<int*, Kokkos::HostSpace> host_cell_1did( "cell_ids_1d",
+                                                          insert_cell_num );
+    std::map<int, int> cell_register;
+    for ( int i = 0; i < insert_cell_num; ++i )
+    {
+        host_cell_1did( i ) = ( std::rand() % total_size );
+        int tile_k = ( host_cell_1did( i ) % size_per_dim ) >> 2;
+        int tile_j =
+            ( ( host_cell_1did( i ) / size_per_dim ) % size_per_dim ) >> 2;
+        int tile_i = ( ( host_cell_1did( i ) / size_per_dim / size_per_dim ) %
+                       size_per_dim ) >>
+                     2;
+        cell_register[tile_i * size_tile_per_dim * size_tile_per_dim +
+                      tile_j * size_tile_per_dim + tile_k] = 1;
+    }
+    int valid_cell_num = cell_register.size();
+    Kokkos::View<int*, TEST_DEVICE> dev_cell_1did( "cell_ids_1d_dev",
+                                                   insert_cell_num );
+    Kokkos::deep_copy( dev_cell_1did, host_cell_1did );
+
+    Kokkos::View<int*, TEST_DEVICE> qtid_res( "query_tile_id",
+                                              insert_cell_num );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            sis.insertCell( i, j, k );
+        } );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            auto qid = sis.queryTile( i, j, k );
+            qtid_res( cell_idx ) = qid;
+        } );
+
+    bool test[size_per_dim * size_per_dim * size_per_dim];
+
+    auto qtid_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qtid_res );
+
+    for ( int i = 0; i < total_size; i++ )
+        test[i] = false;
+
+    for ( int i = 0; i < insert_cell_num; ++i )
+        test[qtid_mirror( i )] = true;
+
+    int idx = 0;
+    while ( idx < valid_cell_num )
+    {
+        EXPECT_EQ( test[idx], true );
+        ++idx;
+    }
+    while ( idx < total_size )
+    {
+        EXPECT_EQ( test[idx], false );
+        ++idx;
+    }
+
+    auto s = sis.size();
+    EXPECT_EQ( s, valid_cell_num );
+
+    uint32_t cap = sis.capacity();
+    EXPECT_EQ(
+        cap >= ( size_tile_per_dim * size_tile_per_dim * size_tile_per_dim ),
+        true );
+
+    uint32_t new_set_cap = total_size;
+    sis.reserve( new_set_cap );
+    uint32_t new_cap = sis.capacity();
+    EXPECT_EQ( new_cap >= new_set_cap, true );
+
+    auto new_s = sis.size();
+    EXPECT_EQ( new_s, valid_cell_num );
+}
+
+void testSparseIndexSpaceReinsert()
+{
+    constexpr int dim_n = 3;
+    constexpr int size_tile_per_dim = 16;
+    constexpr int size_per_dim = size_tile_per_dim * 4;
+    constexpr int total_size = size_per_dim * size_per_dim * size_per_dim;
+
+    std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
+    int capacity = size_per_dim * size_per_dim;
+    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+
+    constexpr int insert_cell_num = 50;
+    Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );
+    Kokkos::View<int*, Kokkos::HostSpace> host_cell_1did( "cell_ids_1d",
+                                                          insert_cell_num );
+    std::map<int, int> cell_register;
+    for ( int i = 0; i < insert_cell_num; ++i )
+    {
+        host_cell_1did( i ) = ( std::rand() % total_size );
+        int tile_k = ( host_cell_1did( i ) % size_per_dim ) >> 2;
+        int tile_j =
+            ( ( host_cell_1did( i ) / size_per_dim ) % size_per_dim ) >> 2;
+        int tile_i = ( ( host_cell_1did( i ) / size_per_dim / size_per_dim ) %
+                       size_per_dim ) >>
+                     2;
+        cell_register[tile_i * size_tile_per_dim * size_tile_per_dim +
+                      tile_j * size_tile_per_dim + tile_k] = 1;
+    }
+    int valid_cell_num = cell_register.size();
+    Kokkos::View<int*, TEST_DEVICE> dev_cell_1did( "cell_ids_1d_dev",
+                                                   insert_cell_num );
+    Kokkos::deep_copy( dev_cell_1did, host_cell_1did );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            sis.insertCell( i, j, k );
+        } );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            auto qid = sis.queryTile( i, j, k );
+            qid_res( cell_idx ) = qid;
+        } );
+
+    bool test[size_per_dim * size_per_dim * size_per_dim];
+
+    auto qid_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qid_res );
+
+    for ( int i = 0; i < total_size; i++ )
+    {
+        test[i] = false;
+    }
+
+    for ( int i = 0; i < insert_cell_num; ++i )
+    {
+        test[qid_mirror( i )] = true;
+    }
+
+    int idx = 0;
+    while ( idx < valid_cell_num )
+    {
+        EXPECT_EQ( test[idx], true );
+        ++idx;
+    }
+    while ( idx < total_size )
+    {
+        EXPECT_EQ( test[idx], false );
+        ++idx;
+    }
+
+    uint32_t oldcap = sis.capacity();
+    sis.clear();
+    uint32_t newcap = sis.capacity();
+    auto newsize = sis.size();
+    EXPECT_EQ( oldcap, newcap );
+    EXPECT_EQ( newsize, 0 );
+
+    std::map<int, int> cell_register_new;
+    for ( int i = 0; i < insert_cell_num; ++i )
+    {
+        host_cell_1did( i ) = ( std::rand() % total_size );
+        int tile_k = ( host_cell_1did( i ) % size_per_dim ) >> 2;
+        int tile_j =
+            ( ( host_cell_1did( i ) / size_per_dim ) % size_per_dim ) >> 2;
+        int tile_i = ( ( host_cell_1did( i ) / size_per_dim / size_per_dim ) %
+                       size_per_dim ) >>
+                     2;
+        cell_register_new[tile_i * size_tile_per_dim * size_tile_per_dim +
+                          tile_j * size_tile_per_dim + tile_k] = 1;
+    }
+    valid_cell_num = cell_register_new.size();
+    Kokkos::deep_copy( dev_cell_1did, host_cell_1did );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            sis.insertCell( i, j, k );
+        } );
+
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
+        KOKKOS_LAMBDA( int cell_idx ) {
+            int id = dev_cell_1did( cell_idx );
+            int k = id % size_per_dim;
+            int j = ( id / size_per_dim ) % size_per_dim;
+            int i = ( id / size_per_dim / size_per_dim ) % size_per_dim;
+            auto qid = sis.queryTile( i, j, k );
+            qid_res( cell_idx ) = qid;
+        } );
+
+    auto qid_mirror_2 =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qid_res );
+
+    for ( int i = 0; i < total_size; i++ )
+    {
+        test[i] = false;
+    }
+
+    for ( int i = 0; i < insert_cell_num; ++i )
+    {
+        test[qid_mirror_2( i )] = true;
+    }
+
+    idx = 0;
+    while ( idx < valid_cell_num )
+    {
+        EXPECT_EQ( test[idx], true );
+        ++idx;
+    }
+    while ( idx < total_size )
+    {
+        EXPECT_EQ( test[idx], false );
+        ++idx;
+    }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( sparse_grid, sparse_index_space_test )
+{
+    testAtomicOr();
+    testAtomicOrPro();
+    testTileSpace<2, 4>(); // tile size 4x4x4
+    testTileSpace<1, 2>(); // tile size 2x2x2
+    testTileSpace<3, 8>(); // tile size 8x8x8
+    testBlockSpace<HashTypes::Naive>();
+    testBlockSpace<HashTypes::Morton>();
+    testSparseIndexSpaceFullInsert();
+    testSparseIndexSpaceSparseInsert();
+    testSparseIndexSpaceReinsert();
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
_I'm making this pull request to keep the work, especially the design and logical part, tracked. 
I'm still testing and clean the code._

Some conventions for naming: 
- tileID = 3D tile indexing, i.e., (i, j, k); 
- tileNo = 1D number indicating the tile position in the array; 
- tileKey/hashKey = 1D number, computed with the given indexing method, i.e. Naive or lexicographical, and Morton

What have been done:
1. Local index inside a block
2. Index blocks with the lexicographical sequence and the Morton sequence ( with some bit operations provided )
3. Hierarchical design of the current SparseIndexSpace, extract the tile index space out. I.e., SparseIndexSpace = (BlockIndexSpace + TileIndexSpace), where BlockIndexSpace provide tile indices in a single block(MPI rank), TileIndexSpace indices inside a single tile.

Further plans:
1. Test the current code, fix bugs.
2. Consider the allocations.

Something can be improved:
1. The Morton coding is hand-coded for 3D now. This can be improved by recursive refactor, which can support arbitrary dimensions with cleaner code.

Here are some thoughts, and current drawbacks.
1. About the indexing curve for the tiles. 
     - If we use the Unordered Map, the indexing curve tends to be useless.  The tile ID would be decided by the sequence to insert the tiles, the indexing curve is only used for computing the hash key. 
     - Possible solutions: (1) Use an ordered map; (2) Assume the current capacity would all be allocated; restrict the hash key to be less than the current capacity, deal with conflicts by some offsets, record/detect the conflicts by the Unordered Hash Table.
     - Some thoughts/questions: Will the sequence of the tiles significantly influence the performance, if the tiles are sparse. We need to maintain the sequence of the blocks every time step, which could be expensive.

2. More thinking about the indexing curve:
     - If we can make more constrictions on the size of the tile size ( eg the tile size must be 2^n ), then we can make use of the bit computations to calculate the global(tile) index and the local index in a more efficient way. OR we can still use bit computations if some memory waste is acceptable.
     - Now I separate the global and local index into two structs. We can actually combine the global and local index into one struct, and specify struct according to the indexing method. 

3. About the label of Owned Grid and Ghost Grid.
     - It could be easy to handle the owned/ghost label in the uniform grid. But things could be complicated for the sparse grid.
     - Possible solutions: (1) Set up two tables, one for the owned grid, and another for ghost grid. (2) set up two tables, one for all the grids, and another for the grid label.