### PR TITLE
Fix scatter view type checker for Kokkos 3.2

### DIFF
--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -233,23 +233,34 @@ namespace P2G
 //---------------------------------------------------------------------------//
 // Scatter-View type checker.
 template <class T>
-struct is_scatter_view : public std::false_type
+struct is_scatter_view_impl : public std::false_type
 {
 };
 
+#if ( KOKKOS_VERSION < 30200 )
+// FIXME: This is for Kokkos 3.1 and earlier
 template <typename DataType, typename Layout, typename ExecSpace, int Op,
           int duplication, int contribution>
-struct is_scatter_view<Kokkos::Experimental::ScatterView<
+struct is_scatter_view_impl<Kokkos::Experimental::ScatterView<
     DataType, Layout, ExecSpace, Op, duplication, contribution>>
     : public std::true_type
 {
 };
 
-template <typename DataType, typename Layout, typename ExecSpace, int Op,
-          int duplication, int contribution>
-struct is_scatter_view<const Kokkos::Experimental::ScatterView<
+#else
+// FIXME: This is for Kokkos 3.2 and later.
+template <typename DataType, typename Layout, typename ExecSpace, typename Op,
+          typename duplication, typename contribution>
+struct is_scatter_view_impl<Kokkos::Experimental::ScatterView<
     DataType, Layout, ExecSpace, Op, duplication, contribution>>
     : public std::true_type
+{
+};
+#endif
+
+template <class T>
+struct is_scatter_view
+    : public is_scatter_view_impl<typename std::remove_cv<T>::type>::type
 {
 };
 


### PR DESCRIPTION
Several template parameters in `Kokkos::ScatterView` that were integers are now more general types as of Kokkos 3.2. This was causing the build to fail as reported by several users (e.g. https://github.com/ECP-copa/ExaMPM/issues/20).

Fixes the issue but now I suspect we have a hard requirement on Kokkos 3.2 because this isn't backwards compatible because `typename` isn't interpreted as `int`. We should update our CI for 3.2 as well - this would have otherwise been caught.