### PR TITLE
Take initial guess on max number of neighbors when building neighbor lists with ArborX

### DIFF
--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -226,7 +226,7 @@ template <typename DeviceType, typename Slice, typename Tag>
 auto makeNeighborList( Tag, Slice const &coordinate_slice,
                        typename Slice::size_type first,
                        typename Slice::size_type last,
-                       typename Slice::value_type radius )
+                       typename Slice::value_type radius, int buffer_size = 0 )
 {
     using MemorySpace = typename DeviceType::memory_space;
     using ExecutionSpace = typename DeviceType::execution_space;
@@ -238,9 +238,10 @@ auto makeNeighborList( Tag, Slice const &coordinate_slice,
         Kokkos::view_alloc( "indices", Kokkos::WithoutInitializing ), 0 );
     Kokkos::View<int *, DeviceType> offset(
         Kokkos::view_alloc( "offset", Kokkos::WithoutInitializing ), 0 );
-    bvh.query( space,
-               Impl::makePredicates( coordinate_slice, first, last, radius ),
-               Impl::NeighborDiscriminatorCallback<Tag>{}, indices, offset );
+    bvh.query(
+        space, Impl::makePredicates( coordinate_slice, first, last, radius ),
+        Impl::NeighborDiscriminatorCallback<Tag>{}, indices, offset,
+        ArborX::Experimental::TraversalPolicy().setBufferSize( buffer_size ) );
 
     return CrsGraph<MemorySpace, Tag>{std::move( indices ), std::move( offset ),
                                       first, bvh.size()};

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -224,6 +224,8 @@ auto makeNeighborList( Tag, Slice const &coordinate_slice,
                        typename Slice::size_type last,
                        typename Slice::value_type radius, int buffer_size = 0 )
 {
+    assert( buffer_size >= 0 );
+
     using MemorySpace = typename DeviceType::memory_space;
     using ExecutionSpace = typename DeviceType::execution_space;
     ExecutionSpace space{};
@@ -259,6 +261,8 @@ auto make2DNeighborList( Tag, Slice const &coordinate_slice,
                          typename Slice::value_type radius,
                          int buffer_size = 0 )
 {
+    assert( buffer_size >= 0 );
+
     using MemorySpace = typename DeviceType::memory_space;
     using ExecutionSpace = typename DeviceType::execution_space;
     ExecutionSpace space{};

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -132,7 +132,6 @@ struct CollisionFilter<HalfNeighborTag>
 template <typename Tag>
 struct NeighborDiscriminatorCallback
 {
-    using tag = ArborX::Details::InlineCallbackTag;
     template <typename Predicate, typename OutputFunctor>
     KOKKOS_FUNCTION void operator()( Predicate const &predicate,
                                      int primitive_index,
@@ -151,7 +150,6 @@ template <typename Counts, typename Tag>
 struct NeighborDiscriminatorCallback2D_FirstPass
 {
     Counts counts;
-    using tag = ArborX::Details::InlineCallbackTag;
     template <typename Predicate>
     KOKKOS_FUNCTION void operator()( Predicate const &predicate,
                                      int primitive_index ) const
@@ -170,7 +168,6 @@ struct NeighborDiscriminatorCallback2D_FirstPass_BufferOptimization
 {
     Counts counts;
     Neighbors neighbors;
-    using tag = ArborX::Details::InlineCallbackTag;
     template <typename Predicate>
     KOKKOS_FUNCTION void operator()( Predicate const &predicate,
                                      int primitive_index ) const
@@ -193,7 +190,6 @@ struct NeighborDiscriminatorCallback2D_SecondPass
 {
     Counts counts;
     Neighbors neighbors;
-    using tag = ArborX::Details::InlineCallbackTag;
     template <typename Predicate>
     KOKKOS_FUNCTION void operator()( Predicate const &predicate,
                                      int primitive_index ) const

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -276,8 +276,9 @@ auto make2DNeighborList( Tag, Slice const &coordinate_slice,
     Kokkos::View<int *, DeviceType> counts( "counts", n_queries );
     if ( buffer_size > 0 )
     {
-        neighbors = Kokkos::View<int **, DeviceType>( "neighbors", n_queries,
-                                                      buffer_size );
+        neighbors = Kokkos::View<int **, DeviceType>(
+            Kokkos::view_alloc( "neighbors", Kokkos::WithoutInitializing ),
+            n_queries, buffer_size );
         bvh.query(
             space, predicates,
             Impl::NeighborDiscriminatorCallback2D_FirstPass_BufferOptimization<

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz
 
 # Install ArborX
 ENV ARBORX_DIR=/opt/arborx
-RUN ARBORX_VERSION=4b8fe6ff6fd48b020ccc26a67df0d9c2792408a7 && \
+RUN ARBORX_VERSION=4834bff44c23c9510c6ed93366638dcdf85ab217 && \
     ARBORX_URL=https://github.com/arborx/ArborX/archive/${ARBORX_VERSION}.tar.gz && \
     ARBORX_ARCHIVE=arborx.tar.gz && \
     wget --quiet ${ARBORX_URL} --output-document=${ARBORX_ARCHIVE} && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -79,7 +79,7 @@ RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz
 
 # Install ArborX
 ENV ARBORX_DIR=/opt/arborx
-RUN ARBORX_VERSION=3aa11ffc57cad33ab098e444ee33c2cea54678db && \
+RUN ARBORX_VERSION=4834bff44c23c9510c6ed93366638dcdf85ab217 && \
     ARBORX_URL=https://github.com/arborx/ArborX/archive/${ARBORX_VERSION}.tar.gz && \
     ARBORX_ARCHIVE=arborx.tar.gz && \
     wget --quiet ${ARBORX_URL} --output-document=${ARBORX_ARCHIVE} && \


### PR DESCRIPTION
**Motivation:**  Pre-allocate memory and attempt to fill and count in a single pass.  Fallback to a second pass is storage was insufficient.

**Changes:**
* Added `buffer_size` trailing argument that defaults to zero (i.e. no buffer optimization) for `makeNeighborList` and `make2DNeighborList`
* Leveraged ArborX buffer optimization capability when building compressed neighbor lists
* Implemented buffer optimization for 2D neighbor lists