### PR TITLE
rearrange find_packages in Cabana_add_dependency()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ macro(Cabana_add_dependency)
   string(TOUPPER "${CABANA_DEPENDENCY_PACKAGE}" CABANA_DEPENDENCY_OPTION )
   option(
     Cabana_REQUIRE_${CABANA_DEPENDENCY_OPTION}
-    "Require Cabana to build with ${CABANA_DEPENDENCY_PACKAGE} support" ${CABANA_DEPENDENCY_PACKAGE}_FOUND)
+    "Require Cabana to build with ${CABANA_DEPENDENCY_PACKAGE} support")
   if(Cabana_REQUIRE_${CABANA_DEPENDENCY_OPTION})
     find_package( ${CABANA_DEPENDENCY_PACKAGE} REQUIRED )
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,14 @@ endif()
 # standard dependency macro
 macro(Cabana_add_dependency)
   cmake_parse_arguments(CABANA_DEPENDENCY "" "PACKAGE" "" ${ARGN})
-  find_package( ${CABANA_DEPENDENCY_PACKAGE} QUIET )
   string(TOUPPER "${CABANA_DEPENDENCY_PACKAGE}" CABANA_DEPENDENCY_OPTION )
   option(
     Cabana_REQUIRE_${CABANA_DEPENDENCY_OPTION}
     "Require Cabana to build with ${CABANA_DEPENDENCY_PACKAGE} support" ${CABANA_DEPENDENCY_PACKAGE}_FOUND)
   if(Cabana_REQUIRE_${CABANA_DEPENDENCY_OPTION})
     find_package( ${CABANA_DEPENDENCY_PACKAGE} REQUIRED )
+  else()
+    find_package( ${CABANA_DEPENDENCY_PACKAGE} QUIET )
   endif()
   set(Cabana_ENABLE_${CABANA_DEPENDENCY_OPTION} ${${CABANA_DEPENDENCY_PACKAGE}_FOUND})
 endmacro()


### PR DESCRIPTION
Currently, `Cabana_add_dependency()` calls `find_package()` two times if `Cabana_REQUIRE_$PACKAGE` is set to ON.
Unless guarded against in the target package, this causes a CMake error. (example: Heffte package for v1.0)

This change rearranges `Cabana_add_dependency()` to ensure `find_package()` is only called once.