### PR TITLE
GPU isolation on Jenkins CI builds

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -14,7 +14,7 @@ pipeline {
                             dir 'docker'
                             additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:10.2-devel'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }
                     }
                     steps {
@@ -43,7 +43,7 @@ pipeline {
                             filename 'Dockerfile.hipcc'
                             dir 'docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-18.04:3.5'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                             label 'rocm-docker && vega'
                         }
                     }


### PR DESCRIPTION
Some of the testing machines have multiple GPUs.  This ensures we only use the specified one which is defined on the Jenkins side as an environment variable.
