### PR TITLE
Make clang-format bind pointers to the type (left)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,3 +7,4 @@ BinPackParameters: true
 IndentWidth: 4
 SpacesInParentheses: true
 BreakConstructorInitializersBeforeComma: true
+PointerAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,3 @@ IndentWidth: 4
 SpacesInParentheses: true
 BreakConstructorInitializersBeforeComma: true
 PointerAlignment: Left
-Standard: cpp17

--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,4 @@ IndentWidth: 4
 SpacesInParentheses: true
 BreakConstructorInitializersBeforeComma: true
 PointerAlignment: Left
-Cpp11BracedListStyle: false
+Standard: cpp17

--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ IndentWidth: 4
 SpacesInParentheses: true
 BreakConstructorInitializersBeforeComma: true
 PointerAlignment: Left
+Cpp11BracedListStyle: false

--- a/cajita/src/Cajita_Array.hpp
+++ b/cajita/src/Cajita_Array.hpp
@@ -46,7 +46,7 @@ class ArrayLayout
       constructed. \param dofs_per_entity The number of degrees-of-freedom per
       grid entity.
     */
-    ArrayLayout( const std::shared_ptr<LocalGrid<MeshType>> &local_grid,
+    ArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
                  const int dofs_per_entity )
         : _local_grid( local_grid )
         , _dofs_per_entity( dofs_per_entity )
@@ -124,7 +124,7 @@ struct is_array_layout<const ArrayLayout<EntityType, MeshType>>
 */
 template <class EntityType, class MeshType>
 std::shared_ptr<ArrayLayout<EntityType, MeshType>>
-createArrayLayout( const std::shared_ptr<LocalGrid<MeshType>> &local_grid,
+createArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
                    const int dofs_per_entity, EntityType )
 {
     return std::make_shared<ArrayLayout<EntityType, MeshType>>(
@@ -141,7 +141,7 @@ createArrayLayout( const std::shared_ptr<LocalGrid<MeshType>> &local_grid,
 */
 template <class EntityType, class MeshType>
 std::shared_ptr<ArrayLayout<EntityType, MeshType>>
-createArrayLayout( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+createArrayLayout( const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
                    const int halo_cell_width, const int dofs_per_entity,
                    EntityType )
 {
@@ -169,7 +169,7 @@ class Array
     using array_layout = ArrayLayout<entity_type, mesh_type>;
 
     // View type.
-    using view_type = Kokkos::View<value_type ****, Params...>;
+    using view_type = Kokkos::View<value_type****, Params...>;
 
     // Device type.
     using device_type = typename view_type::device_type;
@@ -186,8 +186,8 @@ class Array
       \param label A label for the array.
       \param layout The array layout over which to construct the view.
     */
-    Array( const std::string &label,
-           const std::shared_ptr<array_layout> &layout )
+    Array( const std::string& label,
+           const std::shared_ptr<array_layout>& layout )
         : _layout( layout )
         , _data( createView<value_type, Params...>(
               label, layout->indexSpace( Ghost(), Local() ) ) )
@@ -200,7 +200,7 @@ class Array
       \param layout The layout of the array.
       \param view The array data.
     */
-    Array( const std::shared_ptr<array_layout> &layout, const view_type &view )
+    Array( const std::shared_ptr<array_layout>& layout, const view_type& view )
         : _layout( layout )
         , _data( view )
     {
@@ -269,8 +269,8 @@ struct is_array<const Array<Scalar, EntityType, MeshType, Params...>>
  */
 template <class Scalar, class... Params, class EntityType, class MeshType>
 std::shared_ptr<Array<Scalar, EntityType, MeshType, Params...>>
-createArray( const std::string &label,
-             const std::shared_ptr<ArrayLayout<EntityType, MeshType>> &layout )
+createArray( const std::string& label,
+             const std::shared_ptr<ArrayLayout<EntityType, MeshType>>& layout )
 {
     return std::make_shared<Array<Scalar, EntityType, MeshType, Params...>>(
         label, layout );
@@ -293,7 +293,7 @@ std::shared_ptr<Array<
     typename Array<Scalar, EntityType, MeshType, Params...>::device_type,
     typename Array<Scalar, EntityType, MeshType,
                    Params...>::subview_memory_traits>>
-createSubarray( const Array<Scalar, EntityType, MeshType, Params...> &array,
+createSubarray( const Array<Scalar, EntityType, MeshType, Params...>& array,
                 const int dof_min, const int dof_max )
 {
     if ( dof_min < 0 || dof_max > array.layout()->dofsPerEntity() )
@@ -301,8 +301,8 @@ createSubarray( const Array<Scalar, EntityType, MeshType, Params...> &array,
 
     auto space = array.layout()->indexSpace( Ghost(), Local() );
     IndexSpace<4> sub_space(
-        { space.min( 0 ), space.min( 1 ), space.min( 2 ), dof_min },
-        { space.max( 0 ), space.max( 1 ), space.max( 2 ), dof_max } );
+        {space.min( 0 ), space.min( 1 ), space.min( 2 ), dof_min},
+        {space.max( 0 ), space.max( 1 ), space.max( 2 ), dof_max} );
     auto sub_view = createSubview( array.view(), sub_space );
     auto sub_layout = createArrayLayout( array.layout()->localGrid(),
                                          dof_max - dof_min, EntityType() );
@@ -327,7 +327,7 @@ namespace ArrayOp
 */
 template <class Scalar, class... Params, class EntityType, class MeshType>
 std::shared_ptr<Array<Scalar, EntityType, MeshType, Params...>>
-clone( const Array<Scalar, EntityType, MeshType, Params...> &array )
+clone( const Array<Scalar, EntityType, MeshType, Params...>& array )
 {
     return createArray<Scalar, Params...>( array.label(), array.layout() );
 }
@@ -341,7 +341,7 @@ clone( const Array<Scalar, EntityType, MeshType, Params...> &array )
   operation.
 */
 template <class Array_t, class DecompositionTag>
-void assign( Array_t &array, const typename Array_t::value_type alpha,
+void assign( Array_t& array, const typename Array_t::value_type alpha,
              DecompositionTag tag )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
@@ -359,7 +359,7 @@ void assign( Array_t &array, const typename Array_t::value_type alpha,
   operation.
 */
 template <class Array_t, class DecompositionTag>
-void scale( Array_t &array, const typename Array_t::value_type alpha,
+void scale( Array_t& array, const typename Array_t::value_type alpha,
             DecompositionTag tag )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
@@ -383,8 +383,8 @@ void scale( Array_t &array, const typename Array_t::value_type alpha,
   operation.
 */
 template <class Array_t, class DecompositionTag>
-void scale( Array_t &array,
-            const std::vector<typename Array_t::value_type> &alpha,
+void scale( Array_t& array,
+            const std::vector<typename Array_t::value_type>& alpha,
             DecompositionTag tag )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
@@ -392,7 +392,7 @@ void scale( Array_t &array,
          static_cast<unsigned>( array.layout()->dofsPerEntity() ) )
         throw std::runtime_error( "Incorrect vector size" );
 
-    Kokkos::View<const typename Array_t::value_type *, Kokkos::HostSpace,
+    Kokkos::View<const typename Array_t::value_type*, Kokkos::HostSpace,
                  Kokkos::MemoryUnmanaged>
         alpha_view_host( alpha.data(), alpha.size() );
     auto alpha_view = Kokkos::create_mirror_view_and_copy(
@@ -417,7 +417,7 @@ void scale( Array_t &array,
   operation.
 */
 template <class Array_t, class DecompositionTag>
-void copy( Array_t &a, const Array_t &b, DecompositionTag tag )
+void copy( Array_t& a, const Array_t& b, DecompositionTag tag )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
     auto a_space = a.layout()->indexSpace( tag, Local() );
@@ -436,7 +436,7 @@ void copy( Array_t &a, const Array_t &b, DecompositionTag tag )
   \param tag The tag for the decomposition over which to perform the copy.
 */
 template <class Array_t, class DecompositionTag>
-std::shared_ptr<Array_t> cloneCopy( const Array_t &array, DecompositionTag tag )
+std::shared_ptr<Array_t> cloneCopy( const Array_t& array, DecompositionTag tag )
 {
     auto cln = clone( array );
     copy( *cln, array, tag );
@@ -454,8 +454,8 @@ std::shared_ptr<Array_t> cloneCopy( const Array_t &array, DecompositionTag tag )
   operation.
  */
 template <class Array_t, class DecompositionTag>
-void update( Array_t &a, const typename Array_t::value_type alpha,
-             const Array_t &b, const typename Array_t::value_type beta,
+void update( Array_t& a, const typename Array_t::value_type alpha,
+             const Array_t& b, const typename Array_t::value_type beta,
              DecompositionTag tag )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
@@ -482,7 +482,7 @@ struct DotFunctor
     ViewType _a;
     ViewType _b;
 
-    DotFunctor( const ViewType &a, const ViewType &b )
+    DotFunctor( const ViewType& a, const ViewType& b )
         : value_count( a.extent( 3 ) )
         , _a( a )
         , _b( b )
@@ -519,15 +519,15 @@ struct DotFunctor
   per entity.
 */
 template <class Array_t>
-void dot( const Array_t &a, const Array_t &b,
-          std::vector<typename Array_t::value_type> &products )
+void dot( const Array_t& a, const Array_t& b,
+          std::vector<typename Array_t::value_type>& products )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
     if ( products.size() !=
          static_cast<unsigned>( a.layout()->dofsPerEntity() ) )
         throw std::runtime_error( "Incorrect vector size" );
 
-    for ( auto &p : products )
+    for ( auto& p : products )
         p = 0.0;
 
     DotFunctor<typename Array_t::view_type> functor( a.view(), b.view() );
@@ -552,7 +552,7 @@ struct NormInfFunctor
     size_type value_count;
     ViewType _view;
 
-    NormInfFunctor( const ViewType &view )
+    NormInfFunctor( const ViewType& view )
         : value_count( view.extent( 3 ) )
         , _view( view )
     {
@@ -589,15 +589,15 @@ struct NormInfFunctor
   should be pre-sized to the number of degrees-of-freedom per entity.
 */
 template <class Array_t>
-void normInf( const Array_t &array,
-              std::vector<typename Array_t::value_type> &norms )
+void normInf( const Array_t& array,
+              std::vector<typename Array_t::value_type>& norms )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
     if ( norms.size() !=
          static_cast<unsigned>( array.layout()->dofsPerEntity() ) )
         throw std::runtime_error( "Incorrect vector size" );
 
-    for ( auto &n : norms )
+    for ( auto& n : norms )
         n = 0.0;
 
     NormInfFunctor<typename Array_t::view_type> functor( array.view() );
@@ -622,7 +622,7 @@ struct Norm1Functor
     size_type value_count;
     ViewType _view;
 
-    Norm1Functor( const ViewType &view )
+    Norm1Functor( const ViewType& view )
         : value_count( view.extent( 3 ) )
         , _view( view )
     {
@@ -656,15 +656,15 @@ struct Norm1Functor
   should be pre-sized to the number of degrees-of-freedom per entity.
 */
 template <class Array_t>
-void norm1( const Array_t &array,
-            std::vector<typename Array_t::value_type> &norms )
+void norm1( const Array_t& array,
+            std::vector<typename Array_t::value_type>& norms )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
     if ( norms.size() !=
          static_cast<unsigned>( array.layout()->dofsPerEntity() ) )
         throw std::runtime_error( "Incorrect vector size" );
 
-    for ( auto &n : norms )
+    for ( auto& n : norms )
         n = 0.0;
 
     Norm1Functor<typename Array_t::view_type> functor( array.view() );
@@ -689,7 +689,7 @@ struct Norm2Functor
     size_type value_count;
     ViewType _view;
 
-    Norm2Functor( const ViewType &view )
+    Norm2Functor( const ViewType& view )
         : value_count( view.extent( 3 ) )
         , _view( view )
     {
@@ -723,15 +723,15 @@ struct Norm2Functor
   vector should be pre-sized to the number of degrees-of-freedom per entity.
 */
 template <class Array_t>
-void norm2( const Array_t &array,
-            std::vector<typename Array_t::value_type> &norms )
+void norm2( const Array_t& array,
+            std::vector<typename Array_t::value_type>& norms )
 {
     static_assert( is_array<Array_t>::value, "Cajita::Array required" );
     if ( norms.size() !=
          static_cast<unsigned>( array.layout()->dofsPerEntity() ) )
         throw std::runtime_error( "Incorrect vector size" );
 
-    for ( auto &n : norms )
+    for ( auto& n : norms )
         n = 0.0;
 
     Norm2Functor<typename Array_t::view_type> functor( array.view() );
@@ -745,7 +745,7 @@ void norm2( const Array_t &array,
                    MpiTraits<typename Array_t::value_type>::type(), MPI_SUM,
                    array.layout()->localGrid()->globalGrid().comm() );
 
-    for ( auto &n : norms )
+    for ( auto& n : norms )
         n = std::sqrt( n );
 }
 

--- a/cajita/src/Cajita_Array.hpp
+++ b/cajita/src/Cajita_Array.hpp
@@ -301,8 +301,8 @@ createSubarray( const Array<Scalar, EntityType, MeshType, Params...>& array,
 
     auto space = array.layout()->indexSpace( Ghost(), Local() );
     IndexSpace<4> sub_space(
-        {space.min( 0 ), space.min( 1 ), space.min( 2 ), dof_min},
-        {space.max( 0 ), space.max( 1 ), space.max( 2 ), dof_max} );
+        { space.min( 0 ), space.min( 1 ), space.min( 2 ), dof_min },
+        { space.max( 0 ), space.max( 1 ), space.max( 2 ), dof_max } );
     auto sub_view = createSubview( array.view(), sub_space );
     auto sub_layout = createArrayLayout( array.layout()->localGrid(),
                                          dof_max - dof_min, EntityType() );

--- a/cajita/src/Cajita_BovWriter.hpp
+++ b/cajita/src/Cajita_BovWriter.hpp
@@ -84,25 +84,25 @@ struct BovCentering<Node>
 //---------------------------------------------------------------------------//
 // Create the MPI subarray for the given array.
 template <class Array_t>
-MPI_Datatype createSubarray( const Array_t &array,
-                             const std::array<long, 4> &owned_extents,
-                             const std::array<long, 4> &global_extents )
+MPI_Datatype createSubarray( const Array_t& array,
+                             const std::array<long, 4>& owned_extents,
+                             const std::array<long, 4>& global_extents )
 {
     using value_type = typename Array_t::value_type;
-    const auto &global_grid = array.layout()->localGrid()->globalGrid();
+    const auto& global_grid = array.layout()->localGrid()->globalGrid();
 
     int local_start[4] = {
         static_cast<int>( global_grid.globalOffset( Dim::K ) ),
         static_cast<int>( global_grid.globalOffset( Dim::J ) ),
-        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0 };
-    int local_size[4] = { static_cast<int>( owned_extents[Dim::K] ),
-                          static_cast<int>( owned_extents[Dim::J] ),
-                          static_cast<int>( owned_extents[Dim::I] ),
-                          static_cast<int>( owned_extents[3] ) };
-    int global_size[4] = { static_cast<int>( global_extents[Dim::K] ),
-                           static_cast<int>( global_extents[Dim::J] ),
-                           static_cast<int>( global_extents[Dim::I] ),
-                           static_cast<int>( global_extents[3] ) };
+        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0};
+    int local_size[4] = {static_cast<int>( owned_extents[Dim::K] ),
+                         static_cast<int>( owned_extents[Dim::J] ),
+                         static_cast<int>( owned_extents[Dim::I] ),
+                         static_cast<int>( owned_extents[3] )};
+    int global_size[4] = {static_cast<int>( global_extents[Dim::K] ),
+                          static_cast<int>( global_extents[Dim::J] ),
+                          static_cast<int>( global_extents[Dim::I] ),
+                          static_cast<int>( global_extents[3] )};
 
     MPI_Datatype subarray;
     MPI_Type_create_subarray( 4, global_size, local_size, local_start,
@@ -125,7 +125,7 @@ MPI_Datatype createSubarray( const Array_t &array,
 */
 template <class Array_t>
 void writeTimeStep( const int time_step_index, const double time,
-                    const Array_t &array )
+                    const Array_t& array )
 {
     static_assert( isUniformMesh<typename Array_t::mesh_type>::value,
                    "ViSIT BOV writer can only be used with uniform mesh" );
@@ -137,14 +137,14 @@ void writeTimeStep( const int time_step_index, const double time,
     using execution_space = typename device_type::execution_space;
 
     // Get the global grid.
-    const auto &global_grid = array.layout()->localGrid()->globalGrid();
+    const auto& global_grid = array.layout()->localGrid()->globalGrid();
 
     // Get the global mesh.
-    const auto &global_mesh = global_grid.globalMesh();
+    const auto& global_mesh = global_grid.globalMesh();
 
     // If this is a node field, determine periodicity so we can add the last
     // node back to the visualization if needed.
-    std::array<long, 4> global_extents = { -1, -1, -1, -1 };
+    std::array<long, 4> global_extents = {-1, -1, -1, -1};
     for ( int d = 0; d < 3; ++d )
     {
         if ( std::is_same<entity_type, Cell>::value )
@@ -154,7 +154,7 @@ void writeTimeStep( const int time_step_index, const double time,
     }
     global_extents[3] = array.layout()->dofsPerEntity();
     auto owned_index_space = array.layout()->indexSpace( Own(), Local() );
-    std::array<long, 4> owned_extents = { -1, -1, -1, -1 };
+    std::array<long, 4> owned_extents = {-1, -1, -1, -1};
     for ( int d = 0; d < 3; ++d )
     {
         if ( std::is_same<entity_type, Cell>::value )
@@ -176,15 +176,15 @@ void writeTimeStep( const int time_step_index, const double time,
     // Create a contiguous array of the owned array values. Note that we
     // reorder to KJI grid ordering to conform to the BOV format.
     IndexSpace<4> local_space(
-        { owned_index_space.min( Dim::I ), owned_index_space.min( Dim::J ),
-          owned_index_space.min( Dim::K ), 0 },
-        { owned_index_space.min( Dim::I ) + owned_extents[Dim::I],
-          owned_index_space.min( Dim::J ) + owned_extents[Dim::J],
-          owned_index_space.min( Dim::K ) + owned_extents[Dim::K],
-          owned_extents[3] } );
+        {owned_index_space.min( Dim::I ), owned_index_space.min( Dim::J ),
+         owned_index_space.min( Dim::K ), 0},
+        {owned_index_space.min( Dim::I ) + owned_extents[Dim::I],
+         owned_index_space.min( Dim::J ) + owned_extents[Dim::J],
+         owned_index_space.min( Dim::K ) + owned_extents[Dim::K],
+         owned_extents[3]} );
     auto owned_subview = createSubview( array.view(), local_space );
-    IndexSpace<4> reorder_space( { owned_extents[Dim::K], owned_extents[Dim::J],
-                                   owned_extents[Dim::I], owned_extents[3] } );
+    IndexSpace<4> reorder_space( {owned_extents[Dim::K], owned_extents[Dim::J],
+                                  owned_extents[Dim::I], owned_extents[3]} );
     auto owned_view = createView<value_type, Kokkos::LayoutRight, device_type>(
         array.label(), reorder_space );
     Kokkos::parallel_for(

--- a/cajita/src/Cajita_BovWriter.hpp
+++ b/cajita/src/Cajita_BovWriter.hpp
@@ -94,8 +94,7 @@ MPI_Datatype createSubarray( const Array_t& array,
     int local_start[4] = {
         static_cast<int>( global_grid.globalOffset( Dim::K ) ),
         static_cast<int>( global_grid.globalOffset( Dim::J ) ),
-        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0
-    };
+        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0 };
     int local_size[4] = { static_cast<int>( owned_extents[Dim::K] ),
                           static_cast<int>( owned_extents[Dim::J] ),
                           static_cast<int>( owned_extents[Dim::I] ),

--- a/cajita/src/Cajita_BovWriter.hpp
+++ b/cajita/src/Cajita_BovWriter.hpp
@@ -94,15 +94,16 @@ MPI_Datatype createSubarray( const Array_t& array,
     int local_start[4] = {
         static_cast<int>( global_grid.globalOffset( Dim::K ) ),
         static_cast<int>( global_grid.globalOffset( Dim::J ) ),
-        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0};
-    int local_size[4] = {static_cast<int>( owned_extents[Dim::K] ),
-                         static_cast<int>( owned_extents[Dim::J] ),
-                         static_cast<int>( owned_extents[Dim::I] ),
-                         static_cast<int>( owned_extents[3] )};
-    int global_size[4] = {static_cast<int>( global_extents[Dim::K] ),
-                          static_cast<int>( global_extents[Dim::J] ),
-                          static_cast<int>( global_extents[Dim::I] ),
-                          static_cast<int>( global_extents[3] )};
+        static_cast<int>( global_grid.globalOffset( Dim::I ) ), 0
+    };
+    int local_size[4] = { static_cast<int>( owned_extents[Dim::K] ),
+                          static_cast<int>( owned_extents[Dim::J] ),
+                          static_cast<int>( owned_extents[Dim::I] ),
+                          static_cast<int>( owned_extents[3] ) };
+    int global_size[4] = { static_cast<int>( global_extents[Dim::K] ),
+                           static_cast<int>( global_extents[Dim::J] ),
+                           static_cast<int>( global_extents[Dim::I] ),
+                           static_cast<int>( global_extents[3] ) };
 
     MPI_Datatype subarray;
     MPI_Type_create_subarray( 4, global_size, local_size, local_start,
@@ -144,7 +145,7 @@ void writeTimeStep( const int time_step_index, const double time,
 
     // If this is a node field, determine periodicity so we can add the last
     // node back to the visualization if needed.
-    std::array<long, 4> global_extents = {-1, -1, -1, -1};
+    std::array<long, 4> global_extents = { -1, -1, -1, -1 };
     for ( int d = 0; d < 3; ++d )
     {
         if ( std::is_same<entity_type, Cell>::value )
@@ -154,7 +155,7 @@ void writeTimeStep( const int time_step_index, const double time,
     }
     global_extents[3] = array.layout()->dofsPerEntity();
     auto owned_index_space = array.layout()->indexSpace( Own(), Local() );
-    std::array<long, 4> owned_extents = {-1, -1, -1, -1};
+    std::array<long, 4> owned_extents = { -1, -1, -1, -1 };
     for ( int d = 0; d < 3; ++d )
     {
         if ( std::is_same<entity_type, Cell>::value )
@@ -176,15 +177,15 @@ void writeTimeStep( const int time_step_index, const double time,
     // Create a contiguous array of the owned array values. Note that we
     // reorder to KJI grid ordering to conform to the BOV format.
     IndexSpace<4> local_space(
-        {owned_index_space.min( Dim::I ), owned_index_space.min( Dim::J ),
-         owned_index_space.min( Dim::K ), 0},
-        {owned_index_space.min( Dim::I ) + owned_extents[Dim::I],
-         owned_index_space.min( Dim::J ) + owned_extents[Dim::J],
-         owned_index_space.min( Dim::K ) + owned_extents[Dim::K],
-         owned_extents[3]} );
+        { owned_index_space.min( Dim::I ), owned_index_space.min( Dim::J ),
+          owned_index_space.min( Dim::K ), 0 },
+        { owned_index_space.min( Dim::I ) + owned_extents[Dim::I],
+          owned_index_space.min( Dim::J ) + owned_extents[Dim::J],
+          owned_index_space.min( Dim::K ) + owned_extents[Dim::K],
+          owned_extents[3] } );
     auto owned_subview = createSubview( array.view(), local_space );
-    IndexSpace<4> reorder_space( {owned_extents[Dim::K], owned_extents[Dim::J],
-                                  owned_extents[Dim::I], owned_extents[3]} );
+    IndexSpace<4> reorder_space( { owned_extents[Dim::K], owned_extents[Dim::J],
+                                   owned_extents[Dim::I], owned_extents[3] } );
     auto owned_view = createView<value_type, Kokkos::LayoutRight, device_type>(
         array.label(), reorder_space );
     Kokkos::parallel_for(

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -191,7 +191,8 @@ class FastFourierTransform
         std::array<int, 3> global_num_entity = {
             global_grid.globalNumEntity( EntityType(), Dim::K ),
             global_grid.globalNumEntity( EntityType(), Dim::J ),
-            global_grid.globalNumEntity( EntityType(), Dim::I )};
+            global_grid.globalNumEntity( EntityType(), Dim::I )
+        };
 
         // Get the local dimensions of the problem.
         auto entity_space =
@@ -199,19 +200,22 @@ class FastFourierTransform
         std::array<int, 3> local_num_entity = {
             (int)entity_space.extent( Dim::K ),
             (int)entity_space.extent( Dim::J ),
-            (int)entity_space.extent( Dim::I )};
+            (int)entity_space.extent( Dim::I )
+        };
 
         // Get the low corner of the global index space on this rank.
         std::array<int, 3> global_low = {
             (int)global_grid.globalOffset( Dim::K ),
             (int)global_grid.globalOffset( Dim::J ),
-            (int)global_grid.globalOffset( Dim::I )};
+            (int)global_grid.globalOffset( Dim::I )
+        };
 
         // Get the high corner of the global index space on this rank.
         std::array<int, 3> global_high = {
             global_low[Dim::I] + local_num_entity[Dim::I] - 1,
             global_low[Dim::J] + local_num_entity[Dim::J] - 1,
-            global_low[Dim::K] + local_num_entity[Dim::K] - 1};
+            global_low[Dim::K] + local_num_entity[Dim::K] - 1
+        };
 
         // Setup the fft.
         int permute = 0;

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -77,7 +77,7 @@ class FastFourierTransformParams
       If this function is not used to set the type then 2 is used as the
       default.
     */
-    FastFourierTransformParams &setCollectiveType( const int type )
+    FastFourierTransformParams& setCollectiveType( const int type )
     {
         collective = type;
         return *this;
@@ -93,7 +93,7 @@ class FastFourierTransformParams
       If this function is not used to set the type then 0 is used as the
       default.
     */
-    FastFourierTransformParams &setExchangeType( const int type )
+    FastFourierTransformParams& setExchangeType( const int type )
     {
         exchange = type;
         return *this;
@@ -110,7 +110,7 @@ class FastFourierTransformParams
       If this function is not used to set the type then 2 is used as the
       default.
     */
-    FastFourierTransformParams &setPackType( const int type )
+    FastFourierTransformParams& setPackType( const int type )
     {
         packflag = type;
         return *this;
@@ -126,7 +126,7 @@ class FastFourierTransformParams
       If this function is not used to set the type then 1 is used as the
       default.
     */
-    FastFourierTransformParams &setScalingType( const int type )
+    FastFourierTransformParams& setScalingType( const int type )
     {
         scaled = type;
         return *this;
@@ -162,8 +162,8 @@ class FastFourierTransform
       transform.
       \param params Parameters for the 3D FFT.
     */
-    FastFourierTransform( const ArrayLayout<EntityType, MeshType> &layout,
-                          const FastFourierTransformParams &params )
+    FastFourierTransform( const ArrayLayout<EntityType, MeshType>& layout,
+                          const FastFourierTransformParams& params )
         : _fft( layout.localGrid()->globalGrid().comm() )
     {
         if ( 1 != layout.dofsPerEntity() )
@@ -184,14 +184,14 @@ class FastFourierTransform
         _fft.scaled = params.scaled;
 
         // Get the global grid.
-        const auto &global_grid = layout.localGrid()->globalGrid();
+        const auto& global_grid = layout.localGrid()->globalGrid();
 
         // Get the global dimensions of the problem. K indices move the
         // fastest because we fix the work array to be layout right.
         std::array<int, 3> global_num_entity = {
             global_grid.globalNumEntity( EntityType(), Dim::K ),
             global_grid.globalNumEntity( EntityType(), Dim::J ),
-            global_grid.globalNumEntity( EntityType(), Dim::I ) };
+            global_grid.globalNumEntity( EntityType(), Dim::I )};
 
         // Get the local dimensions of the problem.
         auto entity_space =
@@ -199,19 +199,19 @@ class FastFourierTransform
         std::array<int, 3> local_num_entity = {
             (int)entity_space.extent( Dim::K ),
             (int)entity_space.extent( Dim::J ),
-            (int)entity_space.extent( Dim::I ) };
+            (int)entity_space.extent( Dim::I )};
 
         // Get the low corner of the global index space on this rank.
         std::array<int, 3> global_low = {
             (int)global_grid.globalOffset( Dim::K ),
             (int)global_grid.globalOffset( Dim::J ),
-            (int)global_grid.globalOffset( Dim::I ) };
+            (int)global_grid.globalOffset( Dim::I )};
 
         // Get the high corner of the global index space on this rank.
         std::array<int, 3> global_high = {
             global_low[Dim::I] + local_num_entity[Dim::I] - 1,
             global_low[Dim::J] + local_num_entity[Dim::J] - 1,
-            global_low[Dim::K] + local_num_entity[Dim::K] - 1 };
+            global_low[Dim::K] + local_num_entity[Dim::K] - 1};
 
         // Setup the fft.
         int permute = 0;
@@ -226,7 +226,7 @@ class FastFourierTransform
                                     "than local grid size" );
 
         // Allocate the work array.
-        _fft_work = Kokkos::View<Scalar *, DeviceType>(
+        _fft_work = Kokkos::View<Scalar*, DeviceType>(
             Kokkos::ViewAllocateWithoutInitializing( "fft_work" ),
             2 * fftsize );
     }
@@ -236,7 +236,7 @@ class FastFourierTransform
       \param in The array on which to perform the forward transform.
     */
     template <class Array_t>
-    void forward( const Array_t &x )
+    void forward( const Array_t& x )
     {
         compute( x, 1 );
     }
@@ -246,14 +246,14 @@ class FastFourierTransform
      \param out The array on which to perform the reverse transform.
     */
     template <class Array_t>
-    void reverse( const Array_t &x )
+    void reverse( const Array_t& x )
     {
         compute( x, -1 );
     }
 
   public:
     template <class Array_t>
-    void compute( const Array_t &x, const int flag )
+    void compute( const Array_t& x, const int flag )
     {
         static_assert( is_array<Array_t>::value, "Must use an array" );
         static_assert(
@@ -325,7 +325,7 @@ class FastFourierTransform
 
   private:
     HEFFTE::FFT3d<Scalar> _fft;
-    Kokkos::View<Scalar *, DeviceType> _fft_work;
+    Kokkos::View<Scalar*, DeviceType> _fft_work;
 };
 
 //---------------------------------------------------------------------------//
@@ -333,8 +333,8 @@ class FastFourierTransform
 //---------------------------------------------------------------------------//
 template <class Scalar, class DeviceType, class EntityType, class MeshType>
 std::shared_ptr<FastFourierTransform<Scalar, EntityType, MeshType, DeviceType>>
-createFastFourierTransform( const ArrayLayout<EntityType, MeshType> &layout,
-                            const FastFourierTransformParams &params )
+createFastFourierTransform( const ArrayLayout<EntityType, MeshType>& layout,
+                            const FastFourierTransformParams& params )
 {
     return std::make_shared<
         FastFourierTransform<Scalar, EntityType, MeshType, DeviceType>>(

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -191,8 +191,7 @@ class FastFourierTransform
         std::array<int, 3> global_num_entity = {
             global_grid.globalNumEntity( EntityType(), Dim::K ),
             global_grid.globalNumEntity( EntityType(), Dim::J ),
-            global_grid.globalNumEntity( EntityType(), Dim::I )
-        };
+            global_grid.globalNumEntity( EntityType(), Dim::I ) };
 
         // Get the local dimensions of the problem.
         auto entity_space =
@@ -200,22 +199,19 @@ class FastFourierTransform
         std::array<int, 3> local_num_entity = {
             (int)entity_space.extent( Dim::K ),
             (int)entity_space.extent( Dim::J ),
-            (int)entity_space.extent( Dim::I )
-        };
+            (int)entity_space.extent( Dim::I ) };
 
         // Get the low corner of the global index space on this rank.
         std::array<int, 3> global_low = {
             (int)global_grid.globalOffset( Dim::K ),
             (int)global_grid.globalOffset( Dim::J ),
-            (int)global_grid.globalOffset( Dim::I )
-        };
+            (int)global_grid.globalOffset( Dim::I ) };
 
         // Get the high corner of the global index space on this rank.
         std::array<int, 3> global_high = {
             global_low[Dim::I] + local_num_entity[Dim::I] - 1,
             global_low[Dim::J] + local_num_entity[Dim::J] - 1,
-            global_low[Dim::K] + local_num_entity[Dim::K] - 1
-        };
+            global_low[Dim::K] + local_num_entity[Dim::K] - 1 };
 
         // Setup the fft.
         int permute = 0;

--- a/cajita/src/Cajita_GlobalGrid.cpp
+++ b/cajita/src/Cajita_GlobalGrid.cpp
@@ -30,8 +30,7 @@ GlobalGrid<MeshType>::GlobalGrid(
     std::array<int, 3> global_num_cell = {
         _global_mesh->globalNumCell( Dim::I ),
         _global_mesh->globalNumCell( Dim::J ),
-        _global_mesh->globalNumCell( Dim::K )
-    };
+        _global_mesh->globalNumCell( Dim::K ) };
     _ranks_per_dim = partitioner.ranksPerDimension( comm, global_num_cell );
 
     // Extract the periodicity of the boundary as integers.

--- a/cajita/src/Cajita_GlobalGrid.cpp
+++ b/cajita/src/Cajita_GlobalGrid.cpp
@@ -21,8 +21,8 @@ namespace Cajita
 // Constructor.
 template <class MeshType>
 GlobalGrid<MeshType>::GlobalGrid(
-    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>> &global_mesh,
-    const std::array<bool, 3> &periodic, const Partitioner &partitioner )
+    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+    const std::array<bool, 3>& periodic, const Partitioner& partitioner )
     : _global_mesh( global_mesh )
     , _periodic( periodic )
 {
@@ -30,12 +30,12 @@ GlobalGrid<MeshType>::GlobalGrid(
     std::array<int, 3> global_num_cell = {
         _global_mesh->globalNumCell( Dim::I ),
         _global_mesh->globalNumCell( Dim::J ),
-        _global_mesh->globalNumCell( Dim::K ) };
+        _global_mesh->globalNumCell( Dim::K )};
     _ranks_per_dim = partitioner.ranksPerDimension( comm, global_num_cell );
 
     // Extract the periodicity of the boundary as integers.
-    std::array<int, 3> periodic_dims = { _periodic[Dim::I], _periodic[Dim::J],
-                                         _periodic[Dim::K] };
+    std::array<int, 3> periodic_dims = {_periodic[Dim::I], _periodic[Dim::J],
+                                        _periodic[Dim::K]};
 
     // Generate a communicator with a Cartesian topology.
     int reorder_cart_ranks = 1;
@@ -58,7 +58,7 @@ GlobalGrid<MeshType>::GlobalGrid(
 
     // Compute the global cell offset and the local low corner on this rank by
     // computing the starting global cell index via exclusive scan.
-    _global_cell_offset = { 0, 0, 0 };
+    _global_cell_offset = {0, 0, 0};
     for ( int d = 0; d < 3; ++d )
     {
         for ( int r = 0; r < _cart_rank[d]; ++r )
@@ -97,7 +97,7 @@ MPI_Comm GlobalGrid<MeshType>::comm() const
 //---------------------------------------------------------------------------//
 // Get the global mesh data.
 template <class MeshType>
-const GlobalMesh<MeshType> &GlobalGrid<MeshType>::globalMesh() const
+const GlobalMesh<MeshType>& GlobalGrid<MeshType>::globalMesh() const
 {
     return *_global_mesh;
 }
@@ -155,7 +155,7 @@ int GlobalGrid<MeshType>::blockRank( const int i, const int j,
                                      const int k ) const
 {
     // Get the indices.
-    std::array<int, 3> cr = { i, j, k };
+    std::array<int, 3> cr = {i, j, k};
 
     // Check for invalid indices. An index is invalid if it is out of bounds
     // and the dimension is not periodic. An out of bound index in a periodic

--- a/cajita/src/Cajita_GlobalGrid.cpp
+++ b/cajita/src/Cajita_GlobalGrid.cpp
@@ -30,12 +30,13 @@ GlobalGrid<MeshType>::GlobalGrid(
     std::array<int, 3> global_num_cell = {
         _global_mesh->globalNumCell( Dim::I ),
         _global_mesh->globalNumCell( Dim::J ),
-        _global_mesh->globalNumCell( Dim::K )};
+        _global_mesh->globalNumCell( Dim::K )
+    };
     _ranks_per_dim = partitioner.ranksPerDimension( comm, global_num_cell );
 
     // Extract the periodicity of the boundary as integers.
-    std::array<int, 3> periodic_dims = {_periodic[Dim::I], _periodic[Dim::J],
-                                        _periodic[Dim::K]};
+    std::array<int, 3> periodic_dims = { _periodic[Dim::I], _periodic[Dim::J],
+                                         _periodic[Dim::K] };
 
     // Generate a communicator with a Cartesian topology.
     int reorder_cart_ranks = 1;
@@ -58,7 +59,7 @@ GlobalGrid<MeshType>::GlobalGrid(
 
     // Compute the global cell offset and the local low corner on this rank by
     // computing the starting global cell index via exclusive scan.
-    _global_cell_offset = {0, 0, 0};
+    _global_cell_offset = { 0, 0, 0 };
     for ( int d = 0; d < 3; ++d )
     {
         for ( int r = 0; r < _cart_rank[d]; ++r )
@@ -155,7 +156,7 @@ int GlobalGrid<MeshType>::blockRank( const int i, const int j,
                                      const int k ) const
 {
     // Get the indices.
-    std::array<int, 3> cr = {i, j, k};
+    std::array<int, 3> cr = { i, j, k };
 
     // Check for invalid indices. An index is invalid if it is out of bounds
     // and the dimension is not periodic. An out of bound index in a periodic

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -41,9 +41,9 @@ class GlobalGrid
      \param partitioner The grid partitioner.
     */
     GlobalGrid( MPI_Comm comm,
-                const std::shared_ptr<GlobalMesh<MeshType>> &global_mesh,
-                const std::array<bool, 3> &periodic,
-                const Partitioner &partitioner );
+                const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+                const std::array<bool, 3>& periodic,
+                const Partitioner& partitioner );
 
     // Destructor.
     ~GlobalGrid();
@@ -53,7 +53,7 @@ class GlobalGrid
     MPI_Comm comm() const;
 
     // Get the global mesh data.
-    const GlobalMesh<MeshType> &globalMesh() const;
+    const GlobalMesh<MeshType>& globalMesh() const;
 
     // Get whether a given dimension is periodic.
     bool isPeriodic( const int dim ) const;
@@ -114,8 +114,8 @@ class GlobalGrid
 */
 template <class MeshType>
 std::shared_ptr<GlobalGrid<MeshType>> createGlobalGrid(
-    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>> &global_mesh,
-    const std::array<bool, 3> &periodic, const Partitioner &partitioner )
+    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+    const std::array<bool, 3>& periodic, const Partitioner& partitioner )
 {
     return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
                                                    partitioner );

--- a/cajita/src/Cajita_GlobalMesh.hpp
+++ b/cajita/src/Cajita_GlobalMesh.hpp
@@ -49,7 +49,7 @@ class GlobalMesh
                 const scalar_type cell_size )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
-        , _cell_size( {cell_size, cell_size, cell_size} )
+        , _cell_size( { cell_size, cell_size, cell_size } )
     {
         // Check that the domain is evenly divisible by the cell size in each
         // dimension within round-off error.
@@ -231,7 +231,7 @@ class GlobalMesh<NonUniformMesh<Scalar>>
     GlobalMesh( const std::vector<Scalar>& i_edges,
                 const std::vector<Scalar>& j_edges,
                 const std::vector<Scalar>& k_edges )
-        : _edges( {i_edges, j_edges, k_edges} )
+        : _edges( { i_edges, j_edges, k_edges } )
     {
     }
 

--- a/cajita/src/Cajita_GlobalMesh.hpp
+++ b/cajita/src/Cajita_GlobalMesh.hpp
@@ -44,12 +44,12 @@ class GlobalMesh
 
     // Cell size constructor - special case where all cell dimensions are the
     // same.
-    GlobalMesh( const std::array<scalar_type, 3> &global_low_corner,
-                const std::array<scalar_type, 3> &global_high_corner,
+    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
+                const std::array<scalar_type, 3>& global_high_corner,
                 const scalar_type cell_size )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
-        , _cell_size( { cell_size, cell_size, cell_size } )
+        , _cell_size( {cell_size, cell_size, cell_size} )
     {
         // Check that the domain is evenly divisible by the cell size in each
         // dimension within round-off error.
@@ -65,9 +65,9 @@ class GlobalMesh
     }
 
     // Cell size constructor - each cell dimension can be different.
-    GlobalMesh( const std::array<scalar_type, 3> &global_low_corner,
-                const std::array<scalar_type, 3> &global_high_corner,
-                const std::array<scalar_type, 3> &cell_size )
+    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
+                const std::array<scalar_type, 3>& global_high_corner,
+                const std::array<scalar_type, 3>& cell_size )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
         , _cell_size( cell_size )
@@ -86,9 +86,9 @@ class GlobalMesh
     }
 
     // Number of global cells constructor.
-    GlobalMesh( const std::array<scalar_type, 3> &global_low_corner,
-                const std::array<scalar_type, 3> &global_high_corner,
-                const std::array<int, 3> &global_num_cell )
+    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
+                const std::array<scalar_type, 3>& global_high_corner,
+                const std::array<int, 3>& global_num_cell )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
     {
@@ -153,8 +153,8 @@ class GlobalMesh
 // Creation function for Uniform Mesh.
 template <class Scalar>
 std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                         const std::array<Scalar, 3> &global_high_corner,
+createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                         const std::array<Scalar, 3>& global_high_corner,
                          const Scalar cell_size )
 {
     return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
@@ -163,9 +163,9 @@ createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 
 template <class Scalar>
 std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                         const std::array<Scalar, 3> &global_high_corner,
-                         const std::array<Scalar, 3> &cell_size )
+createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                         const std::array<Scalar, 3>& global_high_corner,
+                         const std::array<Scalar, 3>& cell_size )
 {
     return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
         global_low_corner, global_high_corner, cell_size );
@@ -173,9 +173,9 @@ createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 
 template <class Scalar>
 std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                         const std::array<Scalar, 3> &global_high_corner,
-                         const std::array<int, 3> &global_num_cell )
+createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                         const std::array<Scalar, 3>& global_high_corner,
+                         const std::array<int, 3>& global_num_cell )
 {
     return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
         global_low_corner, global_high_corner, global_num_cell );
@@ -184,8 +184,8 @@ createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 // Creation functions for Sparse Mesh.
 template <class Scalar>
 std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                        const std::array<Scalar, 3> &global_high_corner,
+createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                        const std::array<Scalar, 3>& global_high_corner,
                         const Scalar cell_size )
 {
     return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
@@ -194,9 +194,9 @@ createSparseGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 
 template <class Scalar>
 std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                        const std::array<Scalar, 3> &global_high_corner,
-                        const std::array<Scalar, 3> &cell_size )
+createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                        const std::array<Scalar, 3>& global_high_corner,
+                        const std::array<Scalar, 3>& cell_size )
 {
     return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
         global_low_corner, global_high_corner, cell_size );
@@ -204,9 +204,9 @@ createSparseGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 
 template <class Scalar>
 std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
-                        const std::array<Scalar, 3> &global_high_corner,
-                        const std::array<int, 3> &global_num_cell )
+createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
+                        const std::array<Scalar, 3>& global_high_corner,
+                        const std::array<int, 3>& global_num_cell )
 {
     return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
         global_low_corner, global_high_corner, global_num_cell );
@@ -228,10 +228,10 @@ class GlobalMesh<NonUniformMesh<Scalar>>
     using scalar_type = Scalar;
 
     // Constructor.
-    GlobalMesh( const std::vector<Scalar> &i_edges,
-                const std::vector<Scalar> &j_edges,
-                const std::vector<Scalar> &k_edges )
-        : _edges( { i_edges, j_edges, k_edges } )
+    GlobalMesh( const std::vector<Scalar>& i_edges,
+                const std::vector<Scalar>& j_edges,
+                const std::vector<Scalar>& k_edges )
+        : _edges( {i_edges, j_edges, k_edges} )
     {
     }
 
@@ -255,7 +255,7 @@ class GlobalMesh<NonUniformMesh<Scalar>>
     // NON-UNIFORM MESH SPECIFIC
 
     // Get the edge array in a given dimension.
-    const std::vector<Scalar> &nonUniformEdge( const int dim ) const
+    const std::vector<Scalar>& nonUniformEdge( const int dim ) const
     {
         return _edges[dim];
     }
@@ -267,9 +267,9 @@ class GlobalMesh<NonUniformMesh<Scalar>>
 // Creation function.
 template <class Scalar>
 std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar>>>
-createNonUniformGlobalMesh( const std::vector<Scalar> &i_edges,
-                            const std::vector<Scalar> &j_edges,
-                            const std::vector<Scalar> &k_edges )
+createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
+                            const std::vector<Scalar>& j_edges,
+                            const std::vector<Scalar>& k_edges )
 {
     return std::make_shared<GlobalMesh<NonUniformMesh<Scalar>>>(
         i_edges, j_edges, k_edges );

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -42,7 +42,7 @@ class HaloPattern
     virtual ~HaloPattern() = default;
 
     // Assign the neighbors that are in the halo pattern.
-    void setNeighbors( const std::vector<std::array<int, 3>> &neighbors )
+    void setNeighbors( const std::vector<std::array<int, 3>>& neighbors )
     {
         _neighbors = neighbors;
     }
@@ -67,7 +67,7 @@ class FullHaloPattern : public HaloPattern
             for ( int j = -1; j < 2; ++j )
                 for ( int k = -1; k < 2; ++k )
                     if ( !( i == 0 && j == 0 && k == 0 ) )
-                        neighbors.push_back( { i, j, k } );
+                        neighbors.push_back( {i, j, k} );
         this->setNeighbors( neighbors );
     }
 };
@@ -132,8 +132,8 @@ class Halo
       provided in the same order
     */
     template <class... ArrayTypes>
-    Halo( const HaloPattern &pattern, const int width,
-          const ArrayTypes &... arrays )
+    Halo( const HaloPattern& pattern, const int width,
+          const ArrayTypes&... arrays )
     {
         // Get the MPI communicator. All arrays must have the same
         // communicator.
@@ -165,7 +165,7 @@ class Halo
         // allocate buffers. If any of the exchanges are self sends mark these
         // so we know which send buffers correspond to which receive buffers.
         auto neighbors = pattern.getNeighbors();
-        for ( const auto &n : neighbors )
+        for ( const auto& n : neighbors )
         {
             // Get the neighbor ids.
             auto i = n[Dim::I];
@@ -215,8 +215,8 @@ class Halo
       as the input arrays.
     */
     template <class ExecutionSpace, class... ArrayTypes>
-    void gather( const ExecutionSpace &exec_space,
-                 const ArrayTypes &... arrays ) const
+    void gather( const ExecutionSpace& exec_space,
+                 const ArrayTypes&... arrays ) const
     {
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
@@ -298,8 +298,8 @@ class Halo
       \param arrays The arrays to scatter.
     */
     template <class ExecutionSpace, class ReduceOp, class... ArrayTypes>
-    void scatter( const ExecutionSpace &exec_space, const ReduceOp &reduce_op,
-                  const ArrayTypes &... arrays ) const
+    void scatter( const ExecutionSpace& exec_space, const ReduceOp& reduce_op,
+                  const ArrayTypes&... arrays ) const
     {
         // Get the number of neighbors. Return if we have none.
         int num_n = _neighbor_ranks.size();
@@ -374,7 +374,7 @@ class Halo
   public:
     // Get the communicator and check to make sure all are the same.
     template <class Array_t>
-    void getComm( const Array_t &array )
+    void getComm( const Array_t& array )
     {
         // Duplicate the communicator so we have our own communication space.
         MPI_Comm_dup( array.layout()->localGrid()->globalGrid().comm(),
@@ -382,7 +382,7 @@ class Halo
     }
 
     template <class Array_t, class... ArrayTypes>
-    void getComm( const Array_t &array, const ArrayTypes &... arrays )
+    void getComm( const Array_t& array, const ArrayTypes&... arrays )
     {
         // Recurse.
         getComm( arrays... );
@@ -399,13 +399,13 @@ class Halo
     // Get the local grid from the arrays. Check that the grids have the same
     // halo size.
     template <class Array_t>
-    auto getLocalGrid( const Array_t &array )
+    auto getLocalGrid( const Array_t& array )
     {
         return array.layout()->localGrid();
     }
 
     template <class Array_t, class... ArrayTypes>
-    auto getLocalGrid( const Array_t &array, const ArrayTypes &... arrays )
+    auto getLocalGrid( const Array_t& array, const ArrayTypes&... arrays )
     {
         // Recurse.
         auto local_grid = getLocalGrid( arrays... );
@@ -425,22 +425,22 @@ class Halo
     void
     buildCommData( DecompositionTag decomposition_tag, const int width,
                    const int ni, const int nj, const int nk,
-                   std::vector<Kokkos::View<char *, memory_space>> &buffers,
-                   std::vector<Kokkos::View<int *[6], memory_space>> &steering,
-                   const ArrayTypes &... arrays )
+                   std::vector<Kokkos::View<char*, memory_space>>& buffers,
+                   std::vector<Kokkos::View<int* [6], memory_space>>& steering,
+                   const ArrayTypes&... arrays )
     {
         // Number of arrays.
         const std::size_t num_array = sizeof...( ArrayTypes );
 
         // Get the byte sizes of array value types.
         std::array<std::size_t, num_array> value_byte_sizes = {
-            sizeof( typename ArrayTypes::value_type )... };
+            sizeof( typename ArrayTypes::value_type )...};
 
         // Get the index spaces we share with this neighbor. We
         // get a shared index space for each array.
         std::array<IndexSpace<4>, num_array> spaces = {
             ( arrays.layout()->sharedIndexSpace( decomposition_tag, ni, nj, nk,
-                                                 width ) )... };
+                                                 width ) )...};
 
         // Compute the buffer size of this neighbor and the
         // number of elements in the buffer.
@@ -455,10 +455,10 @@ class Halo
         // Allocate the buffer of data that we share with this neighbor. All
         // arrays will be packed into a single buffer.
         buffers.push_back(
-            Kokkos::View<char *, memory_space>( "halo_buffer", buffer_bytes ) );
+            Kokkos::View<char*, memory_space>( "halo_buffer", buffer_bytes ) );
 
         // Allocate the steering vector for building the buffer.
-        steering.push_back( Kokkos::View<int *[6], memory_space>(
+        steering.push_back( Kokkos::View<int* [6], memory_space>(
             "steering", buffer_num_element ) );
 
         // Create the steering vector. For each element in the buffer it gives
@@ -519,11 +519,11 @@ class Halo
     // alignment boundaries.
     template <class ArrayView>
     KOKKOS_INLINE_FUNCTION void
-    packElement( const Kokkos::View<char *, memory_space> &buffer,
-                 const Kokkos::View<int *[6], memory_space> &steering,
-                 const int element_idx, const ArrayView &array_view ) const
+    packElement( const Kokkos::View<char*, memory_space>& buffer,
+                 const Kokkos::View<int* [6], memory_space>& steering,
+                 const int element_idx, const ArrayView& array_view ) const
     {
-        const char *elem_ptr = reinterpret_cast<const char *>( &array_view(
+        const char* elem_ptr = reinterpret_cast<const char*>( &array_view(
             steering( element_idx, 2 ), steering( element_idx, 3 ),
             steering( element_idx, 4 ), steering( element_idx, 5 ) ) );
         for ( std::size_t b = 0; b < sizeof( typename ArrayView::value_type );
@@ -536,11 +536,11 @@ class Halo
     // Pack an array into a buffer.
     template <class... ArrayViews>
     KOKKOS_INLINE_FUNCTION void
-    packArray( const Kokkos::View<char *, memory_space> &buffer,
-               const Kokkos::View<int *[6], memory_space> &steering,
+    packArray( const Kokkos::View<char*, memory_space>& buffer,
+               const Kokkos::View<int* [6], memory_space>& steering,
                const int element_idx,
                const std::integral_constant<std::size_t, 0>,
-               const ParameterPack<ArrayViews...> &array_views ) const
+               const ParameterPack<ArrayViews...>& array_views ) const
     {
         // If the pack element_idx is in the current array, pack it.
         if ( 0 == steering( element_idx, 1 ) )
@@ -550,11 +550,11 @@ class Halo
     // Pack an array into a buffer.
     template <std::size_t N, class... ArrayViews>
     KOKKOS_INLINE_FUNCTION void
-    packArray( const Kokkos::View<char *, memory_space> &buffer,
-               const Kokkos::View<int *[6], memory_space> &steering,
+    packArray( const Kokkos::View<char*, memory_space>& buffer,
+               const Kokkos::View<int* [6], memory_space>& steering,
                const int element_idx,
                const std::integral_constant<std::size_t, N>,
-               const ParameterPack<ArrayViews...> &array_views ) const
+               const ParameterPack<ArrayViews...>& array_views ) const
     {
         // If the pack element_idx is in the current array, pack it.
         if ( N == steering( element_idx, 1 ) )
@@ -567,9 +567,9 @@ class Halo
 
     // Pack arrays into a buffer.
     template <class ExecutionSpace, class... ArrayViews>
-    void packBuffer( const ExecutionSpace &exec_space,
-                     const Kokkos::View<char *, memory_space> &buffer,
-                     const Kokkos::View<int *[6], memory_space> &steering,
+    void packBuffer( const ExecutionSpace& exec_space,
+                     const Kokkos::View<char*, memory_space>& buffer,
+                     const Kokkos::View<int* [6], memory_space>& steering,
                      ArrayViews... array_views ) const
     {
         auto pp = makeParameterPack( array_views... );
@@ -590,7 +590,7 @@ class Halo
     // Reduce an element into the buffer. Sum reduction.
     template <class T>
     KOKKOS_INLINE_FUNCTION void
-    unpackOp( ScatterReduce::Sum, const T &buffer_val, T &array_val ) const
+    unpackOp( ScatterReduce::Sum, const T& buffer_val, T& array_val ) const
     {
         array_val += buffer_val;
     }
@@ -598,7 +598,7 @@ class Halo
     // Reduce an element into the buffer. Min reduction.
     template <class T>
     KOKKOS_INLINE_FUNCTION void
-    unpackOp( ScatterReduce::Min, const T &buffer_val, T &array_val ) const
+    unpackOp( ScatterReduce::Min, const T& buffer_val, T& array_val ) const
     {
         if ( buffer_val < array_val )
             array_val = buffer_val;
@@ -607,7 +607,7 @@ class Halo
     // Reduce an element into the buffer. Max reduction.
     template <class T>
     KOKKOS_INLINE_FUNCTION void
-    unpackOp( ScatterReduce::Max, const T &buffer_val, T &array_val ) const
+    unpackOp( ScatterReduce::Max, const T& buffer_val, T& array_val ) const
     {
         if ( buffer_val > array_val )
             array_val = buffer_val;
@@ -616,7 +616,7 @@ class Halo
     // Reduce an element into the buffer. Replace reduction.
     template <class T>
     KOKKOS_INLINE_FUNCTION void
-    unpackOp( ScatterReduce::Replace, const T &buffer_val, T &array_val ) const
+    unpackOp( ScatterReduce::Replace, const T& buffer_val, T& array_val ) const
     {
         array_val = buffer_val;
     }
@@ -625,13 +625,13 @@ class Halo
     // across alignment boundaries.
     template <class ReduceOp, class ArrayView>
     KOKKOS_INLINE_FUNCTION void
-    unpackElement( const ReduceOp &reduce_op,
-                   const Kokkos::View<char *, memory_space> &buffer,
-                   const Kokkos::View<int *[6], memory_space> &steering,
-                   const int element_idx, const ArrayView &array_view ) const
+    unpackElement( const ReduceOp& reduce_op,
+                   const Kokkos::View<char*, memory_space>& buffer,
+                   const Kokkos::View<int* [6], memory_space>& steering,
+                   const int element_idx, const ArrayView& array_view ) const
     {
         typename ArrayView::value_type elem;
-        char *elem_ptr = reinterpret_cast<char *>( &elem );
+        char* elem_ptr = reinterpret_cast<char*>( &elem );
         for ( std::size_t b = 0; b < sizeof( typename ArrayView::value_type );
               ++b )
         {
@@ -647,12 +647,12 @@ class Halo
     // Unpack an array from a buffer.
     template <class ReduceOp, class... ArrayViews>
     KOKKOS_INLINE_FUNCTION void
-    unpackArray( const ReduceOp &reduce_op,
-                 const Kokkos::View<char *, memory_space> &buffer,
-                 const Kokkos::View<int *[6], memory_space> &steering,
+    unpackArray( const ReduceOp& reduce_op,
+                 const Kokkos::View<char*, memory_space>& buffer,
+                 const Kokkos::View<int* [6], memory_space>& steering,
                  const int element_idx,
                  const std::integral_constant<std::size_t, 0>,
-                 const ParameterPack<ArrayViews...> &array_views ) const
+                 const ParameterPack<ArrayViews...>& array_views ) const
     {
         // If the unpack element_idx is in the current array, unpack it.
         if ( 0 == steering( element_idx, 1 ) )
@@ -664,11 +664,11 @@ class Halo
     template <class ReduceOp, std::size_t N, class... ArrayViews>
     KOKKOS_INLINE_FUNCTION void
     unpackArray( const ReduceOp reduce_op,
-                 const Kokkos::View<char *, memory_space> &buffer,
-                 const Kokkos::View<int *[6], memory_space> &steering,
+                 const Kokkos::View<char*, memory_space>& buffer,
+                 const Kokkos::View<int* [6], memory_space>& steering,
                  const int element_idx,
                  const std::integral_constant<std::size_t, N>,
-                 const ParameterPack<ArrayViews...> &array_views ) const
+                 const ParameterPack<ArrayViews...>& array_views ) const
     {
         // If the unpack element_idx is in the current array, unpack it.
         if ( N == steering( element_idx, 1 ) )
@@ -683,10 +683,10 @@ class Halo
 
     // Unpack arrays from a buffer.
     template <class ExecutionSpace, class ReduceOp, class... ArrayViews>
-    void unpackBuffer( const ReduceOp &reduce_op,
-                       const ExecutionSpace &exec_space,
-                       const Kokkos::View<char *, memory_space> &buffer,
-                       const Kokkos::View<int *[6], memory_space> &steering,
+    void unpackBuffer( const ReduceOp& reduce_op,
+                       const ExecutionSpace& exec_space,
+                       const Kokkos::View<char*, memory_space>& buffer,
+                       const Kokkos::View<int* [6], memory_space>& steering,
                        ArrayViews... array_views ) const
     {
         auto pp = makeParameterPack( array_views... );
@@ -717,16 +717,16 @@ class Halo
     std::vector<int> _receive_tags;
 
     // For each neighbor, send/receive buffers for data we own.
-    std::vector<Kokkos::View<char *, memory_space>> _owned_buffers;
+    std::vector<Kokkos::View<char*, memory_space>> _owned_buffers;
 
     // For each neighbor, send/receive buffers for data we ghost.
-    std::vector<Kokkos::View<char *, memory_space>> _ghosted_buffers;
+    std::vector<Kokkos::View<char*, memory_space>> _ghosted_buffers;
 
     // For each neighbor, steering vector for the owned buffer.
-    std::vector<Kokkos::View<int *[6], memory_space>> _owned_steering;
+    std::vector<Kokkos::View<int* [6], memory_space>> _owned_steering;
 
     // For each neighbor, steering vector for the ghosted buffer.
-    std::vector<Kokkos::View<int *[6], memory_space>> _ghosted_steering;
+    std::vector<Kokkos::View<int* [6], memory_space>> _ghosted_steering;
 };
 
 //---------------------------------------------------------------------------//
@@ -747,8 +747,8 @@ struct ArrayPackMemorySpace
   \param arrays The arrays over which to build the halo.
 */
 template <class... ArrayTypes>
-auto createHalo( const HaloPattern &pattern, const int width,
-                 const ArrayTypes &... arrays )
+auto createHalo( const HaloPattern& pattern, const int width,
+                 const ArrayTypes&... arrays )
 {
     using memory_space = typename ArrayPackMemorySpace<ArrayTypes...>::type;
     return std::make_shared<Halo<memory_space>>( pattern, width, arrays... );
@@ -764,8 +764,8 @@ struct LayoutAdapter
 {
     using value_type = Scalar;
     using memory_space = MemorySpace;
-    const ArrayLayout &array_layout;
-    const ArrayLayout *layout() const { return &array_layout; }
+    const ArrayLayout& array_layout;
+    const ArrayLayout* layout() const { return &array_layout; }
 };
 
 //---------------------------------------------------------------------------//
@@ -780,12 +780,12 @@ struct LayoutAdapter
   only compatible with arrays that have the same scalar and device type.
 */
 template <class Scalar, class Device, class EntityType, class MeshType>
-auto createHalo( const ArrayLayout<EntityType, MeshType> &layout,
-                 const HaloPattern &pattern, const int width = -1 )
+auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
+                 const HaloPattern& pattern, const int width = -1 )
 {
     LayoutAdapter<Scalar, typename Device::memory_space,
                   ArrayLayout<EntityType, MeshType>>
-        adapter{ layout };
+        adapter{layout};
     return createHalo( pattern, width, adapter );
 }
 
@@ -802,14 +802,14 @@ auto createHalo( const ArrayLayout<EntityType, MeshType> &layout,
   type as the input array.
 */
 template <class Scalar, class EntityType, class MeshType, class... Params>
-auto createHalo( const Array<Scalar, EntityType, MeshType, Params...> &array,
-                 const HaloPattern &pattern, const int width = -1 )
+auto createHalo( const Array<Scalar, EntityType, MeshType, Params...>& array,
+                 const HaloPattern& pattern, const int width = -1 )
 {
     LayoutAdapter<
         Scalar,
         typename Array<Scalar, EntityType, MeshType, Params...>::memory_space,
         typename Array<Scalar, EntityType, MeshType, Params...>::array_layout>
-        adapter{ *array.layout() };
+        adapter{*array.layout()};
     return createHalo( pattern, width, adapter );
 }
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -433,14 +433,14 @@ class Halo
         const std::size_t num_array = sizeof...( ArrayTypes );
 
         // Get the byte sizes of array value types.
-        std::array<std::size_t, num_array> value_byte_sizes = { sizeof(
-            typename ArrayTypes::value_type )... };
+        std::array<std::size_t, num_array> value_byte_sizes = {
+            sizeof( typename ArrayTypes::value_type )... };
 
         // Get the index spaces we share with this neighbor. We
         // get a shared index space for each array.
-        std::array<IndexSpace<4>, num_array> spaces = { (
-            arrays.layout()->sharedIndexSpace( decomposition_tag, ni, nj, nk,
-                                               width ) )... };
+        std::array<IndexSpace<4>, num_array> spaces = {
+            ( arrays.layout()->sharedIndexSpace( decomposition_tag, ni, nj, nk,
+                                                 width ) )... };
 
         // Compute the buffer size of this neighbor and the
         // number of elements in the buffer.

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -67,7 +67,7 @@ class FullHaloPattern : public HaloPattern
             for ( int j = -1; j < 2; ++j )
                 for ( int k = -1; k < 2; ++k )
                     if ( !( i == 0 && j == 0 && k == 0 ) )
-                        neighbors.push_back( {i, j, k} );
+                        neighbors.push_back( { i, j, k } );
         this->setNeighbors( neighbors );
     }
 };
@@ -433,14 +433,14 @@ class Halo
         const std::size_t num_array = sizeof...( ArrayTypes );
 
         // Get the byte sizes of array value types.
-        std::array<std::size_t, num_array> value_byte_sizes = {
-            sizeof( typename ArrayTypes::value_type )...};
+        std::array<std::size_t, num_array> value_byte_sizes = { sizeof(
+            typename ArrayTypes::value_type )... };
 
         // Get the index spaces we share with this neighbor. We
         // get a shared index space for each array.
-        std::array<IndexSpace<4>, num_array> spaces = {
-            ( arrays.layout()->sharedIndexSpace( decomposition_tag, ni, nj, nk,
-                                                 width ) )...};
+        std::array<IndexSpace<4>, num_array> spaces = { (
+            arrays.layout()->sharedIndexSpace( decomposition_tag, ni, nj, nk,
+                                               width ) )... };
 
         // Compute the buffer size of this neighbor and the
         // number of elements in the buffer.
@@ -785,7 +785,7 @@ auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
 {
     LayoutAdapter<Scalar, typename Device::memory_space,
                   ArrayLayout<EntityType, MeshType>>
-        adapter{layout};
+        adapter{ layout };
     return createHalo( pattern, width, adapter );
 }
 
@@ -809,7 +809,7 @@ auto createHalo( const Array<Scalar, EntityType, MeshType, Params...>& array,
         Scalar,
         typename Array<Scalar, EntityType, MeshType, Params...>::memory_space,
         typename Array<Scalar, EntityType, MeshType, Params...>::array_layout>
-        adapter{*array.layout()};
+        adapter{ *array.layout() };
     return createHalo( pattern, width, adapter );
 }
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_HypreStructuredSolver.hpp
+++ b/cajita/src/Cajita_HypreStructuredSolver.hpp
@@ -78,12 +78,13 @@ class HypreStructuredSolver
             // directly use Kokkos::deep_copy to move data between Cajita arrays
             // and HYPRE data structures.
             auto global_space = layout.indexSpace( Own(), Global() );
-            _lower = {static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
-                      static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
-                      static_cast<HYPRE_Int>( global_space.min( Dim::I ) )};
-            _upper = {static_cast<HYPRE_Int>( global_space.max( Dim::K ) - 1 ),
-                      static_cast<HYPRE_Int>( global_space.max( Dim::J ) - 1 ),
-                      static_cast<HYPRE_Int>( global_space.max( Dim::I ) - 1 )};
+            _lower = { static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
+                       static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
+                       static_cast<HYPRE_Int>( global_space.min( Dim::I ) ) };
+            _upper = { static_cast<HYPRE_Int>( global_space.max( Dim::K ) - 1 ),
+                       static_cast<HYPRE_Int>( global_space.max( Dim::J ) - 1 ),
+                       static_cast<HYPRE_Int>( global_space.max( Dim::I ) -
+                                               1 ) };
             error = HYPRE_StructGridSetExtents( _grid, _lower.data(),
                                                 _upper.data() );
             checkHypreError( error );
@@ -106,9 +107,9 @@ class HypreStructuredSolver
 
             // Allocate LHS and RHS vectors and initialize to zero. Note that we
             // are fixing the views under these vectors to layout-right.
-            IndexSpace<3> reorder_space( {global_space.extent( Dim::I ),
-                                          global_space.extent( Dim::J ),
-                                          global_space.extent( Dim::K )} );
+            IndexSpace<3> reorder_space( { global_space.extent( Dim::I ),
+                                           global_space.extent( Dim::J ),
+                                           global_space.extent( Dim::K ) } );
             auto vector_values =
                 createView<HYPRE_Complex, Kokkos::LayoutRight,
                            Kokkos::HostSpace>( "vector_values", reorder_space );
@@ -175,8 +176,8 @@ class HypreStructuredSolver
         checkHypreError( error );
         for ( unsigned n = 0; n < stencil.size(); ++n )
         {
-            HYPRE_Int offset[3] = {stencil[n][Dim::I], stencil[n][Dim::J],
-                                   stencil[n][Dim::K]};
+            HYPRE_Int offset[3] = { stencil[n][Dim::I], stencil[n][Dim::J],
+                                    stencil[n][Dim::K] };
             error = HYPRE_StructStencilSetElement( _stencil, n, offset );
             checkHypreError( error );
         }
@@ -233,8 +234,8 @@ class HypreStructuredSolver
         // layout-right.
         auto owned_space = values.layout()->indexSpace( Own(), Local() );
         IndexSpace<4> reorder_space(
-            {owned_space.extent( Dim::I ), owned_space.extent( Dim::J ),
-             owned_space.extent( Dim::K ), _stencil_size} );
+            { owned_space.extent( Dim::I ), owned_space.extent( Dim::J ),
+              owned_space.extent( Dim::K ), _stencil_size } );
         auto a_values =
             createView<HYPRE_Complex, Kokkos::LayoutRight, Kokkos::HostSpace>(
                 "a_values", reorder_space );
@@ -340,9 +341,9 @@ class HypreStructuredSolver
 
         // Copy the RHS into HYPRE. The HYPRE layout is fixed as layout-right.
         auto owned_space = b.layout()->indexSpace( Own(), Local() );
-        IndexSpace<4> reorder_space( {owned_space.extent( Dim::I ),
-                                      owned_space.extent( Dim::J ),
-                                      owned_space.extent( Dim::K ), 1} );
+        IndexSpace<4> reorder_space( { owned_space.extent( Dim::I ),
+                                       owned_space.extent( Dim::J ),
+                                       owned_space.extent( Dim::K ), 1 } );
         auto vector_values =
             createView<HYPRE_Complex, Kokkos::LayoutRight, Kokkos::HostSpace>(
                 "vector_values", reorder_space );

--- a/cajita/src/Cajita_HypreStructuredSolver.hpp
+++ b/cajita/src/Cajita_HypreStructuredSolver.hpp
@@ -81,10 +81,10 @@ class HypreStructuredSolver
             _lower = { static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
                        static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
                        static_cast<HYPRE_Int>( global_space.min( Dim::I ) ) };
-            _upper = { static_cast<HYPRE_Int>( global_space.max( Dim::K ) - 1 ),
-                       static_cast<HYPRE_Int>( global_space.max( Dim::J ) - 1 ),
-                       static_cast<HYPRE_Int>( global_space.max( Dim::I ) -
-                                               1 ) };
+            _upper = {
+                static_cast<HYPRE_Int>( global_space.max( Dim::K ) - 1 ),
+                static_cast<HYPRE_Int>( global_space.max( Dim::J ) - 1 ),
+                static_cast<HYPRE_Int>( global_space.max( Dim::I ) - 1 ) };
             error = HYPRE_StructGridSetExtents( _grid, _lower.data(),
                                                 _upper.data() );
             checkHypreError( error );

--- a/cajita/src/Cajita_IndexConversion.hpp
+++ b/cajita/src/Cajita_IndexConversion.hpp
@@ -54,7 +54,7 @@ struct L2G
     Kokkos::Array<bool, 3> boundary_hi;
 
     // Constructor.
-    L2G( const LocalGrid<MeshType> &local_grid )
+    L2G( const LocalGrid<MeshType>& local_grid )
     {
         // Local index set of owned entities.
         auto local_own_space =
@@ -77,7 +77,7 @@ struct L2G
             global_own_min[d] = global_own_space.min( d );
 
         // Get the global grid.
-        const auto &global_grid = local_grid.globalGrid();
+        const auto& global_grid = local_grid.globalGrid();
 
         // Global number of entities.
         for ( int d = 0; d < 3; ++d )
@@ -99,8 +99,8 @@ struct L2G
 
     // Convert local indices to global indices.
     KOKKOS_INLINE_FUNCTION
-    void operator()( const int li, const int lj, const int lk, int &gi, int &gj,
-                     int &gk ) const
+    void operator()( const int li, const int lj, const int lk, int& gi, int& gj,
+                     int& gk ) const
     {
         // I
         // Compute periodic wrap-around on low I boundary.
@@ -170,7 +170,7 @@ struct L2G
 //---------------------------------------------------------------------------//
 // Creation function.
 template <class MeshType, class EntityType>
-L2G<MeshType, EntityType> createL2G( const LocalGrid<MeshType> &local_grid,
+L2G<MeshType, EntityType> createL2G( const LocalGrid<MeshType>& local_grid,
                                      EntityType )
 {
     return L2G<MeshType, EntityType>( local_grid );

--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -42,7 +42,7 @@ class IndexSpace
     /*!
       \brief Initializer list size constructor.
     */
-    IndexSpace( const std::initializer_list<long> &size )
+    IndexSpace( const std::initializer_list<long>& size )
     {
         std::fill( _min.data(), _min.data() + Rank, 0 );
         std::copy( size.begin(), size.end(), _max.data() );
@@ -51,8 +51,8 @@ class IndexSpace
     /*!
       \brief Initializer list range constructor.
     */
-    IndexSpace( const std::initializer_list<long> &min,
-                const std::initializer_list<long> &max )
+    IndexSpace( const std::initializer_list<long>& min,
+                const std::initializer_list<long>& max )
     {
         std::copy( min.begin(), min.end(), _min.data() );
         std::copy( max.begin(), max.end(), _max.data() );
@@ -61,7 +61,7 @@ class IndexSpace
     /*!
       \brief Vector size constructor.
     */
-    IndexSpace( const std::array<long, N> &size )
+    IndexSpace( const std::array<long, N>& size )
     {
         std::fill( _min.data(), _min.data() + Rank, 0 );
         std::copy( size.begin(), size.end(), _max.data() );
@@ -70,7 +70,7 @@ class IndexSpace
     /*!
       \brief Vector range constructor.
     */
-    IndexSpace( const std::array<long, N> &min, const std::array<long, N> &max )
+    IndexSpace( const std::array<long, N>& min, const std::array<long, N>& max )
     {
         std::copy( min.begin(), min.end(), _min.data() );
         std::copy( max.begin(), max.end(), _max.data() );
@@ -78,7 +78,7 @@ class IndexSpace
 
     //! Comparison operator.
     KOKKOS_INLINE_FUNCTION
-    bool operator==( const IndexSpace<N> &rhs ) const
+    bool operator==( const IndexSpace<N>& rhs ) const
     {
         for ( long i = 0; i < N; ++i )
         {
@@ -90,7 +90,7 @@ class IndexSpace
 
     //! Comparison operator.
     KOKKOS_INLINE_FUNCTION
-    bool operator!=( const IndexSpace<N> &rhs ) const
+    bool operator!=( const IndexSpace<N>& rhs ) const
     {
         return !( operator==( rhs ) );
     }
@@ -152,8 +152,7 @@ class IndexSpace
 */
 template <class ExecutionSpace>
 Kokkos::RangePolicy<ExecutionSpace>
-createExecutionPolicy( const IndexSpace<1> &index_space,
-                       const ExecutionSpace & )
+createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace& )
 {
     return Kokkos::RangePolicy<ExecutionSpace>( index_space.min( 0 ),
                                                 index_space.max( 0 ) );
@@ -167,8 +166,8 @@ createExecutionPolicy( const IndexSpace<1> &index_space,
 */
 template <class ExecutionSpace, class WorkTag>
 Kokkos::RangePolicy<ExecutionSpace, WorkTag>
-createExecutionPolicy( const IndexSpace<1> &index_space, const ExecutionSpace &,
-                       const WorkTag & )
+createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace&,
+                       const WorkTag& )
 {
     return Kokkos::RangePolicy<ExecutionSpace, WorkTag>( index_space.min( 0 ),
                                                          index_space.max( 0 ) );
@@ -180,7 +179,7 @@ createExecutionPolicy( const IndexSpace<1> &index_space, const ExecutionSpace &,
 */
 template <class IndexSpace_t, class ExecutionSpace>
 Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<IndexSpace_t::Rank>>
-createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace & )
+createExecutionPolicy( const IndexSpace_t& index_space, const ExecutionSpace& )
 {
     return Kokkos::MDRangePolicy<ExecutionSpace,
                                  Kokkos::Rank<IndexSpace_t::Rank>>(
@@ -194,8 +193,8 @@ createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace & )
 */
 template <class IndexSpace_t, class ExecutionSpace, class WorkTag>
 Kokkos::MDRangePolicy<ExecutionSpace, WorkTag, Kokkos::Rank<IndexSpace_t::Rank>>
-createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace &,
-                       const WorkTag & )
+createExecutionPolicy( const IndexSpace_t& index_space, const ExecutionSpace&,
+                       const WorkTag& )
 {
     return Kokkos::MDRangePolicy<ExecutionSpace, WorkTag,
                                  Kokkos::Rank<IndexSpace_t::Rank>>(
@@ -210,10 +209,10 @@ createExecutionPolicy( const IndexSpace_t &index_space, const ExecutionSpace &,
   Rank-1 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar *, Params...> createView( const std::string &label,
-                                              const IndexSpace<1> &index_space )
+Kokkos::View<Scalar*, Params...> createView( const std::string& label,
+                                             const IndexSpace<1>& index_space )
 {
-    return Kokkos::View<Scalar *, Params...>(
+    return Kokkos::View<Scalar*, Params...>(
         Kokkos::ViewAllocateWithoutInitializing( label ),
         index_space.extent( 0 ) );
 }
@@ -226,10 +225,10 @@ Kokkos::View<Scalar *, Params...> createView( const std::string &label,
   Rank-1 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar *, Params..., Kokkos::MemoryUnmanaged>
-createView( const IndexSpace<1> &index_space, Scalar *data )
+Kokkos::View<Scalar*, Params..., Kokkos::MemoryUnmanaged>
+createView( const IndexSpace<1>& index_space, Scalar* data )
 {
-    return Kokkos::View<Scalar *, Params..., Kokkos::MemoryUnmanaged>(
+    return Kokkos::View<Scalar*, Params..., Kokkos::MemoryUnmanaged>(
         data, index_space.extent( 0 ) );
 }
 
@@ -241,10 +240,10 @@ createView( const IndexSpace<1> &index_space, Scalar *data )
   Rank-2 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar **, Params...>
-createView( const std::string &label, const IndexSpace<2> &index_space )
+Kokkos::View<Scalar**, Params...> createView( const std::string& label,
+                                              const IndexSpace<2>& index_space )
 {
-    return Kokkos::View<Scalar **, Params...>(
+    return Kokkos::View<Scalar**, Params...>(
         Kokkos::ViewAllocateWithoutInitializing( label ),
         index_space.extent( 0 ), index_space.extent( 1 ) );
 }
@@ -257,10 +256,10 @@ createView( const std::string &label, const IndexSpace<2> &index_space )
   Rank-2 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar **, Params..., Kokkos::MemoryUnmanaged>
-createView( const IndexSpace<2> &index_space, Scalar *data )
+Kokkos::View<Scalar**, Params..., Kokkos::MemoryUnmanaged>
+createView( const IndexSpace<2>& index_space, Scalar* data )
 {
-    return Kokkos::View<Scalar **, Params..., Kokkos::MemoryUnmanaged>(
+    return Kokkos::View<Scalar**, Params..., Kokkos::MemoryUnmanaged>(
         data, index_space.extent( 0 ), index_space.extent( 1 ) );
 }
 
@@ -272,10 +271,10 @@ createView( const IndexSpace<2> &index_space, Scalar *data )
   Rank-3 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar ***, Params...>
-createView( const std::string &label, const IndexSpace<3> &index_space )
+Kokkos::View<Scalar***, Params...>
+createView( const std::string& label, const IndexSpace<3>& index_space )
 {
-    return Kokkos::View<Scalar ***, Params...>(
+    return Kokkos::View<Scalar***, Params...>(
         Kokkos::ViewAllocateWithoutInitializing( label ),
         index_space.extent( 0 ), index_space.extent( 1 ),
         index_space.extent( 2 ) );
@@ -289,10 +288,10 @@ createView( const std::string &label, const IndexSpace<3> &index_space )
   Rank-3 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar ***, Params..., Kokkos::MemoryUnmanaged>
-createView( const IndexSpace<3> &index_space, Scalar *data )
+Kokkos::View<Scalar***, Params..., Kokkos::MemoryUnmanaged>
+createView( const IndexSpace<3>& index_space, Scalar* data )
 {
-    return Kokkos::View<Scalar ***, Params..., Kokkos::MemoryUnmanaged>(
+    return Kokkos::View<Scalar***, Params..., Kokkos::MemoryUnmanaged>(
         data, index_space.extent( 0 ), index_space.extent( 1 ),
         index_space.extent( 2 ) );
 }
@@ -305,10 +304,10 @@ createView( const IndexSpace<3> &index_space, Scalar *data )
   Rank-4 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar ****, Params...>
-createView( const std::string &label, const IndexSpace<4> &index_space )
+Kokkos::View<Scalar****, Params...>
+createView( const std::string& label, const IndexSpace<4>& index_space )
 {
-    return Kokkos::View<Scalar ****, Params...>(
+    return Kokkos::View<Scalar****, Params...>(
         Kokkos::ViewAllocateWithoutInitializing( label ),
         index_space.extent( 0 ), index_space.extent( 1 ),
         index_space.extent( 2 ), index_space.extent( 3 ) );
@@ -322,10 +321,10 @@ createView( const std::string &label, const IndexSpace<4> &index_space )
   Rank-4 specialization.
 */
 template <class Scalar, class... Params>
-Kokkos::View<Scalar ****, Params..., Kokkos::MemoryUnmanaged>
-createView( const IndexSpace<4> &index_space, Scalar *data )
+Kokkos::View<Scalar****, Params..., Kokkos::MemoryUnmanaged>
+createView( const IndexSpace<4>& index_space, Scalar* data )
 {
-    return Kokkos::View<Scalar ****, Params..., Kokkos::MemoryUnmanaged>(
+    return Kokkos::View<Scalar****, Params..., Kokkos::MemoryUnmanaged>(
         data, index_space.extent( 0 ), index_space.extent( 1 ),
         index_space.extent( 2 ), index_space.extent( 3 ) );
 }
@@ -337,8 +336,8 @@ createView( const IndexSpace<4> &index_space, Scalar *data )
   Rank-1 specialization.
 */
 template <class ViewType>
-KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
-                                           const IndexSpace<1> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
+                                           const IndexSpace<1>& index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ) ) )
 {
     static_assert( 1 == ViewType::Rank, "Incorrect view rank" );
@@ -352,8 +351,8 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
   Rank-2 specialization.
 */
 template <class ViewType>
-KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
-                                           const IndexSpace<2> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
+                                           const IndexSpace<2>& index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ) ) )
 {
@@ -369,8 +368,8 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
   Rank-3 specialization.
 */
 template <class ViewType>
-KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
-                                           const IndexSpace<3> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
+                                           const IndexSpace<3>& index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ),
                                   index_space.range( 2 ) ) )
@@ -387,8 +386,8 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
   Rank-4 specialization.
 */
 template <class ViewType>
-KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
-                                           const IndexSpace<4> &index_space )
+KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
+                                           const IndexSpace<4>& index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ),
                                   index_space.range( 2 ),
@@ -404,7 +403,7 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType &view,
 // Given an N-dimensional index space append an additional dimension with the
 // given size.
 template <long N>
-IndexSpace<N + 1> appendDimension( const IndexSpace<N> &index_space,
+IndexSpace<N + 1> appendDimension( const IndexSpace<N>& index_space,
                                    const long size )
 {
     std::array<long, N + 1> min;
@@ -424,7 +423,7 @@ IndexSpace<N + 1> appendDimension( const IndexSpace<N> &index_space,
 // Given an N-dimensional index space append an additional dimension with the
 // given range.
 template <long N>
-IndexSpace<N + 1> appendDimension( const IndexSpace<N> &index_space,
+IndexSpace<N + 1> appendDimension( const IndexSpace<N>& index_space,
                                    const long min, const long max )
 {
     std::array<long, N + 1> range_min;

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -168,7 +168,8 @@ gradient( const ViewType& view, const SplineDataType& sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]
+                };
 
                 for ( int d0 = 0; d0 < 3; ++d0 )
                 {
@@ -442,7 +443,8 @@ divergence( const PointDataType point_data[3][3], const SplineDataType& sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]
+                };
 
                 for ( int d1 = 0; d1 < 3; ++d1 )
                 {
@@ -536,8 +538,8 @@ void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
         "g2p", Kokkos::RangePolicy<execution_space>( 0, num_point ),
         KOKKOS_LAMBDA( const int p ) {
             // Get the point coordinates.
-            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
-                                points( p, Dim::K )};
+            MeshScalar px[3] = { points( p, Dim::I ), points( p, Dim::J ),
+                                 points( p, Dim::K ) };
 
             // Create the local spline data.
             using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;
@@ -840,8 +842,8 @@ void p2g( const PointEvalFunctor& functor, const PointCoordinates& points,
         "p2g", Kokkos::RangePolicy<execution_space>( 0, num_point ),
         KOKKOS_LAMBDA( const int p ) {
             // Get the point coordinates.
-            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
-                                points( p, Dim::K )};
+            MeshScalar px[3] = { points( p, Dim::I ), points( p, Dim::J ),
+                                 points( p, Dim::K ) };
 
             // Create the local spline data.
             using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -168,8 +168,7 @@ gradient( const ViewType& view, const SplineDataType& sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]
-                };
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k] };
 
                 for ( int d0 = 0; d0 < 3; ++d0 )
                 {
@@ -443,8 +442,7 @@ divergence( const PointDataType point_data[3][3], const SplineDataType& sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]
-                };
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k] };
 
                 for ( int d1 = 0; d1 < 3; ++d1 )
                 {

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -44,9 +44,9 @@ namespace G2P
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
+value( const ViewType& view, const SplineDataType& sd, PointDataType& result,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                               void *>::type = 0 )
+                               void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "G2P::value requires spline weight values" );
@@ -73,9 +73,9 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
+value( const ViewType& view, const SplineDataType& sd, PointDataType result[3],
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                               void *>::type = 0 )
+                               void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "G2P::value requires spline weight values" );
@@ -103,10 +103,10 @@ value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-gradient( const ViewType &view, const SplineDataType &sd,
+gradient( const ViewType& view, const SplineDataType& sd,
           PointDataType result[3],
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                                  void *>::type = 0 )
+                                  void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "G2P::gradient requires spline weight values" );
@@ -147,10 +147,10 @@ gradient( const ViewType &view, const SplineDataType &sd,
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-gradient( const ViewType &view, const SplineDataType &sd,
+gradient( const ViewType& view, const SplineDataType& sd,
           PointDataType result[3][3],
           typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                                  void *>::type = 0 )
+                                  void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "G2P::gradient requires spline weight values" );
@@ -168,7 +168,7 @@ gradient( const ViewType &view, const SplineDataType &sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k] };
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
 
                 for ( int d0 = 0; d0 < 3; ++d0 )
                 {
@@ -191,10 +191,10 @@ gradient( const ViewType &view, const SplineDataType &sd,
 */
 template <class ViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-divergence( const ViewType &view, const SplineDataType &sd,
-            PointDataType &result,
+divergence( const ViewType& view, const SplineDataType& sd,
+            PointDataType& result,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                                    void *>::type = 0 )
+                                    void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "G2P::divergence requires spline weight values" );
@@ -273,10 +273,10 @@ struct is_scatter_view
 */
 template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
-value( const PointDataType &point_data, const SplineDataType &sd,
-       const ScatterViewType &view,
+value( const PointDataType& point_data, const SplineDataType& sd,
+       const ScatterViewType& view,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                               void *>::type = 0 )
+                               void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
@@ -302,10 +302,10 @@ value( const PointDataType &point_data, const SplineDataType &sd,
 */
 template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
-value( const PointDataType point_data[3], const SplineDataType &sd,
-       const ScatterViewType &view,
+value( const PointDataType point_data[3], const SplineDataType& sd,
+       const ScatterViewType& view,
        typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                               void *>::type = 0 )
+                               void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::value requires spline weight values" );
@@ -335,8 +335,8 @@ value( const PointDataType point_data[3], const SplineDataType &sd,
 */
 template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
-                                      const SplineDataType &sd,
-                                      const ScatterViewType &view )
+                                      const SplineDataType& sd,
+                                      const ScatterViewType& view )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::gradient requires spline weight values" );
@@ -376,10 +376,10 @@ KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
 */
 template <class PointDataType, class ScatterViewType, class SplineDataType>
 KOKKOS_INLINE_FUNCTION void
-divergence( const PointDataType point_data[3], const SplineDataType &sd,
-            const ScatterViewType &view,
+divergence( const PointDataType point_data[3], const SplineDataType& sd,
+            const ScatterViewType& view,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                                    void *>::type = 0 )
+                                    void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::divergence requires spline weight values" );
@@ -420,10 +420,10 @@ divergence( const PointDataType point_data[3], const SplineDataType &sd,
 */
 template <class ScatterViewType, class SplineDataType, class PointDataType>
 KOKKOS_INLINE_FUNCTION void
-divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
-            const ScatterViewType &view,
+divergence( const PointDataType point_data[3][3], const SplineDataType& sd,
+            const ScatterViewType& view,
             typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
-                                    void *>::type = 0 )
+                                    void*>::type = 0 )
 {
     static_assert( SplineDataType::has_weight_values,
                    "P2G::divergence requires spline weight values" );
@@ -442,7 +442,7 @@ divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
                 typename SplineDataType::scalar_type rg[3] = {
                     sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
                     sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k] };
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
 
                 for ( int d1 = 0; d1 < 3; ++d1 )
                 {
@@ -508,10 +508,10 @@ template <class PointEvalFunctor, class PointCoordinates, class ArrayScalar,
           class MeshScalar, class EntityType, int SplineOrder, class DeviceType,
           class... ArrayParams>
 void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
-                      ArrayParams...> &array,
-          const Halo<DeviceType> &halo, const PointCoordinates &points,
+                      ArrayParams...>& array,
+          const Halo<DeviceType>& halo, const PointCoordinates& points,
           const std::size_t num_point, Spline<SplineOrder>,
-          const PointEvalFunctor &functor )
+          const PointEvalFunctor& functor )
 {
     using array_type =
         Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
@@ -536,8 +536,8 @@ void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
         "g2p", Kokkos::RangePolicy<execution_space>( 0, num_point ),
         KOKKOS_LAMBDA( const int p ) {
             // Get the point coordinates.
-            MeshScalar px[3] = { points( p, Dim::I ), points( p, Dim::J ),
-                                 points( p, Dim::K ) };
+            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
+                                points( p, Dim::K )};
 
             // Create the local spline data.
             using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;
@@ -566,7 +566,7 @@ struct ScalarValueG2P
     ViewType _x;
     value_type _multiplier;
 
-    ScalarValueG2P( const ViewType &x, const value_type multiplier )
+    ScalarValueG2P( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -574,9 +574,9 @@ struct ScalarValueG2P
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type result;
         G2P::value( view, sd, result );
@@ -586,8 +586,8 @@ struct ScalarValueG2P
 
 template <class ViewType>
 ScalarValueG2P<ViewType>
-createScalarValueG2P( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
+createScalarValueG2P( const ViewType& x,
+                      const typename ViewType::value_type& multiplier )
 {
     return ScalarValueG2P<ViewType>( x, multiplier );
 }
@@ -609,7 +609,7 @@ struct VectorValueG2P
     ViewType _x;
     value_type _multiplier;
 
-    VectorValueG2P( const ViewType &x, const value_type multiplier )
+    VectorValueG2P( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -617,9 +617,9 @@ struct VectorValueG2P
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type result[3];
         G2P::value( view, sd, result );
@@ -630,8 +630,8 @@ struct VectorValueG2P
 
 template <class ViewType>
 VectorValueG2P<ViewType>
-createVectorValueG2P( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
+createVectorValueG2P( const ViewType& x,
+                      const typename ViewType::value_type& multiplier )
 {
     return VectorValueG2P<ViewType>( x, multiplier );
 }
@@ -653,7 +653,7 @@ struct ScalarGradientG2P
     ViewType _x;
     value_type _multiplier;
 
-    ScalarGradientG2P( const ViewType &x, const value_type multiplier )
+    ScalarGradientG2P( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -661,9 +661,9 @@ struct ScalarGradientG2P
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type result[3];
         G2P::gradient( view, sd, result );
@@ -674,8 +674,8 @@ struct ScalarGradientG2P
 
 template <class ViewType>
 ScalarGradientG2P<ViewType>
-createScalarGradientG2P( const ViewType &x,
-                         const typename ViewType::value_type &multiplier )
+createScalarGradientG2P( const ViewType& x,
+                         const typename ViewType::value_type& multiplier )
 {
     return ScalarGradientG2P<ViewType>( x, multiplier );
 }
@@ -697,7 +697,7 @@ struct VectorGradientG2P
     ViewType _x;
     value_type _multiplier;
 
-    VectorGradientG2P( const ViewType &x, const value_type multiplier )
+    VectorGradientG2P( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -705,9 +705,9 @@ struct VectorGradientG2P
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type result[3][3];
         G2P::gradient( view, sd, result );
@@ -719,8 +719,8 @@ struct VectorGradientG2P
 
 template <class ViewType>
 VectorGradientG2P<ViewType>
-createVectorGradientG2P( const ViewType &x,
-                         const typename ViewType::value_type &multiplier )
+createVectorGradientG2P( const ViewType& x,
+                         const typename ViewType::value_type& multiplier )
 {
     return VectorGradientG2P<ViewType>( x, multiplier );
 }
@@ -742,7 +742,7 @@ struct VectorDivergenceG2P
     ViewType _x;
     value_type _multiplier;
 
-    VectorDivergenceG2P( const ViewType &x, const value_type multiplier )
+    VectorDivergenceG2P( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -750,9 +750,9 @@ struct VectorDivergenceG2P
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type result;
         G2P::divergence( view, sd, result );
@@ -762,8 +762,8 @@ struct VectorDivergenceG2P
 
 template <class ViewType>
 VectorDivergenceG2P<ViewType>
-createVectorDivergenceG2P( const ViewType &x,
-                           const typename ViewType::value_type &multiplier )
+createVectorDivergenceG2P( const ViewType& x,
+                           const typename ViewType::value_type& multiplier )
 {
     return VectorDivergenceG2P<ViewType>( x, multiplier );
 }
@@ -813,11 +813,11 @@ createVectorDivergenceG2P( const ViewType &x,
 template <class PointEvalFunctor, class PointCoordinates, class ArrayScalar,
           class MeshScalar, class EntityType, int SplineOrder, class DeviceType,
           class... ArrayParams>
-void p2g( const PointEvalFunctor &functor, const PointCoordinates &points,
+void p2g( const PointEvalFunctor& functor, const PointCoordinates& points,
           const std::size_t num_point, Spline<SplineOrder>,
-          const Halo<DeviceType> &halo,
+          const Halo<DeviceType>& halo,
           Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
-                ArrayParams...> &array )
+                ArrayParams...>& array )
 {
     using array_type =
         Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
@@ -840,8 +840,8 @@ void p2g( const PointEvalFunctor &functor, const PointCoordinates &points,
         "p2g", Kokkos::RangePolicy<execution_space>( 0, num_point ),
         KOKKOS_LAMBDA( const int p ) {
             // Get the point coordinates.
-            MeshScalar px[3] = { points( p, Dim::I ), points( p, Dim::J ),
-                                 points( p, Dim::K ) };
+            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
+                                points( p, Dim::K )};
 
             // Create the local spline data.
             using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;
@@ -875,7 +875,7 @@ struct ScalarValueP2G
     ViewType _x;
     value_type _multiplier;
 
-    ScalarValueP2G( const ViewType &x, const value_type multiplier )
+    ScalarValueP2G( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -883,9 +883,9 @@ struct ScalarValueP2G
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type point_data = _x( p ) * _multiplier;
         P2G::value( point_data, sd, view );
@@ -894,8 +894,8 @@ struct ScalarValueP2G
 
 template <class ViewType>
 ScalarValueP2G<ViewType>
-createScalarValueP2G( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
+createScalarValueP2G( const ViewType& x,
+                      const typename ViewType::value_type& multiplier )
 {
     return ScalarValueP2G<ViewType>( x, multiplier );
 }
@@ -917,7 +917,7 @@ struct VectorValueP2G
     ViewType _x;
     value_type _multiplier;
 
-    VectorValueP2G( const ViewType &x, const value_type multiplier )
+    VectorValueP2G( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -925,9 +925,9 @@ struct VectorValueP2G
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type point_data[3];
         for ( int d = 0; d < 3; ++d )
@@ -938,8 +938,8 @@ struct VectorValueP2G
 
 template <class ViewType>
 VectorValueP2G<ViewType>
-createVectorValueP2G( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
+createVectorValueP2G( const ViewType& x,
+                      const typename ViewType::value_type& multiplier )
 {
     return VectorValueP2G<ViewType>( x, multiplier );
 }
@@ -961,7 +961,7 @@ struct ScalarGradientP2G
     ViewType _x;
     value_type _multiplier;
 
-    ScalarGradientP2G( const ViewType &x, const value_type multiplier )
+    ScalarGradientP2G( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -969,9 +969,9 @@ struct ScalarGradientP2G
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type point_data = _x( p ) * _multiplier;
         P2G::gradient( point_data, sd, view );
@@ -980,8 +980,8 @@ struct ScalarGradientP2G
 
 template <class ViewType>
 ScalarGradientP2G<ViewType>
-createScalarGradientP2G( const ViewType &x,
-                         const typename ViewType::value_type &multiplier )
+createScalarGradientP2G( const ViewType& x,
+                         const typename ViewType::value_type& multiplier )
 {
     return ScalarGradientP2G<ViewType>( x, multiplier );
 }
@@ -1003,7 +1003,7 @@ struct VectorDivergenceP2G
     ViewType _x;
     value_type _multiplier;
 
-    VectorDivergenceP2G( const ViewType &x, const value_type multiplier )
+    VectorDivergenceP2G( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -1011,9 +1011,9 @@ struct VectorDivergenceP2G
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type point_data[3];
         for ( int d = 0; d < 3; ++d )
@@ -1024,8 +1024,8 @@ struct VectorDivergenceP2G
 
 template <class ViewType>
 VectorDivergenceP2G<ViewType>
-createVectorDivergenceP2G( const ViewType &x,
-                           const typename ViewType::value_type &multiplier )
+createVectorDivergenceP2G( const ViewType& x,
+                           const typename ViewType::value_type& multiplier )
 {
     return VectorDivergenceP2G<ViewType>( x, multiplier );
 }
@@ -1047,7 +1047,7 @@ struct TensorDivergenceP2G
     ViewType _x;
     value_type _multiplier;
 
-    TensorDivergenceP2G( const ViewType &x, const value_type multiplier )
+    TensorDivergenceP2G( const ViewType& x, const value_type multiplier )
         : _x( x )
         , _multiplier( multiplier )
     {
@@ -1055,9 +1055,9 @@ struct TensorDivergenceP2G
     }
 
     template <class SplineDataType, class GridViewType>
-    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType& sd,
                                             const int p,
-                                            const GridViewType &view ) const
+                                            const GridViewType& view ) const
     {
         value_type point_data[3][3];
         for ( int d0 = 0; d0 < 3; ++d0 )
@@ -1069,8 +1069,8 @@ struct TensorDivergenceP2G
 
 template <class ViewType>
 TensorDivergenceP2G<ViewType>
-createTensorDivergenceP2G( const ViewType &x,
-                           const typename ViewType::value_type &multiplier )
+createTensorDivergenceP2G( const ViewType& x,
+                           const typename ViewType::value_type& multiplier )
 {
     return TensorDivergenceP2G<ViewType>( x, multiplier );
 }

--- a/cajita/src/Cajita_LocalGrid.cpp
+++ b/cajita/src/Cajita_LocalGrid.cpp
@@ -138,10 +138,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Own, Cell, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Cell(), Local() );
@@ -210,10 +210,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Ghost, Cell, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Cell(), Local() );
@@ -341,10 +341,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Own, Node, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Node(), Local() );
@@ -413,10 +413,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Ghost, Node, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Node(), Local() );
@@ -851,10 +851,10 @@ LocalGrid<MeshType>::faceSharedIndexSpace( Own, Face<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Face<Dir>(), Local() );
@@ -925,10 +925,10 @@ LocalGrid<MeshType>::faceSharedIndexSpace( Ghost, Face<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Face<Dir>(), Local() );
@@ -1082,10 +1082,10 @@ LocalGrid<MeshType>::edgeSharedIndexSpace( Own, Edge<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );
@@ -1156,10 +1156,10 @@ LocalGrid<MeshType>::edgeSharedIndexSpace( Ghost, Edge<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
 
     // Wrap the indices.
-    std::array<long, 3> nid = {off_i, off_j, off_k};
+    std::array<long, 3> nid = { off_i, off_j, off_k };
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );

--- a/cajita/src/Cajita_LocalGrid.cpp
+++ b/cajita/src/Cajita_LocalGrid.cpp
@@ -17,7 +17,7 @@ namespace Cajita
 // Constructor.
 template <class MeshType>
 LocalGrid<MeshType>::LocalGrid(
-    const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+    const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
     const int halo_cell_width )
     : _global_grid( global_grid )
     , _halo_cell_width( halo_cell_width )
@@ -27,7 +27,7 @@ LocalGrid<MeshType>::LocalGrid(
 //---------------------------------------------------------------------------//
 // Get the global grid that owns the local grid.
 template <class MeshType>
-const GlobalGrid<MeshType> &LocalGrid<MeshType>::globalGrid() const
+const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
 {
     return *_global_grid;
 }
@@ -138,10 +138,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Own, Cell, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Cell(), Local() );
@@ -210,10 +210,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Ghost, Cell, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Cell(), Local() );
@@ -341,10 +341,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Own, Node, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Node(), Local() );
@@ -413,10 +413,10 @@ LocalGrid<MeshType>::sharedIndexSpace( Ghost, Node, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Node(), Local() );
@@ -851,10 +851,10 @@ LocalGrid<MeshType>::faceSharedIndexSpace( Own, Face<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Face<Dir>(), Local() );
@@ -925,10 +925,10 @@ LocalGrid<MeshType>::faceSharedIndexSpace( Ghost, Face<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Face<Dir>(), Local() );
@@ -1082,10 +1082,10 @@ LocalGrid<MeshType>::edgeSharedIndexSpace( Own, Edge<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );
@@ -1156,10 +1156,10 @@ LocalGrid<MeshType>::edgeSharedIndexSpace( Ghost, Edge<Dir>, const int off_i,
     // Check to see if this is a valid neighbor. If not, return a shared space
     // of size 0.
     if ( neighborRank( off_i, off_j, off_k ) < 0 )
-        return IndexSpace<3>( { 0, 0, 0 }, { 0, 0, 0 } );
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
 
     // Wrap the indices.
-    std::array<long, 3> nid = { off_i, off_j, off_k };
+    std::array<long, 3> nid = {off_i, off_j, off_k};
 
     // Get the owned local index space.
     auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -38,11 +38,11 @@ class LocalGrid
       \param halo_cell_width The number of halo cells surrounding the locally
       owned cells.
     */
-    LocalGrid( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+    LocalGrid( const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
                const int halo_cell_width );
 
     // Get the global grid that owns the local grid.
-    const GlobalGrid<MeshType> &globalGrid() const;
+    const GlobalGrid<MeshType>& globalGrid() const;
 
     // Get the number of cells in the halo.
     int haloCellWidth() const;
@@ -237,7 +237,7 @@ class LocalGrid
 */
 template <class MeshType>
 std::shared_ptr<LocalGrid<MeshType>>
-createLocalGrid( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+createLocalGrid( const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
                  const int halo_cell_width )
 {
     return std::make_shared<LocalGrid<MeshType>>( global_grid,

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -42,10 +42,10 @@ class LocalMesh<Device, UniformMesh<Scalar>>
     using execution_space = typename Device::execution_space;
 
     // Constructor.
-    LocalMesh( const LocalGrid<UniformMesh<Scalar>> &local_grid )
+    LocalMesh( const LocalGrid<UniformMesh<Scalar>>& local_grid )
     {
-        const auto &global_grid = local_grid.globalGrid();
-        const auto &global_mesh = global_grid.globalMesh();
+        const auto& global_grid = local_grid.globalGrid();
+        const auto& global_mesh = global_grid.globalMesh();
 
         // Get the cell size.
         for ( int d = 0; d < 3; ++d )
@@ -222,10 +222,10 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
     using execution_space = typename Device::execution_space;
 
     // Constructor.
-    LocalMesh( const LocalGrid<NonUniformMesh<Scalar>> &local_grid )
+    LocalMesh( const LocalGrid<NonUniformMesh<Scalar>>& local_grid )
     {
-        const auto &global_grid = local_grid.globalGrid();
-        const auto &global_mesh = global_grid.globalMesh();
+        const auto& global_grid = local_grid.globalGrid();
+        const auto& global_mesh = global_grid.globalMesh();
 
         // Compute the owned low corner.
         for ( int d = 0; d < 3; ++d )
@@ -297,9 +297,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
         for ( int d = 0; d < 3; ++d )
         {
             // Allocate edges on the device for this dimension.
-            const auto &global_edge = global_mesh.nonUniformEdge( d );
+            const auto& global_edge = global_mesh.nonUniformEdge( d );
             int nedge = ghosted_nodes_local.extent( d );
-            _local_edges[d] = Kokkos::View<Scalar *, Device>(
+            _local_edges[d] = Kokkos::View<Scalar*, Device>(
                 Kokkos::ViewAllocateWithoutInitializing( "local_edges" ),
                 nedge );
 
@@ -476,14 +476,14 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
     Kokkos::Array<Scalar, 3> _own_high_corner;
     Kokkos::Array<Scalar, 3> _ghost_low_corner;
     Kokkos::Array<Scalar, 3> _ghost_high_corner;
-    Kokkos::Array<Kokkos::View<Scalar *, Device>, 3> _local_edges;
+    Kokkos::Array<Kokkos::View<Scalar*, Device>, 3> _local_edges;
 };
 
 //---------------------------------------------------------------------------//
 // Creation function.
 template <class Device, class MeshType>
 LocalMesh<Device, MeshType>
-createLocalMesh( const LocalGrid<MeshType> &local_grid )
+createLocalMesh( const LocalGrid<MeshType>& local_grid )
 {
     return LocalMesh<Device, MeshType>( local_grid );
 }

--- a/cajita/src/Cajita_ManualPartitioner.cpp
+++ b/cajita/src/Cajita_ManualPartitioner.cpp
@@ -14,7 +14,7 @@
 namespace Cajita
 {
 //---------------------------------------------------------------------------//
-ManualPartitioner::ManualPartitioner( const std::array<int, 3> &ranks_per_dim )
+ManualPartitioner::ManualPartitioner( const std::array<int, 3>& ranks_per_dim )
     : _ranks_per_dim( ranks_per_dim )
 {
 }
@@ -22,7 +22,7 @@ ManualPartitioner::ManualPartitioner( const std::array<int, 3> &ranks_per_dim )
 //---------------------------------------------------------------------------//
 std::array<int, 3>
 ManualPartitioner::ranksPerDimension( MPI_Comm,
-                                      const std::array<int, 3> & ) const
+                                      const std::array<int, 3>& ) const
 {
     return _ranks_per_dim;
 }

--- a/cajita/src/Cajita_ManualPartitioner.hpp
+++ b/cajita/src/Cajita_ManualPartitioner.hpp
@@ -24,11 +24,11 @@ namespace Cajita
 class ManualPartitioner : public Partitioner
 {
   public:
-    ManualPartitioner( const std::array<int, 3> &ranks_per_dim );
+    ManualPartitioner( const std::array<int, 3>& ranks_per_dim );
 
     std::array<int, 3> ranksPerDimension(
         MPI_Comm comm,
-        const std::array<int, 3> &global_cells_per_dim ) const override;
+        const std::array<int, 3>& global_cells_per_dim ) const override;
 
   private:
     std::array<int, 3> _ranks_per_dim;

--- a/cajita/src/Cajita_Parallel.hpp
+++ b/cajita/src/Cajita_Parallel.hpp
@@ -41,10 +41,10 @@ namespace Cajita
   \param functor The functor to execute.
  */
 template <class FunctorType, class ExecutionSpace, long N>
-inline void grid_parallel_for( const std::string &label,
-                               const ExecutionSpace &exec_space,
-                               const IndexSpace<N> &index_space,
-                               const FunctorType &functor )
+inline void grid_parallel_for( const std::string& label,
+                               const ExecutionSpace& exec_space,
+                               const IndexSpace<N>& index_space,
+                               const FunctorType& functor )
 {
     Kokkos::parallel_for(
         label, createExecutionPolicy( index_space, exec_space ), functor );
@@ -75,9 +75,9 @@ inline void grid_parallel_for( const std::string &label,
  */
 template <class FunctorType, class WorkTag, class ExecutionSpace, long N>
 inline void
-grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
-                   const IndexSpace<N> &index_space, const WorkTag &work_tag,
-                   const FunctorType &functor )
+grid_parallel_for( const std::string& label, const ExecutionSpace& exec_space,
+                   const IndexSpace<N>& index_space, const WorkTag& work_tag,
+                   const FunctorType& functor )
 {
     Kokkos::parallel_for(
         label, createExecutionPolicy( index_space, exec_space, work_tag ),
@@ -109,10 +109,10 @@ grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
 template <class FunctorType, class ExecutionSpace, class MeshType,
           class DecompositionType, class EntityType>
 inline void
-grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
-                   const LocalGrid<MeshType> &local_grid,
-                   const DecompositionType &decomposition,
-                   const EntityType &entity_type, const FunctorType &functor )
+grid_parallel_for( const std::string& label, const ExecutionSpace& exec_space,
+                   const LocalGrid<MeshType>& local_grid,
+                   const DecompositionType& decomposition,
+                   const EntityType& entity_type, const FunctorType& functor )
 {
     auto index_space =
         local_grid.indexSpace( decomposition, entity_type, Local() );
@@ -146,11 +146,11 @@ grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
 template <class FunctorType, class WorkTag, class ExecutionSpace,
           class MeshType, class DecompositionType, class EntityType>
 inline void
-grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
-                   const LocalGrid<MeshType> &local_grid,
-                   const DecompositionType &decomposition,
-                   const EntityType &entity_type, const WorkTag &work_tag,
-                   const FunctorType &functor )
+grid_parallel_for( const std::string& label, const ExecutionSpace& exec_space,
+                   const LocalGrid<MeshType>& local_grid,
+                   const DecompositionType& decomposition,
+                   const EntityType& entity_type, const WorkTag& work_tag,
+                   const FunctorType& functor )
 {
     auto index_space =
         local_grid.indexSpace( decomposition, entity_type, Local() );
@@ -183,11 +183,11 @@ grid_parallel_for( const std::string &label, const ExecutionSpace &exec_space,
   \param reducer The parallel reduce result.
  */
 template <class FunctorType, class ExecutionSpace, long N, class ReduceType>
-inline void grid_parallel_reduce( const std::string &label,
-                                  const ExecutionSpace &exec_space,
-                                  const IndexSpace<N> &index_space,
-                                  const FunctorType &functor,
-                                  ReduceType &reducer )
+inline void grid_parallel_reduce( const std::string& label,
+                                  const ExecutionSpace& exec_space,
+                                  const IndexSpace<N>& index_space,
+                                  const FunctorType& functor,
+                                  ReduceType& reducer )
 {
     Kokkos::parallel_reduce( label,
                              createExecutionPolicy( index_space, exec_space ),
@@ -224,10 +224,10 @@ inline void grid_parallel_reduce( const std::string &label,
 template <class FunctorType, class WorkTag, class ExecutionSpace, long N,
           class ReduceType>
 inline void
-grid_parallel_reduce( const std::string &label,
-                      const ExecutionSpace &exec_space,
-                      const IndexSpace<N> &index_space, const WorkTag &work_tag,
-                      const FunctorType &functor, ReduceType &reducer )
+grid_parallel_reduce( const std::string& label,
+                      const ExecutionSpace& exec_space,
+                      const IndexSpace<N>& index_space, const WorkTag& work_tag,
+                      const FunctorType& functor, ReduceType& reducer )
 {
     Kokkos::parallel_reduce(
         label, createExecutionPolicy( index_space, exec_space, work_tag ),
@@ -262,13 +262,13 @@ grid_parallel_reduce( const std::string &label,
  */
 template <class FunctorType, class ExecutionSpace, class MeshType,
           class DecompositionType, class EntityType, class ReduceType>
-inline void grid_parallel_reduce( const std::string &label,
-                                  const ExecutionSpace &exec_space,
-                                  const LocalGrid<MeshType> &local_grid,
-                                  const DecompositionType &decomposition,
-                                  const EntityType &entity_type,
-                                  const FunctorType &functor,
-                                  ReduceType &reducer )
+inline void grid_parallel_reduce( const std::string& label,
+                                  const ExecutionSpace& exec_space,
+                                  const LocalGrid<MeshType>& local_grid,
+                                  const DecompositionType& decomposition,
+                                  const EntityType& entity_type,
+                                  const FunctorType& functor,
+                                  ReduceType& reducer )
 {
     auto index_space =
         local_grid.indexSpace( decomposition, entity_type, Local() );
@@ -307,10 +307,10 @@ template <class FunctorType, class WorkTag, class ExecutionSpace,
           class MeshType, class DecompositionType, class EntityType,
           class ReduceType>
 inline void grid_parallel_reduce(
-    const std::string &label, const ExecutionSpace &exec_space,
-    const LocalGrid<MeshType> &local_grid,
-    const DecompositionType &decomposition, const EntityType &entity_type,
-    const WorkTag &work_tag, const FunctorType &functor, ReduceType &reducer )
+    const std::string& label, const ExecutionSpace& exec_space,
+    const LocalGrid<MeshType>& local_grid,
+    const DecompositionType& decomposition, const EntityType& entity_type,
+    const WorkTag& work_tag, const FunctorType& functor, ReduceType& reducer )
 {
     auto index_space =
         local_grid.indexSpace( decomposition, entity_type, Local() );

--- a/cajita/src/Cajita_ParameterPack.hpp
+++ b/cajita/src/Cajita_ParameterPack.hpp
@@ -108,10 +108,10 @@ struct is_parameter_pack
 template <std::size_t N, class ParameterPack_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_parameter_pack<ParameterPack_t>::value,
-    typename ParameterPack_t::template value_type<N> &>::type
-get( ParameterPack_t &pp )
+    typename ParameterPack_t::template value_type<N>&>::type
+get( ParameterPack_t& pp )
 {
-    return static_cast<typename ParameterPack_t::template element_type<N> &>(
+    return static_cast<typename ParameterPack_t::template element_type<N>&>(
                pp )
         ._m;
 }
@@ -119,11 +119,11 @@ get( ParameterPack_t &pp )
 template <std::size_t N, class ParameterPack_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_parameter_pack<ParameterPack_t>::value,
-    const typename ParameterPack_t::template value_type<N> &>::type
-get( const ParameterPack_t &pp )
+    const typename ParameterPack_t::template value_type<N>&>::type
+get( const ParameterPack_t& pp )
 {
     return static_cast<
-               const typename ParameterPack_t::template element_type<N> &>( pp )
+               const typename ParameterPack_t::template element_type<N>&>( pp )
         ._m;
 }
 
@@ -131,18 +131,18 @@ get( const ParameterPack_t &pp )
 // Fill a parameter pack. Note the indexing is such that the Nth element of a
 // parameter pack is the Nth element of the tuple.
 template <typename ParameterPack_t, typename T, typename... Types>
-void fillParameterPackImpl( ParameterPack_t &pp,
+void fillParameterPackImpl( ParameterPack_t& pp,
                             const std::integral_constant<std::size_t, 0>,
-                            const T &t, const Types &... )
+                            const T& t, const Types&... )
 {
     get<ParameterPack_t::size - 1>( pp ) = t;
 }
 
 template <typename ParameterPack_t, std::size_t N, typename T,
           typename... Types>
-void fillParameterPackImpl( ParameterPack_t &pp,
+void fillParameterPackImpl( ParameterPack_t& pp,
                             const std::integral_constant<std::size_t, N>,
-                            const T &t, const Types &... ts )
+                            const T& t, const Types&... ts )
 {
     get<ParameterPack_t::size - 1 - N>( pp ) = t;
     fillParameterPackImpl( pp, std::integral_constant<std::size_t, N - 1>(),
@@ -150,7 +150,7 @@ void fillParameterPackImpl( ParameterPack_t &pp,
 }
 
 template <typename ParameterPack_t, typename... Types>
-void fillParameterPack( ParameterPack_t &pp, const Types &... ts )
+void fillParameterPack( ParameterPack_t& pp, const Types&... ts )
 {
     fillParameterPackImpl(
         pp, std::integral_constant<std::size_t, ParameterPack_t::size - 1>(),
@@ -159,14 +159,14 @@ void fillParameterPack( ParameterPack_t &pp, const Types &... ts )
 
 // Empty case.
 template <typename ParameterPack_t>
-void fillParameterPack( ParameterPack_t & )
+void fillParameterPack( ParameterPack_t& )
 {
 }
 
 //---------------------------------------------------------------------------//
 // Create a parameter pack.
 template <typename... Types>
-ParameterPack<Types...> makeParameterPack( const Types &... ts )
+ParameterPack<Types...> makeParameterPack( const Types&... ts )
 {
     ParameterPack<Types...> pp;
     fillParameterPack( pp, ts... );

--- a/cajita/src/Cajita_Partitioner.hpp
+++ b/cajita/src/Cajita_Partitioner.hpp
@@ -32,7 +32,7 @@ class Partitioner
     */
     virtual std::array<int, 3> ranksPerDimension(
         MPI_Comm comm,
-        const std::array<int, 3> &global_cells_per_dim ) const = 0;
+        const std::array<int, 3>& global_cells_per_dim ) const = 0;
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_ReferenceStructuredSolver.hpp
+++ b/cajita/src/Cajita_ReferenceStructuredSolver.hpp
@@ -58,7 +58,7 @@ class ReferenceStructuredSolver
       component if this is true.
     */
     virtual void
-    setMatrixStencil( const std::vector<std::array<int, 3>> &stencil,
+    setMatrixStencil( const std::vector<std::array<int, 3>>& stencil,
                       const bool is_symmetric ) = 0;
 
     /*!
@@ -70,7 +70,7 @@ class ReferenceStructuredSolver
       corresponding to stencil entries outside of the domain should be set to
       zero.
     */
-    virtual const Array_t &getMatrixValues() = 0;
+    virtual const Array_t& getMatrixValues() = 0;
 
     /*!
       \brief Set the preconditioner stencil.
@@ -81,7 +81,7 @@ class ReferenceStructuredSolver
       symmetric component if this is true.
     */
     virtual void
-    setPreconditionerStencil( const std::vector<std::array<int, 3>> &stencil,
+    setPreconditionerStencil( const std::vector<std::array<int, 3>>& stencil,
                               const bool is_symmetric ) = 0;
 
     /*!
@@ -93,7 +93,7 @@ class ReferenceStructuredSolver
       corresponding to stencil entries outside of the domain should be set to
       zero.
     */
-    virtual const Array_t &getPreconditionerValues() = 0;
+    virtual const Array_t& getPreconditionerValues() = 0;
 
     // Set convergence tolerance implementation.
     virtual void setTolerance( const double tol ) = 0;
@@ -112,7 +112,7 @@ class ReferenceStructuredSolver
       \param b The forcing term.
       \param x The solution.
     */
-    virtual void solve( const Array_t &b, Array_t &x ) = 0;
+    virtual void solve( const Array_t& b, Array_t& x ) = 0;
 
     // Get the number of iterations taken on the last solve.
     virtual int getNumIter() = 0;
@@ -142,15 +142,15 @@ class ReferenceConjugateGradient
     {
         using value_type = ScalarT;
         using memory_space = MemorySpaceT;
-        const ArrayLayoutT &array_layout;
-        const ArrayLayoutT *layout() const { return &array_layout; }
+        const ArrayLayoutT& array_layout;
+        const ArrayLayoutT* layout() const { return &array_layout; }
     };
 
     /*!
       \brief Constructor.
     */
     ReferenceConjugateGradient(
-        const ArrayLayout<EntityType, MeshType> &layout )
+        const ArrayLayout<EntityType, MeshType>& layout )
         : _tol( 1.0e-6 )
         , _max_iter( 1000 )
         , _print_level( 0 )
@@ -172,7 +172,7 @@ class ReferenceConjugateGradient
       stencil entries should only contain one entry from each symmetric
       component if this is true.
     */
-    void setMatrixStencil( const std::vector<std::array<int, 3>> &stencil,
+    void setMatrixStencil( const std::vector<std::array<int, 3>>& stencil,
                            const bool is_symmetric = false ) override
     {
         setStencil( stencil, is_symmetric, _A_stencil, _A_halo, _A );
@@ -186,7 +186,7 @@ class ReferenceConjugateGradient
       stencil definition. Note that values corresponding to stencil entries
       outside of the domain should be set to zero.
     */
-    const Array_t &getMatrixValues() override { return *_A; }
+    const Array_t& getMatrixValues() override { return *_A; }
 
     /*!
       \brief Set the preconditioner stencil.
@@ -197,7 +197,7 @@ class ReferenceConjugateGradient
       symmetric component if this is true.
     */
     void
-    setPreconditionerStencil( const std::vector<std::array<int, 3>> &stencil,
+    setPreconditionerStencil( const std::vector<std::array<int, 3>>& stencil,
                               const bool is_symmetric = false ) override
     {
         setStencil( stencil, is_symmetric, _M_stencil, _M_halo, _M );
@@ -211,7 +211,7 @@ class ReferenceConjugateGradient
       stencil definition. Note that values corresponding to stencil entries
       outside of the domain should be set to zero.
     */
-    const Array_t &getPreconditionerValues() override { return *_M; }
+    const Array_t& getPreconditionerValues() override { return *_M; }
 
     // Set convergence tolerance implementation.
     void setTolerance( const double tol ) override { _tol = tol; }
@@ -233,7 +233,7 @@ class ReferenceConjugateGradient
       \param b The forcing term.
       \param x The solution.
     */
-    void solve( const Array_t &b, Array_t &x ) override
+    void solve( const Array_t& b, Array_t& x ) override
     {
         // Get the local grid.
         auto local_grid = _vectors->layout()->localGrid();
@@ -288,7 +288,7 @@ class ReferenceConjugateGradient
             "compute_r0",
             createExecutionPolicy( entity_space, execution_space() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k,
-                           Scalar &result ) {
+                           Scalar& result ) {
                 // Compute the local contribution from matrix-vector
                 // multiplication. Note that we copied x into p for this
                 // operation to easily perform the gather. Only apply the
@@ -334,7 +334,7 @@ class ReferenceConjugateGradient
             "compute_z0",
             createExecutionPolicy( entity_space, execution_space() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k,
-                           Scalar &result ) {
+                           Scalar& result ) {
                 // Compute the local contribution from matrix-vector
                 // multiplication. Only apply the stencil entry if it is
                 // greater than 0.
@@ -368,7 +368,7 @@ class ReferenceConjugateGradient
             "compute_q0",
             createExecutionPolicy( entity_space, execution_space() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k,
-                           Scalar &result ) {
+                           Scalar& result ) {
                 // Compute the local contribution from matrix-vector
                 // multiplication. This computes the updated p vector
                 // in-line to avoid another kernel launch. Only apply the
@@ -410,7 +410,7 @@ class ReferenceConjugateGradient
                 "cg_kernel_1",
                 createExecutionPolicy( entity_space, execution_space() ),
                 KOKKOS_LAMBDA( const int i, const int j, const int k,
-                               Scalar &result ) {
+                               Scalar& result ) {
                     // Compute the local contribution from matrix-vector
                     // multiplication. This computes the updated q vector
                     // in-line to avoid another kernel launch. Only apply the
@@ -482,7 +482,7 @@ class ReferenceConjugateGradient
                 "cg_kernel_2",
                 createExecutionPolicy( entity_space, execution_space() ),
                 KOKKOS_LAMBDA( const int i, const int j, const int k,
-                               Scalar &result ) {
+                               Scalar& result ) {
                     // Compute the local contribution from matrix-vector
                     // multiplication. This computes the updated p vector
                     // in-line to avoid another kernel launch. Only apply the
@@ -544,11 +544,11 @@ class ReferenceConjugateGradient
 
   private:
     // Set the stencil of a matrix.
-    void setStencil( const std::vector<std::array<int, 3>> &stencil,
+    void setStencil( const std::vector<std::array<int, 3>>& stencil,
                      const bool is_symmetric,
-                     Kokkos::View<int *[3], DeviceType> &device_stencil,
-                     std::shared_ptr<Halo<memory_space>> &halo,
-                     std::shared_ptr<Array_t> &matrix )
+                     Kokkos::View<int* [3], DeviceType>& device_stencil,
+                     std::shared_ptr<Halo<memory_space>>& halo,
+                     std::shared_ptr<Array_t>& matrix )
     {
         // For now we don't support symmetry.
         if ( is_symmetric )
@@ -559,7 +559,7 @@ class ReferenceConjugateGradient
         auto local_grid = _vectors->layout()->localGrid();
 
         // Copy stencil to the device.
-        device_stencil = Kokkos::View<int *[3], DeviceType>(
+        device_stencil = Kokkos::View<int* [3], DeviceType>(
             Kokkos::ViewAllocateWithoutInitializing( "stencil" ),
             stencil.size() );
         auto stencil_mirror =
@@ -611,8 +611,8 @@ class ReferenceConjugateGradient
     int _num_iter;
     Scalar _residual_norm;
     int _diag_entry;
-    Kokkos::View<int *[3], DeviceType> _A_stencil;
-    Kokkos::View<int *[3], DeviceType> _M_stencil;
+    Kokkos::View<int* [3], DeviceType> _A_stencil;
+    Kokkos::View<int* [3], DeviceType> _M_stencil;
     std::shared_ptr<Halo<memory_space>> _A_halo;
     std::shared_ptr<Halo<memory_space>> _M_halo;
     std::shared_ptr<Array_t> _A;
@@ -627,7 +627,7 @@ template <class Scalar, class DeviceType, class EntityType, class MeshType>
 std::shared_ptr<
     ReferenceConjugateGradient<Scalar, EntityType, MeshType, DeviceType>>
 createReferenceConjugateGradient(
-    const ArrayLayout<EntityType, MeshType> &layout )
+    const ArrayLayout<EntityType, MeshType>& layout )
 {
     return std::make_shared<
         ReferenceConjugateGradient<Scalar, EntityType, MeshType, DeviceType>>(

--- a/cajita/src/Cajita_Splines.hpp
+++ b/cajita/src/Cajita_Splines.hpp
@@ -601,7 +601,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     SplineData<Scalar, Order, EntityType, DataTags>::has_physical_cell_size>
 setSplineData( SplinePhysicalCellSize,
-               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               SplineData<Scalar, Order, EntityType, DataTags>& data,
                const int d, const Scalar dx )
 {
     data.dx[d] = dx;
@@ -611,7 +611,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     !SplineData<Scalar, Order, EntityType, DataTags>::has_physical_cell_size>
 setSplineData( SplinePhysicalCellSize,
-               SplineData<Scalar, Order, EntityType, DataTags> &, const int,
+               SplineData<Scalar, Order, EntityType, DataTags>&, const int,
                const Scalar )
 {
 }
@@ -621,7 +621,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     SplineData<Scalar, Order, EntityType, DataTags>::has_logical_position>
 setSplineData( SplineLogicalPosition,
-               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               SplineData<Scalar, Order, EntityType, DataTags>& data,
                const int d, const Scalar x )
 {
     data.x[d] = x;
@@ -631,7 +631,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     !SplineData<Scalar, Order, EntityType, DataTags>::has_logical_position>
 setSplineData( SplineLogicalPosition,
-               SplineData<Scalar, Order, EntityType, DataTags> &, const int,
+               SplineData<Scalar, Order, EntityType, DataTags>&, const int,
                const Scalar )
 {
 }
@@ -641,7 +641,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     SplineData<Scalar, Order, EntityType, DataTags>::has_weight_values>
 setSplineData( SplineWeightValues,
-               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               SplineData<Scalar, Order, EntityType, DataTags>& data,
                const Scalar x[3] )
 
 {
@@ -655,7 +655,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     !SplineData<Scalar, Order, EntityType, DataTags>::has_weight_values>
 setSplineData( SplineWeightValues,
-               SplineData<Scalar, Order, EntityType, DataTags> &,
+               SplineData<Scalar, Order, EntityType, DataTags>&,
                const Scalar[3] )
 
 {
@@ -667,7 +667,7 @@ KOKKOS_INLINE_FUNCTION
     std::enable_if_t<SplineData<Scalar, Order, EntityType,
                                 DataTags>::has_weight_physical_gradients>
     setSplineData( SplineWeightPhysicalGradients,
-                   SplineData<Scalar, Order, EntityType, DataTags> &data,
+                   SplineData<Scalar, Order, EntityType, DataTags>& data,
                    const Scalar x[3], const Scalar rdx[3] )
 
 {
@@ -682,7 +682,7 @@ KOKKOS_INLINE_FUNCTION
     std::enable_if_t<!SplineData<Scalar, Order, EntityType,
                                  DataTags>::has_weight_physical_gradients>
     setSplineData( SplineWeightPhysicalGradients,
-                   SplineData<Scalar, Order, EntityType, DataTags> &,
+                   SplineData<Scalar, Order, EntityType, DataTags>&,
                    const Scalar[3], const Scalar[3] )
 
 {
@@ -693,7 +693,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     SplineData<Scalar, Order, EntityType, DataTags>::has_physical_distance>
 setSplineData( SplinePhysicalDistance,
-               SplineData<Scalar, Order, EntityType, DataTags> &data,
+               SplineData<Scalar, Order, EntityType, DataTags>& data,
                const Scalar low_x[3], const Scalar p[3], const Scalar dx[3] )
 
 {
@@ -712,7 +712,7 @@ template <typename Scalar, int Order, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<
     !SplineData<Scalar, Order, EntityType, DataTags>::has_physical_distance>
 setSplineData( SplinePhysicalDistance,
-               SplineData<Scalar, Order, EntityType, DataTags> &,
+               SplineData<Scalar, Order, EntityType, DataTags>&,
                const Scalar[3], const Scalar[3], const Scalar[3] )
 {
 }
@@ -722,9 +722,9 @@ setSplineData( SplinePhysicalDistance,
 template <typename Scalar, int Order, class Device, class EntityType,
           class DataTags>
 KOKKOS_INLINE_FUNCTION void
-evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
+evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>>& local_mesh,
                 const Scalar p[3],
-                SplineData<Scalar, Order, EntityType, DataTags> &data )
+                SplineData<Scalar, Order, EntityType, DataTags>& data )
 {
     // data type
     using sd_type = SplineData<Scalar, Order, EntityType, DataTags>;
@@ -733,7 +733,7 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
 
     // Get the low corner of the mesh.
     Scalar low_x[3];
-    int low_id[3] = { 0, 0, 0 };
+    int low_id[3] = {0, 0, 0};
     local_mesh.coordinates( EntityType(), low_id, low_x );
 
     // Compute the physical cell size.

--- a/cajita/src/Cajita_Splines.hpp
+++ b/cajita/src/Cajita_Splines.hpp
@@ -733,7 +733,7 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>>& local_mesh,
 
     // Get the low corner of the mesh.
     Scalar low_x[3];
-    int low_id[3] = {0, 0, 0};
+    int low_id[3] = { 0, 0, 0 };
     local_mesh.coordinates( EntityType(), low_id, low_x );
 
     // Compute the physical cell size.

--- a/cajita/src/Cajita_UniformDimPartitioner.cpp
+++ b/cajita/src/Cajita_UniformDimPartitioner.cpp
@@ -21,7 +21,7 @@ UniformDimPartitioner::ranksPerDimension( MPI_Comm comm,
     int comm_size;
     MPI_Comm_size( comm, &comm_size );
 
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     return ranks_per_dim;

--- a/cajita/src/Cajita_UniformDimPartitioner.cpp
+++ b/cajita/src/Cajita_UniformDimPartitioner.cpp
@@ -16,12 +16,12 @@ namespace Cajita
 //---------------------------------------------------------------------------//
 std::array<int, 3>
 UniformDimPartitioner::ranksPerDimension( MPI_Comm comm,
-                                          const std::array<int, 3> & ) const
+                                          const std::array<int, 3>& ) const
 {
     int comm_size;
     MPI_Comm_size( comm, &comm_size );
 
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     return ranks_per_dim;

--- a/cajita/src/Cajita_UniformDimPartitioner.hpp
+++ b/cajita/src/Cajita_UniformDimPartitioner.hpp
@@ -26,7 +26,7 @@ class UniformDimPartitioner : public Partitioner
   public:
     std::array<int, 3> ranksPerDimension(
         MPI_Comm comm,
-        const std::array<int, 3> &global_cells_per_dim ) const override;
+        const std::array<int, 3>& global_cells_per_dim ) const override;
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstArray.hpp
+++ b/cajita/unit_test/tstArray.hpp
@@ -44,8 +44,7 @@ void layoutTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -195,8 +194,7 @@ void arrayTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -238,8 +236,7 @@ void arrayOpTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstArray.hpp
+++ b/cajita/unit_test/tstArray.hpp
@@ -38,13 +38,14 @@ void layoutTest()
 
     // Create the global .
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -188,13 +189,14 @@ void arrayTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -230,13 +232,14 @@ void arrayOpTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -275,7 +278,7 @@ void arrayOpTest()
                     EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
 
     // Scale each array component by a different value.
-    std::vector<double> scales = {2.3, 1.5, 8.9, -12.1};
+    std::vector<double> scales = { 2.3, 1.5, 8.9, -12.1 };
     ArrayOp::scale( *array, scales, Ghost() );
     Kokkos::deep_copy( host_view, array->view() );
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
@@ -341,8 +344,8 @@ void arrayOpTest()
                          fabs( 3.0 * scales[n] + 1.0 ) * total_num_node );
 
     // Compute the infinity-norm of the array components
-    std::vector<double> large_vals = {-1939304932.2, 20399994.532,
-                                      9098201010.114, -89877402343.99};
+    std::vector<double> large_vals = { -1939304932.2, 20399994.532,
+                                       9098201010.114, -89877402343.99 };
     for ( int n = 0; n < dofs_per_cell; ++n )
         host_view( 4, 4, 4, n ) = large_vals[n];
     Kokkos::deep_copy( array->view(), host_view );

--- a/cajita/unit_test/tstArray.hpp
+++ b/cajita/unit_test/tstArray.hpp
@@ -38,13 +38,13 @@ void layoutTest()
 
     // Create the global .
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -188,13 +188,13 @@ void arrayTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -230,13 +230,13 @@ void arrayOpTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -275,7 +275,7 @@ void arrayOpTest()
                     EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
 
     // Scale each array component by a different value.
-    std::vector<double> scales = { 2.3, 1.5, 8.9, -12.1 };
+    std::vector<double> scales = {2.3, 1.5, 8.9, -12.1};
     ArrayOp::scale( *array, scales, Ghost() );
     Kokkos::deep_copy( host_view, array->view() );
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
@@ -341,8 +341,8 @@ void arrayOpTest()
                          fabs( 3.0 * scales[n] + 1.0 ) * total_num_node );
 
     // Compute the infinity-norm of the array components
-    std::vector<double> large_vals = { -1939304932.2, 20399994.532,
-                                       9098201010.114, -89877402343.99 };
+    std::vector<double> large_vals = {-1939304932.2, 20399994.532,
+                                      9098201010.114, -89877402343.99};
     for ( int n = 0; n < dofs_per_cell; ++n )
         host_view( 4, 4, 4, n ) = large_vals[n];
     Kokkos::deep_copy( array->view(), host_view );

--- a/cajita/unit_test/tstBovWriter.hpp
+++ b/cajita/unit_test/tstBovWriter.hpp
@@ -43,8 +43,7 @@ void writeTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );

--- a/cajita/unit_test/tstBovWriter.hpp
+++ b/cajita/unit_test/tstBovWriter.hpp
@@ -38,13 +38,13 @@ void writeTest()
     // Create the global mesh.
     UniformDimPartitioner partitioner;
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 22, 19, 21 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {22, 19, 21};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -116,8 +116,7 @@ void writeTest()
                       i < global_grid->globalNumEntity( Cell(), Dim::I ); ++i )
                 {
                     cell_data_file.seekg( cell_id * sizeof( double ) );
-                    cell_data_file.read( (char *)&cell_value,
-                                         sizeof( double ) );
+                    cell_data_file.read( (char*)&cell_value, sizeof( double ) );
                     EXPECT_EQ( cell_value, i + j + k );
                     ++cell_id;
                 }
@@ -146,7 +145,7 @@ void writeTest()
                             ? 0
                             : i;
                     node_data_file.seekg( node_id * sizeof( int ) );
-                    node_data_file.read( (char *)&node_value, sizeof( int ) );
+                    node_data_file.read( (char*)&node_value, sizeof( int ) );
                     EXPECT_EQ( node_value, ival );
                     ++node_id;
 
@@ -155,7 +154,7 @@ void writeTest()
                             ? 0
                             : j;
                     node_data_file.seekg( node_id * sizeof( int ) );
-                    node_data_file.read( (char *)&node_value, sizeof( int ) );
+                    node_data_file.read( (char*)&node_value, sizeof( int ) );
                     EXPECT_EQ( node_value, jval );
                     ++node_id;
 
@@ -164,7 +163,7 @@ void writeTest()
                             ? 0
                             : k;
                     node_data_file.seekg( node_id * sizeof( int ) );
-                    node_data_file.read( (char *)&node_value, sizeof( int ) );
+                    node_data_file.read( (char*)&node_value, sizeof( int ) );
                     EXPECT_EQ( node_value, kval );
                     ++node_id;
                 }

--- a/cajita/unit_test/tstBovWriter.hpp
+++ b/cajita/unit_test/tstBovWriter.hpp
@@ -38,13 +38,14 @@ void writeTest()
     // Create the global mesh.
     UniformDimPartitioner partitioner;
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {22, 19, 21};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 22, 19, 21 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstFastFourierTransform.hpp
+++ b/cajita/unit_test/tstFastFourierTransform.hpp
@@ -48,9 +48,9 @@ void forwardReverseTest()
 {
     // Create the global mesh.
     double cell_size = 0.1;
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
-    std::array<double, 3> global_low_corner = {-1.0, -2.0, -1.0};
-    std::array<double, 3> global_high_corner = {1.0, 1.0, 0.5};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<double, 3> global_low_corner = { -1.0, -2.0, -1.0 };
+    std::array<double, 3> global_high_corner = { 1.0, 1.0, 0.5 };
     auto global_mesh = createUniformGlobalMesh( global_low_corner,
                                                 global_high_corner, cell_size );
 

--- a/cajita/unit_test/tstFastFourierTransform.hpp
+++ b/cajita/unit_test/tstFastFourierTransform.hpp
@@ -38,7 +38,7 @@ void memoryTest()
     fft_mem.memory_type = mtype;
     int size = 12;
     int nbytes = size * sizeof( double );
-    double *ptr = (double *)fft_mem.smalloc( nbytes, mtype );
+    double* ptr = (double*)fft_mem.smalloc( nbytes, mtype );
     EXPECT_NE( ptr, nullptr );
     fft_mem.sfree( ptr, mtype );
 }
@@ -48,9 +48,9 @@ void forwardReverseTest()
 {
     // Create the global mesh.
     double cell_size = 0.1;
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
-    std::array<double, 3> global_low_corner = { -1.0, -2.0, -1.0 };
-    std::array<double, 3> global_high_corner = { 1.0, 1.0, 0.5 };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {-1.0, -2.0, -1.0};
+    std::array<double, 3> global_high_corner = {1.0, 1.0, 0.5};
     auto global_mesh = createUniformGlobalMesh( global_low_corner,
                                                 global_high_corner, cell_size );
 

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -26,19 +26,19 @@ namespace Test
 {
 
 //---------------------------------------------------------------------------//
-void gridTest( const std::array<bool, 3> &is_dim_periodic )
+void gridTest( const std::array<bool, 3>& is_dim_periodic )
 {
     // Let MPI compute the partitioning for this test.
     UniformDimPartitioner partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -242,9 +242,9 @@ void gridTest( const std::array<bool, 3> &is_dim_periodic )
 //---------------------------------------------------------------------------//
 TEST( global_grid, grid_test )
 {
-    std::array<bool, 3> periodic = { true, true, true };
+    std::array<bool, 3> periodic = {true, true, true};
     gridTest( periodic );
-    std::array<bool, 3> not_periodic = { false, false, false };
+    std::array<bool, 3> not_periodic = {false, false, false};
     gridTest( not_periodic );
 }
 

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -33,12 +33,13 @@ void gridTest( const std::array<bool, 3>& is_dim_periodic )
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -242,9 +243,9 @@ void gridTest( const std::array<bool, 3>& is_dim_periodic )
 //---------------------------------------------------------------------------//
 TEST( global_grid, grid_test )
 {
-    std::array<bool, 3> periodic = {true, true, true};
+    std::array<bool, 3> periodic = { true, true, true };
     gridTest( periodic );
-    std::array<bool, 3> not_periodic = {false, false, false};
+    std::array<bool, 3> not_periodic = { false, false, false };
     gridTest( not_periodic );
 }
 

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -38,8 +38,7 @@ void gridTest( const std::array<bool, 3>& is_dim_periodic )
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstGlobalMesh.hpp
+++ b/cajita/unit_test/tstGlobalMesh.hpp
@@ -26,8 +26,8 @@ namespace Test
 // Test uniform mesh with cubic cells.
 void uniformTest1()
 {
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
     double cell_size = 0.05;
 
     auto global_mesh =
@@ -43,7 +43,7 @@ void uniformTest1()
         EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
                           global_mesh->extent( d ) );
 
-    std::array<int, 3> num_cell = {18, 188, 4};
+    std::array<int, 3> num_cell = { 18, 188, 4 };
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
 
@@ -55,9 +55,9 @@ void uniformTest1()
 // Test uniform mesh with number of cells constructor.
 void uniformTest2()
 {
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
-    std::array<int, 3> num_cell = {18, 188, 4};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
+    std::array<int, 3> num_cell = { 18, 188, 4 };
 
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, num_cell );
@@ -85,9 +85,9 @@ void uniformTest2()
 // dimension
 void uniformTest3()
 {
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
-    std::array<double, 3> cell_size = {0.05, 0.05, 0.05};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
+    std::array<double, 3> cell_size = { 0.05, 0.05, 0.05 };
 
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
@@ -102,7 +102,7 @@ void uniformTest3()
         EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
                           global_mesh->extent( d ) );
 
-    std::array<int, 3> num_cell = {18, 188, 4};
+    std::array<int, 3> num_cell = { 18, 188, 4 };
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
 
@@ -114,9 +114,9 @@ void uniformTest3()
 // test a non uniform mesh
 void nonUniformTest()
 {
-    std::vector<float> i_edge = {-0.3, 0.4, 1.1};
-    std::vector<float> j_edge = {3.3, 8.1, 9.5, 12.2};
-    std::vector<float> k_edge = {-1.1, -0.9, 0.4, 8.8, 19.3};
+    std::vector<float> i_edge = { -0.3, 0.4, 1.1 };
+    std::vector<float> j_edge = { 3.3, 8.1, 9.5, 12.2 };
+    std::vector<float> k_edge = { -1.1, -0.9, 0.4, 8.8, 19.3 };
 
     auto global_mesh = createNonUniformGlobalMesh( i_edge, j_edge, k_edge );
 

--- a/cajita/unit_test/tstGlobalMesh.hpp
+++ b/cajita/unit_test/tstGlobalMesh.hpp
@@ -26,8 +26,8 @@ namespace Test
 // Test uniform mesh with cubic cells.
 void uniformTest1()
 {
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
     double cell_size = 0.05;
 
     auto global_mesh =
@@ -43,7 +43,7 @@ void uniformTest1()
         EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
                           global_mesh->extent( d ) );
 
-    std::array<int, 3> num_cell = { 18, 188, 4 };
+    std::array<int, 3> num_cell = {18, 188, 4};
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
 
@@ -55,9 +55,9 @@ void uniformTest1()
 // Test uniform mesh with number of cells constructor.
 void uniformTest2()
 {
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
-    std::array<int, 3> num_cell = { 18, 188, 4 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
+    std::array<int, 3> num_cell = {18, 188, 4};
 
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, num_cell );
@@ -85,9 +85,9 @@ void uniformTest2()
 // dimension
 void uniformTest3()
 {
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
-    std::array<double, 3> cell_size = { 0.05, 0.05, 0.05 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 1.3};
+    std::array<double, 3> cell_size = {0.05, 0.05, 0.05};
 
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
@@ -102,7 +102,7 @@ void uniformTest3()
         EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
                           global_mesh->extent( d ) );
 
-    std::array<int, 3> num_cell = { 18, 188, 4 };
+    std::array<int, 3> num_cell = {18, 188, 4};
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
 
@@ -114,9 +114,9 @@ void uniformTest3()
 // test a non uniform mesh
 void nonUniformTest()
 {
-    std::vector<float> i_edge = { -0.3, 0.4, 1.1 };
-    std::vector<float> j_edge = { 3.3, 8.1, 9.5, 12.2 };
-    std::vector<float> k_edge = { -1.1, -0.9, 0.4, 8.8, 19.3 };
+    std::vector<float> i_edge = {-0.3, 0.4, 1.1};
+    std::vector<float> j_edge = {3.3, 8.1, 9.5, 12.2};
+    std::vector<float> k_edge = {-1.1, -0.9, 0.4, 8.8, 19.3};
 
     auto global_mesh = createNonUniformGlobalMesh( i_edge, j_edge, k_edge );
 
@@ -139,17 +139,17 @@ void nonUniformTest()
     EXPECT_EQ( 3, global_mesh->globalNumCell( Dim::J ) );
     EXPECT_EQ( 4, global_mesh->globalNumCell( Dim::K ) );
 
-    const auto &mesh_i = global_mesh->nonUniformEdge( Dim::I );
+    const auto& mesh_i = global_mesh->nonUniformEdge( Dim::I );
     int ni = mesh_i.size();
     for ( int i = 0; i < ni; ++i )
         EXPECT_FLOAT_EQ( i_edge[i], mesh_i[i] );
 
-    const auto &mesh_j = global_mesh->nonUniformEdge( Dim::J );
+    const auto& mesh_j = global_mesh->nonUniformEdge( Dim::J );
     int nj = mesh_j.size();
     for ( int j = 0; j < nj; ++j )
         EXPECT_FLOAT_EQ( j_edge[j], mesh_j[j] );
 
-    const auto &mesh_k = global_mesh->nonUniformEdge( Dim::K );
+    const auto& mesh_k = global_mesh->nonUniformEdge( Dim::K );
     int nk = mesh_k.size();
     for ( int k = 0; k < nk; ++k )
         EXPECT_FLOAT_EQ( k_edge[k], mesh_k[k] );

--- a/cajita/unit_test/tstHalo.hpp
+++ b/cajita/unit_test/tstHalo.hpp
@@ -144,8 +144,7 @@ void gatherScatterTest( const ManualPartitioner& partitioner,
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -346,8 +345,7 @@ void scatterReduceTest( const ReduceFunc& reduce )
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -373,10 +371,9 @@ void scatterReduceTest( const ReduceFunc& reduce )
     // eliminate overlap between neighbors and not need to resolve the
     // collision.
     HaloPattern pattern;
-    std::vector<std::array<int, 3>> neighbors = { { -1, -1, -1 }, { 1, -1, -1 },
-                                                  { -1, 1, -1 },  { 1, 1, -1 },
-                                                  { -1, -1, 1 },  { 1, -1, 1 },
-                                                  { -1, 1, 1 },   { 1, 1, 1 } };
+    std::vector<std::array<int, 3>> neighbors = {
+        { -1, -1, -1 }, { 1, -1, -1 }, { -1, 1, -1 }, { 1, 1, -1 },
+        { -1, -1, 1 },  { 1, -1, 1 },  { -1, 1, 1 },  { 1, 1, 1 } };
     pattern.setNeighbors( neighbors );
 
     // Create a halo.

--- a/cajita/unit_test/tstHalo.hpp
+++ b/cajita/unit_test/tstHalo.hpp
@@ -139,12 +139,13 @@ void gatherScatterTest( const ManualPartitioner& partitioner,
 {
     // Create the global grid.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {32, 23, 41};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 32, 23, 41 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -340,17 +341,18 @@ void scatterReduceTest( const ReduceFunc& reduce )
 {
     // Create the global grid.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {32, 23, 41};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 32, 23, 41 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
     // Create the global grid.
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_grid =
         createGlobalGrid( MPI_COMM_WORLD, global_mesh, is_dim_periodic,
                           Cajita::UniformDimPartitioner() );
@@ -371,9 +373,10 @@ void scatterReduceTest( const ReduceFunc& reduce )
     // eliminate overlap between neighbors and not need to resolve the
     // collision.
     HaloPattern pattern;
-    std::vector<std::array<int, 3>> neighbors = {
-        {-1, -1, -1}, {1, -1, -1}, {-1, 1, -1}, {1, 1, -1},
-        {-1, -1, 1},  {1, -1, 1},  {-1, 1, 1},  {1, 1, 1}};
+    std::vector<std::array<int, 3>> neighbors = { { -1, -1, -1 }, { 1, -1, -1 },
+                                                  { -1, 1, -1 },  { 1, 1, -1 },
+                                                  { -1, -1, 1 },  { 1, -1, 1 },
+                                                  { -1, 1, 1 },   { 1, 1, 1 } };
     pattern.setNeighbors( neighbors );
 
     // Create a halo.
@@ -413,12 +416,12 @@ TEST( TEST_CATEGORY, not_periodic_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
     ManualPartitioner partitioner( ranks_per_dim );
 
     // Boundaries are not periodic.
-    std::array<bool, 3> is_dim_periodic = {false, false, false};
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
@@ -443,12 +446,12 @@ TEST( TEST_CATEGORY, periodic_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
     ManualPartitioner partitioner( ranks_per_dim );
 
     // Every boundary is periodic
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.

--- a/cajita/unit_test/tstHalo.hpp
+++ b/cajita/unit_test/tstHalo.hpp
@@ -52,7 +52,7 @@ int haloPad( Edge<D>, int d )
 // Check initial array gather. We should get 1 everywhere in the array now
 // where there was ghost overlap. Otherwise there will still be 0.
 template <class Array>
-void checkGather( const int halo_width, const Array &array )
+void checkGather( const int halo_width, const Array& array )
 {
     auto owned_space = array.layout()->indexSpace( Own(), Local() );
     auto ghosted_space = array.layout()->indexSpace( Ghost(), Local() );
@@ -81,14 +81,14 @@ void checkGather( const int halo_width, const Array &array )
 // neighbors it has. Corner neighbors get 8, edge neighbors get 4, face
 // neighbors get 2, and no neighbors remain at 1.
 template <class Array>
-void checkScatter( const std::array<bool, 3> &is_dim_periodic,
-                   const int halo_width, const Array &array )
+void checkScatter( const std::array<bool, 3>& is_dim_periodic,
+                   const int halo_width, const Array& array )
 {
     // Get data.
     auto owned_space = array.layout()->indexSpace( Own(), Local() );
     auto host_view = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
                                                           array.view() );
-    const auto &global_grid = array.layout()->localGrid()->globalGrid();
+    const auto& global_grid = array.layout()->localGrid()->globalGrid();
 
     // This function checks if an index is in the halo of a low neighbor in
     // the given dimension
@@ -134,17 +134,17 @@ void checkScatter( const std::array<bool, 3> &is_dim_periodic,
 }
 
 //---------------------------------------------------------------------------//
-void gatherScatterTest( const ManualPartitioner &partitioner,
-                        const std::array<bool, 3> &is_dim_periodic )
+void gatherScatterTest( const ManualPartitioner& partitioner,
+                        const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global grid.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 32, 23, 41 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {32, 23, 41};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -336,21 +336,21 @@ struct TestHaloReduce<ScatterReduce::Replace>
 };
 
 template <class ReduceFunc>
-void scatterReduceTest( const ReduceFunc &reduce )
+void scatterReduceTest( const ReduceFunc& reduce )
 {
     // Create the global grid.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 32, 23, 41 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {32, 23, 41};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
     // Create the global grid.
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
     auto global_grid =
         createGlobalGrid( MPI_COMM_WORLD, global_mesh, is_dim_periodic,
                           Cajita::UniformDimPartitioner() );
@@ -372,8 +372,8 @@ void scatterReduceTest( const ReduceFunc &reduce )
     // collision.
     HaloPattern pattern;
     std::vector<std::array<int, 3>> neighbors = {
-        { -1, -1, -1 }, { 1, -1, -1 }, { -1, 1, -1 }, { 1, 1, -1 },
-        { -1, -1, 1 },  { 1, -1, 1 },  { -1, 1, 1 },  { 1, 1, 1 } };
+        {-1, -1, -1}, {1, -1, -1}, {-1, 1, -1}, {1, 1, -1},
+        {-1, -1, 1},  {1, -1, 1},  {-1, 1, 1},  {1, 1, 1}};
     pattern.setNeighbors( neighbors );
 
     // Create a halo.
@@ -385,7 +385,7 @@ void scatterReduceTest( const ReduceFunc &reduce )
     // Check the reduction.
     auto host_array = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
                                                            array->view() );
-    for ( const auto &n : neighbors )
+    for ( const auto& n : neighbors )
     {
         auto neighbor_rank =
             cell_layout->localGrid()->neighborRank( n[0], n[1], n[2] );
@@ -413,12 +413,12 @@ TEST( TEST_CATEGORY, not_periodic_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
     ManualPartitioner partitioner( ranks_per_dim );
 
     // Boundaries are not periodic.
-    std::array<bool, 3> is_dim_periodic = { false, false, false };
+    std::array<bool, 3> is_dim_periodic = {false, false, false};
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
@@ -443,12 +443,12 @@ TEST( TEST_CATEGORY, periodic_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
     ManualPartitioner partitioner( ranks_per_dim );
 
     // Every boundary is periodic
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.

--- a/cajita/unit_test/tstHypreStructuredSolver.hpp
+++ b/cajita/unit_test/tstHypreStructuredSolver.hpp
@@ -35,9 +35,9 @@ void poissonTest( const std::string& solver_type,
 {
     // Create the global grid.
     double cell_size = 0.1;
-    std::array<bool, 3> is_dim_periodic = {false, false, false};
-    std::array<double, 3> global_low_corner = {-1.0, -2.0, -1.0};
-    std::array<double, 3> global_high_corner = {1.0, 1.0, 0.5};
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
+    std::array<double, 3> global_low_corner = { -1.0, -2.0, -1.0 };
+    std::array<double, 3> global_high_corner = { 1.0, 1.0, 0.5 };
     auto global_mesh = createUniformGlobalMesh( global_low_corner,
                                                 global_high_corner, cell_size );
 
@@ -64,9 +64,10 @@ void poissonTest( const std::string& solver_type,
         solver_type, *vector_layout );
 
     // Create a 7-point 3d laplacian stencil.
-    std::vector<std::array<int, 3>> stencil = {
-        {0, 0, 0}, {-1, 0, 0}, {1, 0, 0}, {0, -1, 0},
-        {0, 1, 0}, {0, 0, -1}, {0, 0, 1}};
+    std::vector<std::array<int, 3>> stencil = { { 0, 0, 0 }, { -1, 0, 0 },
+                                                { 1, 0, 0 }, { 0, -1, 0 },
+                                                { 0, 1, 0 }, { 0, 0, -1 },
+                                                { 0, 0, 1 } };
     solver->setMatrixStencil( stencil );
 
     // Create the matrix entries. The stencil is defined over cells.
@@ -141,7 +142,7 @@ void poissonTest( const std::string& solver_type,
             matrix_view( i, j, k, 6 ) = ( gk + 1 < ncell_k ) ? 1.0 : 0.0;
         } );
 
-    std::vector<std::array<int, 3>> diag_stencil = {{0, 0, 0}};
+    std::vector<std::array<int, 3>> diag_stencil = { { 0, 0, 0 } };
     ref_solver->setPreconditionerStencil( diag_stencil );
     const auto& preconditioner_entries = ref_solver->getPreconditionerValues();
     auto preconditioner_view = preconditioner_entries.view();

--- a/cajita/unit_test/tstHypreStructuredSolver.hpp
+++ b/cajita/unit_test/tstHypreStructuredSolver.hpp
@@ -64,10 +64,9 @@ void poissonTest( const std::string& solver_type,
         solver_type, *vector_layout );
 
     // Create a 7-point 3d laplacian stencil.
-    std::vector<std::array<int, 3>> stencil = { { 0, 0, 0 }, { -1, 0, 0 },
-                                                { 1, 0, 0 }, { 0, -1, 0 },
-                                                { 0, 1, 0 }, { 0, 0, -1 },
-                                                { 0, 0, 1 } };
+    std::vector<std::array<int, 3>> stencil = {
+        { 0, 0, 0 }, { -1, 0, 0 }, { 1, 0, 0 }, { 0, -1, 0 },
+        { 0, 1, 0 }, { 0, 0, -1 }, { 0, 0, 1 } };
     solver->setMatrixStencil( stencil );
 
     // Create the matrix entries. The stencil is defined over cells.

--- a/cajita/unit_test/tstHypreStructuredSolver.hpp
+++ b/cajita/unit_test/tstHypreStructuredSolver.hpp
@@ -30,14 +30,14 @@ namespace Test
 {
 
 //---------------------------------------------------------------------------//
-void poissonTest( const std::string &solver_type,
-                  const std::string &precond_type )
+void poissonTest( const std::string& solver_type,
+                  const std::string& precond_type )
 {
     // Create the global grid.
     double cell_size = 0.1;
-    std::array<bool, 3> is_dim_periodic = { false, false, false };
-    std::array<double, 3> global_low_corner = { -1.0, -2.0, -1.0 };
-    std::array<double, 3> global_high_corner = { 1.0, 1.0, 0.5 };
+    std::array<bool, 3> is_dim_periodic = {false, false, false};
+    std::array<double, 3> global_low_corner = {-1.0, -2.0, -1.0};
+    std::array<double, 3> global_high_corner = {1.0, 1.0, 0.5};
     auto global_mesh = createUniformGlobalMesh( global_low_corner,
                                                 global_high_corner, cell_size );
 
@@ -65,8 +65,8 @@ void poissonTest( const std::string &solver_type,
 
     // Create a 7-point 3d laplacian stencil.
     std::vector<std::array<int, 3>> stencil = {
-        { 0, 0, 0 }, { -1, 0, 0 }, { 1, 0, 0 }, { 0, -1, 0 },
-        { 0, 1, 0 }, { 0, 0, -1 }, { 0, 0, 1 } };
+        {0, 0, 0}, {-1, 0, 0}, {1, 0, 0}, {0, -1, 0},
+        {0, 1, 0}, {0, 0, -1}, {0, 0, 1}};
     solver->setMatrixStencil( stencil );
 
     // Create the matrix entries. The stencil is defined over cells.
@@ -119,7 +119,7 @@ void poissonTest( const std::string &solver_type,
     auto ref_solver =
         createReferenceConjugateGradient<double, TEST_DEVICE>( *vector_layout );
     ref_solver->setMatrixStencil( stencil );
-    const auto &ref_entries = ref_solver->getMatrixValues();
+    const auto& ref_entries = ref_solver->getMatrixValues();
     auto matrix_view = ref_entries.view();
     auto global_space = local_mesh->indexSpace( Own(), Cell(), Global() );
     int ncell_i = global_grid->globalNumEntity( Cell(), Dim::I );
@@ -141,9 +141,9 @@ void poissonTest( const std::string &solver_type,
             matrix_view( i, j, k, 6 ) = ( gk + 1 < ncell_k ) ? 1.0 : 0.0;
         } );
 
-    std::vector<std::array<int, 3>> diag_stencil = { { 0, 0, 0 } };
+    std::vector<std::array<int, 3>> diag_stencil = {{0, 0, 0}};
     ref_solver->setPreconditionerStencil( diag_stencil );
-    const auto &preconditioner_entries = ref_solver->getPreconditionerValues();
+    const auto& preconditioner_entries = ref_solver->getPreconditionerValues();
     auto preconditioner_view = preconditioner_entries.view();
     Kokkos::parallel_for(
         "fill_preconditioner_entries",

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -39,12 +39,13 @@ void testConversion( const std::array<bool, 3>& is_dim_periodic )
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -124,68 +125,68 @@ void testConversion( const std::array<bool, 3>& is_dim_periodic )
 //---------------------------------------------------------------------------//
 TEST( index_conversion, node_periodic_test )
 {
-    testConversion<Node>( {{true, true, true}} );
+    testConversion<Node>( { { true, true, true } } );
 }
 TEST( index_conversion, cell_periodic_test )
 {
-    testConversion<Cell>( {{true, true, true}} );
+    testConversion<Cell>( { { true, true, true } } );
 }
 TEST( index_conversion, face_i_periodic_test )
 {
-    testConversion<Face<Dim::I>>( {{true, true, true}} );
+    testConversion<Face<Dim::I>>( { { true, true, true } } );
 }
 TEST( index_conversion, face_j_periodic_test )
 {
-    testConversion<Face<Dim::J>>( {{true, true, true}} );
+    testConversion<Face<Dim::J>>( { { true, true, true } } );
 }
 TEST( index_conversion, face_k_periodic_test )
 {
-    testConversion<Face<Dim::K>>( {{true, true, true}} );
+    testConversion<Face<Dim::K>>( { { true, true, true } } );
 }
 TEST( index_conversion, edge_i_periodic_test )
 {
-    testConversion<Edge<Dim::I>>( {{true, true, true}} );
+    testConversion<Edge<Dim::I>>( { { true, true, true } } );
 }
 TEST( index_conversion, edge_j_periodic_test )
 {
-    testConversion<Edge<Dim::J>>( {{true, true, true}} );
+    testConversion<Edge<Dim::J>>( { { true, true, true } } );
 }
 TEST( index_conversion, edge_k_periodic_test )
 {
-    testConversion<Edge<Dim::K>>( {{true, true, true}} );
+    testConversion<Edge<Dim::K>>( { { true, true, true } } );
 }
 
 TEST( index_conversion, node_not_periodic_test )
 {
-    testConversion<Node>( {{false, false, false}} );
+    testConversion<Node>( { { false, false, false } } );
 }
 TEST( index_conversion, cell_not_periodic_test )
 {
-    testConversion<Cell>( {{false, false, false}} );
+    testConversion<Cell>( { { false, false, false } } );
 }
 TEST( index_conversion, face_i_not_periodic_test )
 {
-    testConversion<Face<Dim::I>>( {{false, false, false}} );
+    testConversion<Face<Dim::I>>( { { false, false, false } } );
 }
 TEST( index_conversion, face_j_not_periodic_test )
 {
-    testConversion<Face<Dim::J>>( {{false, false, false}} );
+    testConversion<Face<Dim::J>>( { { false, false, false } } );
 }
 TEST( index_conversion, face_k_not_periodic_test )
 {
-    testConversion<Face<Dim::K>>( {{false, false, false}} );
+    testConversion<Face<Dim::K>>( { { false, false, false } } );
 }
 TEST( index_conversion, edge_i_not_periodic_test )
 {
-    testConversion<Edge<Dim::I>>( {{false, false, false}} );
+    testConversion<Edge<Dim::I>>( { { false, false, false } } );
 }
 TEST( index_conversion, edge_j_not_periodic_test )
 {
-    testConversion<Edge<Dim::J>>( {{false, false, false}} );
+    testConversion<Edge<Dim::J>>( { { false, false, false } } );
 }
 TEST( index_conversion, edge_k_not_periodic_test )
 {
-    testConversion<Edge<Dim::K>>( {{false, false, false}} );
+    testConversion<Edge<Dim::K>>( { { false, false, false } } );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -32,19 +32,19 @@ namespace Test
 {
 //---------------------------------------------------------------------------//
 template <class EntityType>
-void testConversion( const std::array<bool, 3> &is_dim_periodic )
+void testConversion( const std::array<bool, 3>& is_dim_periodic )
 {
     // Let MPI compute the partitioning for this test.
     UniformDimPartitioner partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -124,68 +124,68 @@ void testConversion( const std::array<bool, 3> &is_dim_periodic )
 //---------------------------------------------------------------------------//
 TEST( index_conversion, node_periodic_test )
 {
-    testConversion<Node>( { { true, true, true } } );
+    testConversion<Node>( {{true, true, true}} );
 }
 TEST( index_conversion, cell_periodic_test )
 {
-    testConversion<Cell>( { { true, true, true } } );
+    testConversion<Cell>( {{true, true, true}} );
 }
 TEST( index_conversion, face_i_periodic_test )
 {
-    testConversion<Face<Dim::I>>( { { true, true, true } } );
+    testConversion<Face<Dim::I>>( {{true, true, true}} );
 }
 TEST( index_conversion, face_j_periodic_test )
 {
-    testConversion<Face<Dim::J>>( { { true, true, true } } );
+    testConversion<Face<Dim::J>>( {{true, true, true}} );
 }
 TEST( index_conversion, face_k_periodic_test )
 {
-    testConversion<Face<Dim::K>>( { { true, true, true } } );
+    testConversion<Face<Dim::K>>( {{true, true, true}} );
 }
 TEST( index_conversion, edge_i_periodic_test )
 {
-    testConversion<Edge<Dim::I>>( { { true, true, true } } );
+    testConversion<Edge<Dim::I>>( {{true, true, true}} );
 }
 TEST( index_conversion, edge_j_periodic_test )
 {
-    testConversion<Edge<Dim::J>>( { { true, true, true } } );
+    testConversion<Edge<Dim::J>>( {{true, true, true}} );
 }
 TEST( index_conversion, edge_k_periodic_test )
 {
-    testConversion<Edge<Dim::K>>( { { true, true, true } } );
+    testConversion<Edge<Dim::K>>( {{true, true, true}} );
 }
 
 TEST( index_conversion, node_not_periodic_test )
 {
-    testConversion<Node>( { { false, false, false } } );
+    testConversion<Node>( {{false, false, false}} );
 }
 TEST( index_conversion, cell_not_periodic_test )
 {
-    testConversion<Cell>( { { false, false, false } } );
+    testConversion<Cell>( {{false, false, false}} );
 }
 TEST( index_conversion, face_i_not_periodic_test )
 {
-    testConversion<Face<Dim::I>>( { { false, false, false } } );
+    testConversion<Face<Dim::I>>( {{false, false, false}} );
 }
 TEST( index_conversion, face_j_not_periodic_test )
 {
-    testConversion<Face<Dim::J>>( { { false, false, false } } );
+    testConversion<Face<Dim::J>>( {{false, false, false}} );
 }
 TEST( index_conversion, face_k_not_periodic_test )
 {
-    testConversion<Face<Dim::K>>( { { false, false, false } } );
+    testConversion<Face<Dim::K>>( {{false, false, false}} );
 }
 TEST( index_conversion, edge_i_not_periodic_test )
 {
-    testConversion<Edge<Dim::I>>( { { false, false, false } } );
+    testConversion<Edge<Dim::I>>( {{false, false, false}} );
 }
 TEST( index_conversion, edge_j_not_periodic_test )
 {
-    testConversion<Edge<Dim::J>>( { { false, false, false } } );
+    testConversion<Edge<Dim::J>>( {{false, false, false}} );
 }
 TEST( index_conversion, edge_k_not_periodic_test )
 {
-    testConversion<Edge<Dim::K>>( { { false, false, false } } );
+    testConversion<Edge<Dim::K>>( {{false, false, false}} );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -44,8 +44,7 @@ void testConversion( const std::array<bool, 3>& is_dim_periodic )
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -24,7 +24,7 @@ void sizeConstructorTest()
 {
     // Rank-1
     int s0 = 3;
-    IndexSpace<1> is1( { s0 } );
+    IndexSpace<1> is1( {s0} );
     EXPECT_EQ( is1.min( 0 ), 0 );
     EXPECT_EQ( is1.max( 0 ), s0 );
 
@@ -42,7 +42,7 @@ void sizeConstructorTest()
 
     // Rank-2
     int s1 = 5;
-    IndexSpace<2> is2( { s0, s1 } );
+    IndexSpace<2> is2( {s0, s1} );
     EXPECT_EQ( is2.min( 0 ), 0 );
     EXPECT_EQ( is2.max( 0 ), s0 );
     EXPECT_EQ( is2.min( 1 ), 0 );
@@ -68,7 +68,7 @@ void sizeConstructorTest()
 
     // Rank-3
     int s2 = 9;
-    IndexSpace<3> is3( { s0, s1, s2 } );
+    IndexSpace<3> is3( {s0, s1, s2} );
     EXPECT_EQ( is3.min( 0 ), 0 );
     EXPECT_EQ( is3.max( 0 ), s0 );
     EXPECT_EQ( is3.min( 1 ), 0 );
@@ -102,7 +102,7 @@ void sizeConstructorTest()
 
     // Rank-4
     int s3 = 4;
-    IndexSpace<4> is4( { s0, s1, s2, s3 } );
+    IndexSpace<4> is4( {s0, s1, s2, s3} );
     EXPECT_EQ( is4.min( 0 ), 0 );
     EXPECT_EQ( is4.max( 0 ), s0 );
     EXPECT_EQ( is4.min( 1 ), 0 );
@@ -148,7 +148,7 @@ void rangeConstructorTest()
 {
     // Rank-1
     int s0 = 3;
-    IndexSpace<1> is1( { 0 }, { s0 } );
+    IndexSpace<1> is1( {0}, {s0} );
     EXPECT_EQ( is1.min( 0 ), 0 );
     EXPECT_EQ( is1.max( 0 ), s0 );
 
@@ -166,7 +166,7 @@ void rangeConstructorTest()
 
     // Rank-2
     int s1 = 5;
-    IndexSpace<2> is2( { 0, 0 }, { s0, s1 } );
+    IndexSpace<2> is2( {0, 0}, {s0, s1} );
     EXPECT_EQ( is2.min( 0 ), 0 );
     EXPECT_EQ( is2.max( 0 ), s0 );
     EXPECT_EQ( is2.min( 1 ), 0 );
@@ -192,7 +192,7 @@ void rangeConstructorTest()
 
     // Rank-3
     int s2 = 9;
-    IndexSpace<3> is3( { 0, 0, 0 }, { s0, s1, s2 } );
+    IndexSpace<3> is3( {0, 0, 0}, {s0, s1, s2} );
     EXPECT_EQ( is3.min( 0 ), 0 );
     EXPECT_EQ( is3.max( 0 ), s0 );
     EXPECT_EQ( is3.min( 1 ), 0 );
@@ -226,7 +226,7 @@ void rangeConstructorTest()
 
     // Rank-4
     int s3 = 4;
-    IndexSpace<4> is4( { 0, 0, 0, 0 }, { s0, s1, s2, s3 } );
+    IndexSpace<4> is4( {0, 0, 0, 0}, {s0, s1, s2, s3} );
     EXPECT_EQ( is4.min( 0 ), 0 );
     EXPECT_EQ( is4.max( 0 ), s0 );
     EXPECT_EQ( is4.min( 1 ), 0 );
@@ -274,8 +274,8 @@ void executionTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double *, TEST_DEVICE> v1( "v1", size_i );
+    IndexSpace<1> is1( {min_i}, {max_i} );
+    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     Kokkos::parallel_for(
         "fill_rank_1", createExecutionPolicy( is1, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
@@ -293,8 +293,8 @@ void executionTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double **, TEST_DEVICE> v2( "v2", size_i, size_j );
+    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     Kokkos::parallel_for(
         "fill_rank_2", createExecutionPolicy( is2, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
@@ -314,8 +314,8 @@ void executionTest()
     int min_k = 2;
     int max_k = 11;
     int size_k = 13;
-    IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
-    Kokkos::View<double ***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
+    IndexSpace<3> is3( {min_i, min_j, min_k}, {max_i, max_j, max_k} );
+    Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
     Kokkos::parallel_for(
         "fill_rank_3", createExecutionPolicy( is3, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
@@ -339,10 +339,10 @@ void executionTest()
     int min_l = 7;
     int max_l = 9;
     int size_l = 14;
-    IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
-                       { max_i, max_j, max_k, max_l } );
-    Kokkos::View<double ****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
-                                               size_l );
+    IndexSpace<4> is4( {min_i, min_j, min_k, min_l},
+                       {max_i, max_j, max_k, max_l} );
+    Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
+                                              size_l );
     Kokkos::parallel_for(
         "fill_rank_4", createExecutionPolicy( is4, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int l ) {
@@ -372,8 +372,8 @@ void subviewTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double *, TEST_DEVICE> v1( "v1", size_i );
+    IndexSpace<1> is1( {min_i}, {max_i} );
+    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     auto sv1 = createSubview( v1, is1 );
     Kokkos::deep_copy( sv1, 1.0 );
     auto v1_mirror =
@@ -390,8 +390,8 @@ void subviewTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double **, TEST_DEVICE> v2( "v2", size_i, size_j );
+    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     auto sv2 = createSubview( v2, is2 );
     Kokkos::deep_copy( sv2, 1.0 );
     auto v2_mirror =
@@ -410,8 +410,8 @@ void subviewTest()
     int min_k = 2;
     int max_k = 11;
     int size_k = 13;
-    IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
-    Kokkos::View<double ***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
+    IndexSpace<3> is3( {min_i, min_j, min_k}, {max_i, max_j, max_k} );
+    Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
     auto sv3 = createSubview( v3, is3 );
     Kokkos::deep_copy( sv3, 1.0 );
     auto v3_mirror =
@@ -432,10 +432,10 @@ void subviewTest()
     int min_l = 7;
     int max_l = 9;
     int size_l = 14;
-    IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
-                       { max_i, max_j, max_k, max_l } );
-    Kokkos::View<double ****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
-                                               size_l );
+    IndexSpace<4> is4( {min_i, min_j, min_k, min_l},
+                       {max_i, max_j, max_k, max_l} );
+    Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
+                                              size_l );
     auto sv4 = createSubview( v4, is4 );
     Kokkos::deep_copy( sv4, 1.0 );
     auto v4_mirror =
@@ -463,7 +463,7 @@ void subviewTest()
 void sizeAppendTest()
 {
     int s0 = 3;
-    IndexSpace<1> is1( { s0 } );
+    IndexSpace<1> is1( {s0} );
     int s1 = 5;
     auto is2 = appendDimension( is1, s1 );
 
@@ -495,7 +495,7 @@ void sizeAppendTest()
 void rangeAppendTest()
 {
     int s0 = 3;
-    IndexSpace<1> is1( { s0 } );
+    IndexSpace<1> is1( {s0} );
     int s1 = 5;
     auto is2 = appendDimension( is1, 0, s1 );
 
@@ -526,9 +526,9 @@ void rangeAppendTest()
 //---------------------------------------------------------------------------//
 void comparisonTest()
 {
-    IndexSpace<3> is1( { 9, 2, 1 }, { 12, 16, 4 } );
-    IndexSpace<3> is2( { 9, 2, 1 }, { 12, 16, 4 } );
-    IndexSpace<3> is3( { 9, 2, 1 }, { 12, 16, 5 } );
+    IndexSpace<3> is1( {9, 2, 1}, {12, 16, 4} );
+    IndexSpace<3> is2( {9, 2, 1}, {12, 16, 4} );
+    IndexSpace<3> is3( {9, 2, 1}, {12, 16, 5} );
     EXPECT_TRUE( is1 == is2 );
     EXPECT_FALSE( is1 != is2 );
     EXPECT_FALSE( is1 == is3 );
@@ -546,7 +546,7 @@ void defaultConstructorTest()
     EXPECT_EQ( is1.max( 1 ), -1 );
     EXPECT_EQ( is1.max( 2 ), -1 );
 
-    IndexSpace<3> is2( { 9, 2, 1 }, { 12, 16, 4 } );
+    IndexSpace<3> is2( {9, 2, 1}, {12, 16, 4} );
     is1 = is2;
     EXPECT_TRUE( is1 == is2 );
 }

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -24,7 +24,7 @@ void sizeConstructorTest()
 {
     // Rank-1
     int s0 = 3;
-    IndexSpace<1> is1( {s0} );
+    IndexSpace<1> is1( { s0 } );
     EXPECT_EQ( is1.min( 0 ), 0 );
     EXPECT_EQ( is1.max( 0 ), s0 );
 
@@ -42,7 +42,7 @@ void sizeConstructorTest()
 
     // Rank-2
     int s1 = 5;
-    IndexSpace<2> is2( {s0, s1} );
+    IndexSpace<2> is2( { s0, s1 } );
     EXPECT_EQ( is2.min( 0 ), 0 );
     EXPECT_EQ( is2.max( 0 ), s0 );
     EXPECT_EQ( is2.min( 1 ), 0 );
@@ -68,7 +68,7 @@ void sizeConstructorTest()
 
     // Rank-3
     int s2 = 9;
-    IndexSpace<3> is3( {s0, s1, s2} );
+    IndexSpace<3> is3( { s0, s1, s2 } );
     EXPECT_EQ( is3.min( 0 ), 0 );
     EXPECT_EQ( is3.max( 0 ), s0 );
     EXPECT_EQ( is3.min( 1 ), 0 );
@@ -102,7 +102,7 @@ void sizeConstructorTest()
 
     // Rank-4
     int s3 = 4;
-    IndexSpace<4> is4( {s0, s1, s2, s3} );
+    IndexSpace<4> is4( { s0, s1, s2, s3 } );
     EXPECT_EQ( is4.min( 0 ), 0 );
     EXPECT_EQ( is4.max( 0 ), s0 );
     EXPECT_EQ( is4.min( 1 ), 0 );
@@ -148,7 +148,7 @@ void rangeConstructorTest()
 {
     // Rank-1
     int s0 = 3;
-    IndexSpace<1> is1( {0}, {s0} );
+    IndexSpace<1> is1( { 0 }, { s0 } );
     EXPECT_EQ( is1.min( 0 ), 0 );
     EXPECT_EQ( is1.max( 0 ), s0 );
 
@@ -166,7 +166,7 @@ void rangeConstructorTest()
 
     // Rank-2
     int s1 = 5;
-    IndexSpace<2> is2( {0, 0}, {s0, s1} );
+    IndexSpace<2> is2( { 0, 0 }, { s0, s1 } );
     EXPECT_EQ( is2.min( 0 ), 0 );
     EXPECT_EQ( is2.max( 0 ), s0 );
     EXPECT_EQ( is2.min( 1 ), 0 );
@@ -192,7 +192,7 @@ void rangeConstructorTest()
 
     // Rank-3
     int s2 = 9;
-    IndexSpace<3> is3( {0, 0, 0}, {s0, s1, s2} );
+    IndexSpace<3> is3( { 0, 0, 0 }, { s0, s1, s2 } );
     EXPECT_EQ( is3.min( 0 ), 0 );
     EXPECT_EQ( is3.max( 0 ), s0 );
     EXPECT_EQ( is3.min( 1 ), 0 );
@@ -226,7 +226,7 @@ void rangeConstructorTest()
 
     // Rank-4
     int s3 = 4;
-    IndexSpace<4> is4( {0, 0, 0, 0}, {s0, s1, s2, s3} );
+    IndexSpace<4> is4( { 0, 0, 0, 0 }, { s0, s1, s2, s3 } );
     EXPECT_EQ( is4.min( 0 ), 0 );
     EXPECT_EQ( is4.max( 0 ), s0 );
     EXPECT_EQ( is4.min( 1 ), 0 );
@@ -274,7 +274,7 @@ void executionTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( {min_i}, {max_i} );
+    IndexSpace<1> is1( { min_i }, { max_i } );
     Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     Kokkos::parallel_for(
         "fill_rank_1", createExecutionPolicy( is1, TEST_EXECSPACE() ),
@@ -293,7 +293,7 @@ void executionTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
     Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     Kokkos::parallel_for(
         "fill_rank_2", createExecutionPolicy( is2, TEST_EXECSPACE() ),
@@ -314,7 +314,7 @@ void executionTest()
     int min_k = 2;
     int max_k = 11;
     int size_k = 13;
-    IndexSpace<3> is3( {min_i, min_j, min_k}, {max_i, max_j, max_k} );
+    IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
     Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
     Kokkos::parallel_for(
         "fill_rank_3", createExecutionPolicy( is3, TEST_EXECSPACE() ),
@@ -339,8 +339,8 @@ void executionTest()
     int min_l = 7;
     int max_l = 9;
     int size_l = 14;
-    IndexSpace<4> is4( {min_i, min_j, min_k, min_l},
-                       {max_i, max_j, max_k, max_l} );
+    IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
+                       { max_i, max_j, max_k, max_l } );
     Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
                                               size_l );
     Kokkos::parallel_for(
@@ -372,7 +372,7 @@ void subviewTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( {min_i}, {max_i} );
+    IndexSpace<1> is1( { min_i }, { max_i } );
     Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     auto sv1 = createSubview( v1, is1 );
     Kokkos::deep_copy( sv1, 1.0 );
@@ -390,7 +390,7 @@ void subviewTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
     Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     auto sv2 = createSubview( v2, is2 );
     Kokkos::deep_copy( sv2, 1.0 );
@@ -410,7 +410,7 @@ void subviewTest()
     int min_k = 2;
     int max_k = 11;
     int size_k = 13;
-    IndexSpace<3> is3( {min_i, min_j, min_k}, {max_i, max_j, max_k} );
+    IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
     Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
     auto sv3 = createSubview( v3, is3 );
     Kokkos::deep_copy( sv3, 1.0 );
@@ -432,8 +432,8 @@ void subviewTest()
     int min_l = 7;
     int max_l = 9;
     int size_l = 14;
-    IndexSpace<4> is4( {min_i, min_j, min_k, min_l},
-                       {max_i, max_j, max_k, max_l} );
+    IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
+                       { max_i, max_j, max_k, max_l } );
     Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
                                               size_l );
     auto sv4 = createSubview( v4, is4 );
@@ -463,7 +463,7 @@ void subviewTest()
 void sizeAppendTest()
 {
     int s0 = 3;
-    IndexSpace<1> is1( {s0} );
+    IndexSpace<1> is1( { s0 } );
     int s1 = 5;
     auto is2 = appendDimension( is1, s1 );
 
@@ -495,7 +495,7 @@ void sizeAppendTest()
 void rangeAppendTest()
 {
     int s0 = 3;
-    IndexSpace<1> is1( {s0} );
+    IndexSpace<1> is1( { s0 } );
     int s1 = 5;
     auto is2 = appendDimension( is1, 0, s1 );
 
@@ -526,9 +526,9 @@ void rangeAppendTest()
 //---------------------------------------------------------------------------//
 void comparisonTest()
 {
-    IndexSpace<3> is1( {9, 2, 1}, {12, 16, 4} );
-    IndexSpace<3> is2( {9, 2, 1}, {12, 16, 4} );
-    IndexSpace<3> is3( {9, 2, 1}, {12, 16, 5} );
+    IndexSpace<3> is1( { 9, 2, 1 }, { 12, 16, 4 } );
+    IndexSpace<3> is2( { 9, 2, 1 }, { 12, 16, 4 } );
+    IndexSpace<3> is3( { 9, 2, 1 }, { 12, 16, 5 } );
     EXPECT_TRUE( is1 == is2 );
     EXPECT_FALSE( is1 != is2 );
     EXPECT_FALSE( is1 == is3 );
@@ -546,7 +546,7 @@ void defaultConstructorTest()
     EXPECT_EQ( is1.max( 1 ), -1 );
     EXPECT_EQ( is1.max( 2 ), -1 );
 
-    IndexSpace<3> is2( {9, 2, 1}, {12, 16, 4} );
+    IndexSpace<3> is2( { 9, 2, 1 }, { 12, 16, 4 } );
     is1 = is2;
     EXPECT_TRUE( is1 == is2 );
 }

--- a/cajita/unit_test/tstInterpolation.hpp
+++ b/cajita/unit_test/tstInterpolation.hpp
@@ -38,15 +38,15 @@ namespace Test
 void interpolationTest()
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
 
     // Create the global grid.
     UniformDimPartitioner partitioner;
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -68,7 +68,7 @@ void interpolationTest()
             int pk = k - halo_width;
             int pid = pi + cell_space.extent( Dim::I ) *
                                ( pj + cell_space.extent( Dim::J ) * pk );
-            int idx[3] = {i, j, k};
+            int idx[3] = { i, j, k };
             double x[3];
             local_mesh.coordinates( Cell(), idx, x );
             points( pid, Dim::I ) = x[Dim::I];

--- a/cajita/unit_test/tstInterpolation.hpp
+++ b/cajita/unit_test/tstInterpolation.hpp
@@ -38,15 +38,15 @@ namespace Test
 void interpolationTest()
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
 
     // Create the global grid.
     UniformDimPartitioner partitioner;
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -58,7 +58,7 @@ void interpolationTest()
     // Create a point in the center of every cell.
     auto cell_space = local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
-    Kokkos::View<double *[3], TEST_DEVICE> points(
+    Kokkos::View<double* [3], TEST_DEVICE> points(
         Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
     Kokkos::parallel_for(
         "fill_points", createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -68,7 +68,7 @@ void interpolationTest()
             int pk = k - halo_width;
             int pid = pi + cell_space.extent( Dim::I ) *
                                ( pj + cell_space.extent( Dim::J ) * pk );
-            int idx[3] = { i, j, k };
+            int idx[3] = {i, j, k};
             double x[3];
             local_mesh.coordinates( Cell(), idx, x );
             points( pid, Dim::I ) = x[Dim::I];
@@ -93,19 +93,19 @@ void interpolationTest()
         Kokkos::create_mirror_view( vector_grid_field->view() );
 
     // Create a scalar point field.
-    Kokkos::View<double *, TEST_DEVICE> scalar_point_field(
+    Kokkos::View<double*, TEST_DEVICE> scalar_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "scalar_point_field" ),
         num_point );
     auto scalar_point_host = Kokkos::create_mirror_view( scalar_point_field );
 
     // Create a vector point field.
-    Kokkos::View<double *[3], TEST_DEVICE> vector_point_field(
+    Kokkos::View<double* [3], TEST_DEVICE> vector_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "vector_point_field" ),
         num_point );
     auto vector_point_host = Kokkos::create_mirror_view( vector_point_field );
 
     // Create a tensor point field.
-    Kokkos::View<double *[3][3], TEST_DEVICE> tensor_point_field(
+    Kokkos::View<double* [3][3], TEST_DEVICE> tensor_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "tensor_point_field" ),
         num_point );
     auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -40,8 +40,7 @@ void periodicTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -1650,8 +1649,7 @@ void notPeriodicTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -1768,8 +1766,7 @@ void notPeriodicTest()
                     std::vector<int> nr = {
                         global_grid->dimBlockId( Dim::I ) + i,
                         global_grid->dimBlockId( Dim::J ) + j,
-                        global_grid->dimBlockId( Dim::K ) + k
-                    };
+                        global_grid->dimBlockId( Dim::K ) + k };
                     int nrank;
                     MPI_Cart_rank( grid_comm, nr.data(), &nrank );
                     EXPECT_EQ( local_grid->neighborRank( i, j, k ), nrank );

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -35,17 +35,17 @@ void periodicTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
     // Create the global grid.
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -91,9 +91,9 @@ void periodicTest()
         for ( int j = -1; j < 2; ++j )
             for ( int k = -1; k < 2; ++k )
             {
-                std::vector<int> nr = { cart_rank[Dim::I] + i,
-                                        cart_rank[Dim::J] + j,
-                                        cart_rank[Dim::K] + k };
+                std::vector<int> nr = {cart_rank[Dim::I] + i,
+                                       cart_rank[Dim::J] + j,
+                                       cart_rank[Dim::K] + k};
                 int nrank;
                 MPI_Cart_rank( grid_comm, nr.data(), &nrank );
                 EXPECT_EQ( local_grid->neighborRank( i, j, k ), nrank );
@@ -1643,13 +1643,13 @@ void notPeriodicTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<bool, 3> is_dim_periodic = { false, false, false };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {false, false, false};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -1766,7 +1766,7 @@ void notPeriodicTest()
                     std::vector<int> nr = {
                         global_grid->dimBlockId( Dim::I ) + i,
                         global_grid->dimBlockId( Dim::J ) + j,
-                        global_grid->dimBlockId( Dim::K ) + k };
+                        global_grid->dimBlockId( Dim::K ) + k};
                     int nrank;
                     MPI_Cart_rank( grid_comm, nr.data(), &nrank );
                     EXPECT_EQ( local_grid->neighborRank( i, j, k ), nrank );

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -35,17 +35,18 @@ void periodicTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
     // Create the global grid.
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -91,9 +92,9 @@ void periodicTest()
         for ( int j = -1; j < 2; ++j )
             for ( int k = -1; k < 2; ++k )
             {
-                std::vector<int> nr = {cart_rank[Dim::I] + i,
-                                       cart_rank[Dim::J] + j,
-                                       cart_rank[Dim::K] + k};
+                std::vector<int> nr = { cart_rank[Dim::I] + i,
+                                        cart_rank[Dim::J] + j,
+                                        cart_rank[Dim::K] + k };
                 int nrank;
                 MPI_Cart_rank( grid_comm, nr.data(), &nrank );
                 EXPECT_EQ( local_grid->neighborRank( i, j, k ), nrank );
@@ -1643,13 +1644,14 @@ void notPeriodicTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<bool, 3> is_dim_periodic = {false, false, false};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -1766,7 +1768,8 @@ void notPeriodicTest()
                     std::vector<int> nr = {
                         global_grid->dimBlockId( Dim::I ) + i,
                         global_grid->dimBlockId( Dim::J ) + j,
-                        global_grid->dimBlockId( Dim::K ) + k};
+                        global_grid->dimBlockId( Dim::K ) + k
+                    };
                     int nrank;
                     MPI_Cart_rank( grid_comm, nr.data(), &nrank );
                     EXPECT_EQ( local_grid->neighborRank( i, j, k ), nrank );

--- a/cajita/unit_test/tstLocalMesh.hpp
+++ b/cajita/unit_test/tstLocalMesh.hpp
@@ -33,13 +33,13 @@ namespace Test
 
 //---------------------------------------------------------------------------//
 template <class LocalMeshType, class LocalGridType>
-void uniformLocalMeshTest( const LocalMeshType &local_mesh,
-                           const LocalGridType &local_grid,
-                           const std::array<double, 3> &low_corner,
+void uniformLocalMeshTest( const LocalMeshType& local_mesh,
+                           const LocalGridType& local_grid,
+                           const std::array<double, 3>& low_corner,
                            const double cell_size, const int halo_width )
 {
     // Get the global grid.
-    const auto &global_grid = local_grid.globalGrid();
+    const auto& global_grid = local_grid.globalGrid();
 
     // Check the low and high corners.
     Kokkos::View<double[3], TEST_DEVICE> own_lc( "own_lc" );
@@ -127,7 +127,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Cell(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -172,7 +172,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( node_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Node(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -215,7 +215,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( face_i_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Face<Dim::I>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -261,7 +261,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( face_j_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Face<Dim::J>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -307,7 +307,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( face_k_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Face<Dim::K>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -353,7 +353,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( edge_i_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Edge<Dim::I>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -397,7 +397,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( edge_j_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Edge<Dim::J>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -441,7 +441,7 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
             createExecutionPolicy( edge_k_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = { i, j, k };
+                int idx[3] = {i, j, k};
                 local_mesh.coordinates( Edge<Dim::K>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -473,12 +473,12 @@ void uniformLocalMeshTest( const LocalMeshType &local_mesh,
 }
 
 //---------------------------------------------------------------------------//
-void uniformTest( const std::array<int, 3> &ranks_per_dim,
-                  const std::array<bool, 3> &is_dim_periodic )
+void uniformTest( const std::array<int, 3>& ranks_per_dim,
+                  const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
@@ -501,13 +501,13 @@ void uniformTest( const std::array<int, 3> &ranks_per_dim,
 }
 
 //---------------------------------------------------------------------------//
-void nonUniformTest( const std::array<int, 3> &ranks_per_dim,
-                     const std::array<bool, 3> &is_dim_periodic )
+void nonUniformTest( const std::array<int, 3>& ranks_per_dim,
+                     const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
     double cell_size = 0.05;
-    std::array<int, 3> num_cell = { 18, 188, 24 };
+    std::array<int, 3> num_cell = {18, 188, 24};
     std::array<std::vector<double>, 3> edges;
     for ( int d = 0; d < 3; ++d )
         for ( int n = 0; n < num_cell[d] + 1; ++n )
@@ -533,15 +533,15 @@ void nonUniformTest( const std::array<int, 3> &ranks_per_dim,
 }
 
 //---------------------------------------------------------------------------//
-void irregularTest( const std::array<int, 3> &ranks_per_dim )
+void irregularTest( const std::array<int, 3>& ranks_per_dim )
 {
     // Create the global mesh using functions to build the edges. Use a cyclic
     // pattern for the cell sizes so we can easily compute cell sizes from
     // periodic wrap-around.
-    std::array<double, 3> low_corner = { 3.1, 4.1, -2.8 };
+    std::array<double, 3> low_corner = {3.1, 4.1, -2.8};
     int ncell = 20;
     double ref_cell_size = 8.0 * std::atan( 1.0 ) / ncell;
-    std::array<int, 3> num_cell = { ncell, ncell, ncell };
+    std::array<int, 3> num_cell = {ncell, ncell, ncell};
 
     auto i_func = [=]( const int i ) {
         return 0.5 * std::cos( i * ref_cell_size ) + low_corner[Dim::I];
@@ -565,7 +565,7 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
                                                    edges[Dim::K] );
 
     // Create the global grid.
-    std::array<bool, 3> periodic = { true, true, true };
+    std::array<bool, 3> periodic = {true, true, true};
     ManualPartitioner partitioner( ranks_per_dim );
     auto global_grid =
         createGlobalGrid( MPI_COMM_WORLD, global_mesh, periodic, partitioner );
@@ -656,7 +656,7 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
         "get_cell_data",
         createExecutionPolicy( own_cell_local_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
-            int idx[3] = { i, j, k };
+            int idx[3] = {i, j, k};
             double loc[3];
             local_mesh.coordinates( Cell(), idx, loc );
             cell_location_x( i, j, k ) = loc[Dim::I];
@@ -728,12 +728,12 @@ void irregularTest( const std::array<int, 3> &ranks_per_dim )
 //---------------------------------------------------------------------------//
 TEST( mesh, periodic_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -752,12 +752,12 @@ TEST( mesh, periodic_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, periodic_non_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -776,12 +776,12 @@ TEST( mesh, periodic_non_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, non_periodic_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = { false, false, false };
+    std::array<bool, 3> is_dim_periodic = {false, false, false};
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -800,12 +800,12 @@ TEST( mesh, non_periodic_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, non_periodic_non_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = { false, false, false };
+    std::array<bool, 3> is_dim_periodic = {false, false, false};
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -827,7 +827,7 @@ TEST( mesh, irregular_non_uniform_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    std::array<int, 3> ranks_per_dim = {0, 0, 0};
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the

--- a/cajita/unit_test/tstLocalMesh.hpp
+++ b/cajita/unit_test/tstLocalMesh.hpp
@@ -127,7 +127,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Cell(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -172,7 +172,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( node_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Node(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -215,7 +215,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( face_i_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Face<Dim::I>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -261,7 +261,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( face_j_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Face<Dim::J>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -307,7 +307,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( face_k_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Face<Dim::K>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -353,7 +353,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( edge_i_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Edge<Dim::I>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -397,7 +397,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( edge_j_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Edge<Dim::J>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -441,7 +441,7 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
             createExecutionPolicy( edge_k_space, TEST_EXECSPACE() ),
             KOKKOS_LAMBDA( const int i, const int j, const int k ) {
                 double loc[3];
-                int idx[3] = {i, j, k};
+                int idx[3] = { i, j, k };
                 local_mesh.coordinates( Edge<Dim::K>(), idx, loc );
                 loc_x( i, j, k ) = loc[Dim::I];
                 loc_y( i, j, k ) = loc[Dim::J];
@@ -477,8 +477,8 @@ void uniformTest( const std::array<int, 3>& ranks_per_dim,
                   const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
@@ -505,9 +505,9 @@ void nonUniformTest( const std::array<int, 3>& ranks_per_dim,
                      const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
     double cell_size = 0.05;
-    std::array<int, 3> num_cell = {18, 188, 24};
+    std::array<int, 3> num_cell = { 18, 188, 24 };
     std::array<std::vector<double>, 3> edges;
     for ( int d = 0; d < 3; ++d )
         for ( int n = 0; n < num_cell[d] + 1; ++n )
@@ -538,10 +538,10 @@ void irregularTest( const std::array<int, 3>& ranks_per_dim )
     // Create the global mesh using functions to build the edges. Use a cyclic
     // pattern for the cell sizes so we can easily compute cell sizes from
     // periodic wrap-around.
-    std::array<double, 3> low_corner = {3.1, 4.1, -2.8};
+    std::array<double, 3> low_corner = { 3.1, 4.1, -2.8 };
     int ncell = 20;
     double ref_cell_size = 8.0 * std::atan( 1.0 ) / ncell;
-    std::array<int, 3> num_cell = {ncell, ncell, ncell};
+    std::array<int, 3> num_cell = { ncell, ncell, ncell };
 
     auto i_func = [=]( const int i ) {
         return 0.5 * std::cos( i * ref_cell_size ) + low_corner[Dim::I];
@@ -565,7 +565,7 @@ void irregularTest( const std::array<int, 3>& ranks_per_dim )
                                                    edges[Dim::K] );
 
     // Create the global grid.
-    std::array<bool, 3> periodic = {true, true, true};
+    std::array<bool, 3> periodic = { true, true, true };
     ManualPartitioner partitioner( ranks_per_dim );
     auto global_grid =
         createGlobalGrid( MPI_COMM_WORLD, global_mesh, periodic, partitioner );
@@ -656,7 +656,7 @@ void irregularTest( const std::array<int, 3>& ranks_per_dim )
         "get_cell_data",
         createExecutionPolicy( own_cell_local_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
-            int idx[3] = {i, j, k};
+            int idx[3] = { i, j, k };
             double loc[3];
             local_mesh.coordinates( Cell(), idx, loc );
             cell_location_x( i, j, k ) = loc[Dim::I];
@@ -728,12 +728,12 @@ void irregularTest( const std::array<int, 3>& ranks_per_dim )
 //---------------------------------------------------------------------------//
 TEST( mesh, periodic_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -752,12 +752,12 @@ TEST( mesh, periodic_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, periodic_non_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -776,12 +776,12 @@ TEST( mesh, periodic_non_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, non_periodic_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = {false, false, false};
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -800,12 +800,12 @@ TEST( mesh, non_periodic_uniform_test )
 //---------------------------------------------------------------------------//
 TEST( mesh, non_periodic_non_uniform_test )
 {
-    std::array<bool, 3> is_dim_periodic = {false, false, false};
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
 
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the
@@ -827,7 +827,7 @@ TEST( mesh, irregular_non_uniform_test )
     // Let MPI compute the partitioning for this test.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {0, 0, 0};
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
 
     // Test with different block configurations to make sure all the

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -205,8 +205,7 @@ void parallelLocalGridTest()
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]
-    };
+        global_low_corner[2] + cell_size * global_num_cell[2] };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -38,13 +38,13 @@ struct ReduceTag
 
 struct TestFunctor1
 {
-    Kokkos::View<double *, TEST_DEVICE> v;
+    Kokkos::View<double*, TEST_DEVICE> v;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ForTag &, const int i ) const { v( i ) = 2.0; }
+    void operator()( const ForTag&, const int i ) const { v( i ) = 2.0; }
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReduceTag &, const int i, double &result ) const
+    void operator()( const ReduceTag&, const int i, double& result ) const
     {
         result += v( i );
     }
@@ -52,17 +52,17 @@ struct TestFunctor1
 
 struct TestFunctor2
 {
-    Kokkos::View<double **, TEST_DEVICE> v;
+    Kokkos::View<double**, TEST_DEVICE> v;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ForTag &, const int i, const int j ) const
+    void operator()( const ForTag&, const int i, const int j ) const
     {
         v( i, j ) = 2.0;
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReduceTag &, const int i, const int j,
-                     double &result ) const
+    void operator()( const ReduceTag&, const int i, const int j,
+                     double& result ) const
     {
         result += v( i, j );
     }
@@ -70,10 +70,10 @@ struct TestFunctor2
 
 struct TestFunctorArray
 {
-    Kokkos::View<double ****, TEST_DEVICE> v;
+    Kokkos::View<double****, TEST_DEVICE> v;
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ForTag &, const int i, const int j,
+    void operator()( const ForTag&, const int i, const int j,
                      const int k ) const
     {
         for ( int l = 0; l < 4; ++l )
@@ -81,8 +81,8 @@ struct TestFunctorArray
     }
 
     KOKKOS_INLINE_FUNCTION
-    void operator()( const ReduceTag &, const int i, const int j, const int k,
-                     double &result ) const
+    void operator()( const ReduceTag&, const int i, const int j, const int k,
+                     double& result ) const
     {
         for ( int l = 0; l < 4; ++l )
             result += v( i, j, k, l );
@@ -96,8 +96,8 @@ void parallelIndexSpaceTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double *, TEST_DEVICE> v1( "v1", size_i );
+    IndexSpace<1> is1( {min_i}, {max_i} );
+    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     grid_parallel_for(
         "fill_rank_1", TEST_EXECSPACE(), is1,
         KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
@@ -115,7 +115,7 @@ void parallelIndexSpaceTest()
     double sum1 = 0.0;
     grid_parallel_reduce(
         "reduce_rank_1", TEST_EXECSPACE(), is1,
-        KOKKOS_LAMBDA( const int i, double &result ) { result += v1( i ); },
+        KOKKOS_LAMBDA( const int i, double& result ) { result += v1( i ); },
         sum1 );
     EXPECT_EQ( sum1, is1.size() );
 
@@ -142,8 +142,8 @@ void parallelIndexSpaceTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double **, TEST_DEVICE> v2( "v2", size_i, size_j );
+    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     grid_parallel_for(
         "fill_rank_2", TEST_EXECSPACE(), is2,
         KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
@@ -163,7 +163,7 @@ void parallelIndexSpaceTest()
     double sum2 = 0.0;
     grid_parallel_reduce(
         "reduce_rank_2", TEST_EXECSPACE(), is2,
-        KOKKOS_LAMBDA( const int i, const int j, double &result ) {
+        KOKKOS_LAMBDA( const int i, const int j, double& result ) {
             result += v2( i, j );
         },
         sum2 );
@@ -199,13 +199,13 @@ void parallelLocalGridTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = { 101, 85, 99 };
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
-    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<int, 3> global_num_cell = {101, 85, 99};
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2] };
+        global_low_corner[2] + cell_size * global_num_cell[2]};
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -245,7 +245,7 @@ void parallelLocalGridTest()
     double sum = 0.0;
     grid_parallel_reduce(
         "reduce_array", TEST_EXECSPACE(), *local_grid, Ghost(), Cell(),
-        KOKKOS_LAMBDA( const int i, const int j, const int k, double &result ) {
+        KOKKOS_LAMBDA( const int i, const int j, const int k, double& result ) {
             for ( int l = 0; l < 4; ++l )
                 result += array_view( i, j, k, l );
         },

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -96,7 +96,7 @@ void parallelIndexSpaceTest()
     int min_i = 4;
     int max_i = 8;
     int size_i = 12;
-    IndexSpace<1> is1( {min_i}, {max_i} );
+    IndexSpace<1> is1( { min_i }, { max_i } );
     Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
     grid_parallel_for(
         "fill_rank_1", TEST_EXECSPACE(), is1,
@@ -142,7 +142,7 @@ void parallelIndexSpaceTest()
     int min_j = 3;
     int max_j = 9;
     int size_j = 18;
-    IndexSpace<2> is2( {min_i, min_j}, {max_i, max_j} );
+    IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
     Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
     grid_parallel_for(
         "fill_rank_2", TEST_EXECSPACE(), is2,
@@ -199,13 +199,14 @@ void parallelLocalGridTest()
 
     // Create the global mesh.
     double cell_size = 0.23;
-    std::array<int, 3> global_num_cell = {101, 85, 99};
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
-    std::array<double, 3> global_low_corner = {1.2, 3.3, -2.8};
+    std::array<int, 3> global_num_cell = { 101, 85, 99 };
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
     std::array<double, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
-        global_low_corner[2] + cell_size * global_num_cell[2]};
+        global_low_corner[2] + cell_size * global_num_cell[2]
+    };
     auto global_mesh = createUniformGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 

--- a/cajita/unit_test/tstSplineEvaluation.hpp
+++ b/cajita/unit_test/tstSplineEvaluation.hpp
@@ -64,24 +64,24 @@ struct PointSet
     std::size_t num_alloc;
 
     // Physical cell size. (point,dim)
-    Kokkos::View<Scalar *[3], device_type> cell_size;
+    Kokkos::View<Scalar* [3], device_type> cell_size;
 
     // Point logical position. (point,dim)
-    Kokkos::View<Scalar *[3], device_type> logical_coords;
+    Kokkos::View<Scalar* [3], device_type> logical_coords;
 
     // Point mesh stencil. (point,ns,dim)
-    Kokkos::View<int *[ns][3], device_type> stencil;
+    Kokkos::View<int* [ns][3], device_type> stencil;
 
     // Point basis values at entities in stencil. (point,ns,dim)
-    Kokkos::View<Scalar *[ns][3], device_type> value;
+    Kokkos::View<Scalar* [ns][3], device_type> value;
 
     // Point basis gradient values at entities in stencil
     // (point,ni,nj,nk,dim)
-    Kokkos::View<Scalar *[ns][ns][ns][3], device_type> gradient;
+    Kokkos::View<Scalar* [ns][ns][ns][3], device_type> gradient;
 
     // Point basis distance values at entities in stencil
     // (point,ni,nj,nk,dim)
-    Kokkos::View<Scalar *[ns][3], device_type> distance;
+    Kokkos::View<Scalar* [ns][3], device_type> distance;
 
     // Mesh uniform cell size.
     Scalar dx;
@@ -97,9 +97,9 @@ struct PointSet
 //---------------------------------------------------------------------------//
 template <class LocalMeshType, class EntityType, class PointCoordinates,
           class PointSetType>
-void updatePointSet( const LocalMeshType &local_mesh, EntityType,
-                     const PointCoordinates &points,
-                     const std::size_t num_point, PointSetType &point_set )
+void updatePointSet( const LocalMeshType& local_mesh, EntityType,
+                     const PointCoordinates& points,
+                     const std::size_t num_point, PointSetType& point_set )
 {
     static_assert( std::is_same<typename PointCoordinates::value_type,
                                 typename PointSetType::scalar_type>::value,
@@ -147,8 +147,8 @@ void updatePointSet( const LocalMeshType &local_mesh, EntityType,
         KOKKOS_LAMBDA( const int p ) {
             // Create a spline evaluation data set. This is what we are
             // actually testing in this test.
-            scalar_type px[3] = { points( p, Dim::I ), points( p, Dim::J ),
-                                  points( p, Dim::K ) };
+            scalar_type px[3] = {points( p, Dim::I ), points( p, Dim::J ),
+                                 points( p, Dim::K )};
             sd_type sd;
             evaluateSpline( local_mesh, px, sd );
 
@@ -198,10 +198,10 @@ template <class DataTags, class PointCoordinates, class EntityType,
 PointSet<typename PointCoordinates::value_type, EntityType, SplineOrder,
          typename PointCoordinates::device_type, DataTags>
 createPointSet(
-    const PointCoordinates &points, const std::size_t num_point,
+    const PointCoordinates& points, const std::size_t num_point,
     const std::size_t num_alloc,
-    const LocalGrid<UniformMesh<typename PointCoordinates::value_type>>
-        &local_grid,
+    const LocalGrid<UniformMesh<typename PointCoordinates::value_type>>&
+        local_grid,
     EntityType, Spline<SplineOrder> )
 {
     using scalar_type = typename PointCoordinates::value_type;
@@ -221,34 +221,34 @@ createPointSet(
     point_set.num_point = num_point;
     point_set.num_alloc = num_alloc;
 
-    point_set.cell_size = Kokkos::View<scalar_type *[3], device_type>(
+    point_set.cell_size = Kokkos::View<scalar_type* [3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::cell_size" ),
         num_alloc );
 
-    point_set.logical_coords = Kokkos::View<scalar_type *[3], device_type>(
+    point_set.logical_coords = Kokkos::View<scalar_type* [3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::logical_coords" ),
         num_alloc );
 
-    point_set.stencil = Kokkos::View<int *[ns][3], device_type>(
+    point_set.stencil = Kokkos::View<int* [ns][3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::stencil" ),
         num_alloc );
 
-    point_set.value = Kokkos::View<scalar_type *[ns][3], device_type>(
+    point_set.value = Kokkos::View<scalar_type* [ns][3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::value" ),
         num_alloc );
 
     point_set.gradient =
-        Kokkos::View<scalar_type *[ns][ns][ns][3], device_type>(
+        Kokkos::View<scalar_type* [ns][ns][ns][3], device_type>(
             Kokkos::ViewAllocateWithoutInitializing( "PointSet::gradients" ),
             num_alloc );
 
-    point_set.distance = Kokkos::View<scalar_type *[ns][3], device_type>(
+    point_set.distance = Kokkos::View<scalar_type* [ns][3], device_type>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::distance" ),
         num_alloc );
 
     auto local_mesh = createLocalMesh<Kokkos::HostSpace>( local_grid );
 
-    int idx_low[3] = { 0, 0, 0 };
+    int idx_low[3] = {0, 0, 0};
     point_set.dx = local_mesh.measure( Edge<Dim::I>(), idx_low );
 
     point_set.rdx = 1.0 / point_set.dx;
@@ -266,15 +266,15 @@ template <class DataTags>
 void splineEvaluationTest()
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
-    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
+    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
+    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
 
     // Create the global grid.
     UniformDimPartitioner partitioner;
-    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    std::array<bool, 3> is_dim_periodic = {true, true, true};
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -286,7 +286,7 @@ void splineEvaluationTest()
     // Create a point in the center of every cell.
     auto cell_space = local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
-    Kokkos::View<double *[3], TEST_DEVICE> points(
+    Kokkos::View<double* [3], TEST_DEVICE> points(
         Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
     Kokkos::parallel_for(
         "fill_points", createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -297,7 +297,7 @@ void splineEvaluationTest()
             int pid = pi + cell_space.extent( Dim::I ) *
                                ( pj + cell_space.extent( Dim::J ) * pk );
             double x[3];
-            int idx[3] = { i, j, k };
+            int idx[3] = {i, j, k};
             local_mesh.coordinates( Cell(), idx, x );
             points( pid, Dim::I ) = x[Dim::I];
             points( pid, Dim::J ) = x[Dim::J];
@@ -313,7 +313,7 @@ void splineEvaluationTest()
     EXPECT_EQ( point_set.dx, cell_size );
     EXPECT_EQ( point_set.rdx, 1.0 / cell_size );
     double xn_low[3];
-    int idx_low[3] = { 0, 0, 0 };
+    int idx_low[3] = {0, 0, 0};
     local_mesh.coordinates( Node(), idx_low, xn_low );
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( point_set.low_corner[d], xn_low[d] );

--- a/cajita/unit_test/tstSplineEvaluation.hpp
+++ b/cajita/unit_test/tstSplineEvaluation.hpp
@@ -147,8 +147,8 @@ void updatePointSet( const LocalMeshType& local_mesh, EntityType,
         KOKKOS_LAMBDA( const int p ) {
             // Create a spline evaluation data set. This is what we are
             // actually testing in this test.
-            scalar_type px[3] = {points( p, Dim::I ), points( p, Dim::J ),
-                                 points( p, Dim::K )};
+            scalar_type px[3] = { points( p, Dim::I ), points( p, Dim::J ),
+                                  points( p, Dim::K ) };
             sd_type sd;
             evaluateSpline( local_mesh, px, sd );
 
@@ -248,7 +248,7 @@ createPointSet(
 
     auto local_mesh = createLocalMesh<Kokkos::HostSpace>( local_grid );
 
-    int idx_low[3] = {0, 0, 0};
+    int idx_low[3] = { 0, 0, 0 };
     point_set.dx = local_mesh.measure( Edge<Dim::I>(), idx_low );
 
     point_set.rdx = 1.0 / point_set.dx;
@@ -266,15 +266,15 @@ template <class DataTags>
 void splineEvaluationTest()
 {
     // Create the global mesh.
-    std::array<double, 3> low_corner = {-1.2, 0.1, 1.1};
-    std::array<double, 3> high_corner = {-0.3, 9.5, 2.3};
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
     double cell_size = 0.05;
     auto global_mesh =
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
 
     // Create the global grid.
     UniformDimPartitioner partitioner;
-    std::array<bool, 3> is_dim_periodic = {true, true, true};
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -297,7 +297,7 @@ void splineEvaluationTest()
             int pid = pi + cell_space.extent( Dim::I ) *
                                ( pj + cell_space.extent( Dim::J ) * pk );
             double x[3];
-            int idx[3] = {i, j, k};
+            int idx[3] = { i, j, k };
             local_mesh.coordinates( Cell(), idx, x );
             points( pid, Dim::I ) = x[Dim::I];
             points( pid, Dim::J ) = x[Dim::J];
@@ -313,7 +313,7 @@ void splineEvaluationTest()
     EXPECT_EQ( point_set.dx, cell_size );
     EXPECT_EQ( point_set.rdx, 1.0 / cell_size );
     double xn_low[3];
-    int idx_low[3] = {0, 0, 0};
+    int idx_low[3] = { 0, 0, 0 };
     local_mesh.coordinates( Node(), idx_low, xn_low );
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( point_set.low_corner[d], xn_low[d] );

--- a/core/performance_test/benchmark/Cabana_BenchmarkTimer.hpp
+++ b/core/performance_test/benchmark/Cabana_BenchmarkTimer.hpp
@@ -37,7 +37,7 @@ class Timer
 {
   public:
     // Create the timer.
-    Timer( const std::string &name, const int num_data )
+    Timer( const std::string& name, const int num_data )
         : _name( name )
         , _starts( num_data )
         , _data( num_data )
@@ -78,9 +78,9 @@ class Timer
 // Write timer results. Provide the values of the data points so
 // they can be injected into the table.
 template <class Scalar>
-void outputResults( std::ostream &stream, const std::string &data_point_name,
-                    const std::vector<Scalar> &data_point_vals,
-                    const Timer &timer )
+void outputResults( std::ostream& stream, const std::string& data_point_name,
+                    const std::vector<Scalar>& data_point_vals,
+                    const Timer& timer )
 {
     // Write the data header.
     stream << "\n";
@@ -121,9 +121,9 @@ void outputResults( std::ostream &stream, const std::string &data_point_name,
 // communication.
 #ifdef Cabana_ENABLE_MPI
 template <class Scalar>
-void outputResults( std::ostream &stream, const std::string &data_point_name,
-                    const std::vector<Scalar> &data_point_vals,
-                    const Timer &timer, MPI_Comm comm )
+void outputResults( std::ostream& stream, const std::string& data_point_name,
+                    const std::vector<Scalar>& data_point_vals,
+                    const Timer& timer, MPI_Comm comm )
 {
     // Get comm rank;
     int comm_rank;

--- a/core/performance_test/benchmark/Cabana_BinSortPerformance.cpp
+++ b/core/performance_test/benchmark/Cabana_BinSortPerformance.cpp
@@ -30,7 +30,7 @@ template <class Device>
 void performanceTest( std::ostream& stream, const std::string& test_prefix )
 {
     // Declare problem sizes.
-    std::vector<int> problem_sizes = {1000, 10000, 100000, 1000000, 10000000};
+    std::vector<int> problem_sizes = { 1000, 10000, 100000, 1000000, 10000000 };
     int num_problem_size = problem_sizes.size();
 
     // Generate a random set of keys
@@ -46,8 +46,8 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix )
     Kokkos::deep_copy( keys, host_keys );
 
     // Declare the number of bins to generate.
-    std::vector<int> num_bins = {10,     100,     1000,    10000,
-                                 100000, 1000000, 10000000};
+    std::vector<int> num_bins = { 10,     100,     1000,    10000,
+                                  100000, 1000000, 10000000 };
     int num_bin_size = num_bins.size();
 
     // Number of runs in the test loops.

--- a/core/performance_test/benchmark/Cabana_BinSortPerformance.cpp
+++ b/core/performance_test/benchmark/Cabana_BinSortPerformance.cpp
@@ -27,17 +27,17 @@
 //---------------------------------------------------------------------------//
 // Performance test.
 template <class Device>
-void performanceTest( std::ostream &stream, const std::string &test_prefix )
+void performanceTest( std::ostream& stream, const std::string& test_prefix )
 {
     // Declare problem sizes.
-    std::vector<int> problem_sizes = { 1000, 10000, 100000, 1000000, 10000000 };
+    std::vector<int> problem_sizes = {1000, 10000, 100000, 1000000, 10000000};
     int num_problem_size = problem_sizes.size();
 
     // Generate a random set of keys
-    Kokkos::View<unsigned long *, Device> keys(
+    Kokkos::View<unsigned long*, Device> keys(
         Kokkos::ViewAllocateWithoutInitializing( "keys" ),
         problem_sizes.back() );
-    Kokkos::View<unsigned long *, Kokkos::HostSpace> host_keys(
+    Kokkos::View<unsigned long*, Kokkos::HostSpace> host_keys(
         Kokkos::ViewAllocateWithoutInitializing( "host_keys" ),
         problem_sizes.back() );
     std::minstd_rand0 generator( 3439203991 );
@@ -46,8 +46,8 @@ void performanceTest( std::ostream &stream, const std::string &test_prefix )
     Kokkos::deep_copy( keys, host_keys );
 
     // Declare the number of bins to generate.
-    std::vector<int> num_bins = { 10,     100,     1000,    10000,
-                                  100000, 1000000, 10000000 };
+    std::vector<int> num_bins = {10,     100,     1000,    10000,
+                                 100000, 1000000, 10000000};
     int num_bin_size = num_bins.size();
 
     // Number of runs in the test loops.
@@ -180,7 +180,7 @@ void performanceTest( std::ostream &stream, const std::string &test_prefix )
 
 //---------------------------------------------------------------------------//
 // main
-int main( int argc, char *argv[] )
+int main( int argc, char* argv[] )
 {
     // Initialize environment
     Kokkos::initialize( argc, argv );

--- a/core/performance_test/benchmark/Cabana_CommPerformance.cpp
+++ b/core/performance_test/benchmark/Cabana_CommPerformance.cpp
@@ -30,8 +30,8 @@
 // Data device type is where the data to be communicated lives.
 // Comm device type is the device we want to use for communication.
 template <class DataDevice, class CommDevice>
-void performanceTest( std::ostream &stream, const std::size_t num_particle,
-                      const std::string &test_prefix )
+void performanceTest( std::ostream& stream, const std::size_t num_particle,
+                      const std::string& test_prefix )
 {
     // PROBLEM SETUP
     // -------------
@@ -71,8 +71,8 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
             for ( int i = -1; i < 2; ++i )
                 if ( !( i == 0 && j == 0 && k == 0 ) )
                 {
-                    std::vector<int> ncr = { cart_rank[0] + i, cart_rank[1] + j,
-                                             cart_rank[2] + k };
+                    std::vector<int> ncr = {cart_rank[0] + i, cart_rank[1] + j,
+                                            cart_rank[2] + k};
                     int nr;
                     MPI_Cart_rank( cart_comm, ncr.data(), &nr );
                     neighbor_ranks.push_back( nr );
@@ -103,8 +103,8 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
     // Fraction of particles on each rank that will be communicated to the
     // neighbors. We will sweep through these fractions to get an indicator of
     // performance as a function of message size.
-    std::vector<double> comm_fraction = { 0.0001, 0.001, 0.005, 0.01,
-                                          0.05,   0.10,  0.25,  0.5 };
+    std::vector<double> comm_fraction = {0.0001, 0.001, 0.005, 0.01,
+                                         0.05,   0.10,  0.25,  0.5};
     int num_fraction = comm_fraction.size();
 
     // Number of bytes we will send to each neighbor.
@@ -137,8 +137,8 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
         num_send = send_per_neighbor * 26;
         int num_stay = num_particle - num_send;
         comm_bytes[fraction] = send_per_neighbor * bytes_per_particle;
-        Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host(
-            "export_ranks", num_particle );
+        Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                                 num_particle );
         for ( int p = 0; p < num_stay; ++p )
         {
             export_ranks_host( p ) = neighbor_ranks[0];
@@ -263,10 +263,10 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
         int send_per_neighbor = num_send / 26;
         num_send = send_per_neighbor * 26;
         comm_bytes[fraction] = send_per_neighbor * bytes_per_particle;
-        Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host(
-            "export_ranks", num_send );
-        Kokkos::View<int *, Kokkos::HostSpace> export_ids_host( "export_ids",
-                                                                num_send );
+        Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                                 num_send );
+        Kokkos::View<int*, Kokkos::HostSpace> export_ids_host( "export_ids",
+                                                               num_send );
         for ( int n = 0; n < 26; ++n )
         {
             for ( int p = 0; p < send_per_neighbor; ++p )
@@ -376,7 +376,7 @@ void performanceTest( std::ostream &stream, const std::size_t num_particle,
 
 //---------------------------------------------------------------------------//
 // main
-int main( int argc, char *argv[] )
+int main( int argc, char* argv[] )
 {
     // Initialize environment
     MPI_Init( &argc, &argv );

--- a/core/performance_test/benchmark/Cabana_CommPerformance.cpp
+++ b/core/performance_test/benchmark/Cabana_CommPerformance.cpp
@@ -71,8 +71,8 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             for ( int i = -1; i < 2; ++i )
                 if ( !( i == 0 && j == 0 && k == 0 ) )
                 {
-                    std::vector<int> ncr = {cart_rank[0] + i, cart_rank[1] + j,
-                                            cart_rank[2] + k};
+                    std::vector<int> ncr = { cart_rank[0] + i, cart_rank[1] + j,
+                                             cart_rank[2] + k };
                     int nr;
                     MPI_Cart_rank( cart_comm, ncr.data(), &nr );
                     neighbor_ranks.push_back( nr );
@@ -103,8 +103,8 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
     // Fraction of particles on each rank that will be communicated to the
     // neighbors. We will sweep through these fractions to get an indicator of
     // performance as a function of message size.
-    std::vector<double> comm_fraction = {0.0001, 0.001, 0.005, 0.01,
-                                         0.05,   0.10,  0.25,  0.5};
+    std::vector<double> comm_fraction = { 0.0001, 0.001, 0.005, 0.01,
+                                          0.05,   0.10,  0.25,  0.5 };
     int num_fraction = comm_fraction.size();
 
     // Number of bytes we will send to each neighbor.

--- a/core/performance_test/benchmark/md_neighbor_perf_test.cpp
+++ b/core/performance_test/benchmark/md_neighbor_perf_test.cpp
@@ -161,15 +161,15 @@ void perfTest( const double cutoff_ratio, const std::size_t num_data,
     }
 
     // Neighbor grid list params.
-    double grid_min[3] = {x_min, x_min, x_min};
-    double grid_max[3] = {x_max, x_max, x_max};
+    double grid_min[3] = { x_min, x_min, x_min };
+    double grid_max[3] = { x_max, x_max, x_max };
 
     // Sort the particles to make them more realistic in terms of what we
     // would expect in an MD simulation. They aren't going to be randomly
     // scattered about but rather will be periodically sorted for spatial
     // locality. Bin them in cells the size of the cutoff distance.
-    double sort_delta[3] = {interaction_cutoff, interaction_cutoff,
-                            interaction_cutoff};
+    double sort_delta[3] = { interaction_cutoff, interaction_cutoff,
+                             interaction_cutoff };
     Cabana::LinkedCellList<DeviceType> linked_cell_list(
         Cabana::slice<Position>( aosoa, "position" ), sort_delta, grid_min,
         grid_max );

--- a/core/performance_test/benchmark/md_neighbor_perf_test.cpp
+++ b/core/performance_test/benchmark/md_neighbor_perf_test.cpp
@@ -133,7 +133,7 @@ void perfTest( const double cutoff_ratio, const std::size_t num_data,
                 {
                     for ( int k = k_min; k < k_max; ++k )
                     {
-                        for ( auto &n : bins[bin_id( i, j, k )] )
+                        for ( auto& n : bins[bin_id( i, j, k )] )
                         {
                             double dx = x( n, 0 ) - x( p, 0 );
                             double dy = x( n, 1 ) - x( p, 1 );
@@ -161,15 +161,15 @@ void perfTest( const double cutoff_ratio, const std::size_t num_data,
     }
 
     // Neighbor grid list params.
-    double grid_min[3] = { x_min, x_min, x_min };
-    double grid_max[3] = { x_max, x_max, x_max };
+    double grid_min[3] = {x_min, x_min, x_min};
+    double grid_max[3] = {x_max, x_max, x_max};
 
     // Sort the particles to make them more realistic in terms of what we
     // would expect in an MD simulation. They aren't going to be randomly
     // scattered about but rather will be periodically sorted for spatial
     // locality. Bin them in cells the size of the cutoff distance.
-    double sort_delta[3] = { interaction_cutoff, interaction_cutoff,
-                             interaction_cutoff };
+    double sort_delta[3] = {interaction_cutoff, interaction_cutoff,
+                            interaction_cutoff};
     Cabana::LinkedCellList<DeviceType> linked_cell_list(
         Cabana::slice<Position>( aosoa, "position" ), sort_delta, grid_min,
         grid_max );
@@ -185,7 +185,7 @@ void perfTest( const double cutoff_ratio, const std::size_t num_data,
     Kokkos::parallel_reduce(
         "Cabana::countMinMax",
         Kokkos::RangePolicy<ExecutionSpace>( 0, num_data ),
-        Kokkos::Impl::min_max_functor<Kokkos::View<int *, DeviceType>>(
+        Kokkos::Impl::min_max_functor<Kokkos::View<int*, DeviceType>>(
             stat_list._data.counts ),
         reducer );
     Kokkos::fence();
@@ -226,14 +226,14 @@ void perfTest( const double cutoff_ratio, const std::size_t num_data,
     }
 
     double avg = 0.0;
-    for ( auto &t : times )
+    for ( auto& t : times )
         avg += t;
     avg /= num_create;
     std::cout << "Average run time: " << avg << "ms" << std::endl;
     std::cout << std::endl;
 }
 
-int main( int argc, char *argv[] )
+int main( int argc, char* argv[] )
 {
     // Minimum particle distance to particle interaction cutoff distance ratio.
     double cutoff_ratio = std::atof( argv[1] );

--- a/core/performance_test/peakflops/01_cpp_simple.cpp
+++ b/core/performance_test/peakflops/01_cpp_simple.cpp
@@ -152,9 +152,9 @@ TEST( cpp, simple )
     data* c_ = new data();
 
     long i;
-    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
-                            static_cast<unsigned short>( seed >> 8 ),
-                            static_cast<unsigned short>( seed )};
+    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
+                             static_cast<unsigned short>( seed >> 8 ),
+                             static_cast<unsigned short>( seed ) };
 
     for ( i = 0; i < CABANA_PERFORMANCE_VECLENGTH; i++ )
     {

--- a/core/performance_test/peakflops/01_cpp_simple.cpp
+++ b/core/performance_test/peakflops/01_cpp_simple.cpp
@@ -93,13 +93,13 @@ struct data
     float vec[CABANA_PERFORMANCE_VECLENGTH];
 };
 
-struct data *
-axpy_10( struct data *__restrict__ a, struct data *__restrict__ x0,
-         struct data *__restrict__ x1, struct data *__restrict__ x2,
-         struct data *__restrict__ x3, struct data *__restrict__ x4,
-         struct data *__restrict__ x5, struct data *__restrict__ x6,
-         struct data *__restrict__ x7, struct data *__restrict__ x8,
-         struct data *__restrict__ x9, struct data *__restrict__ c, long n )
+struct data*
+axpy_10( struct data* __restrict__ a, struct data* __restrict__ x0,
+         struct data* __restrict__ x1, struct data* __restrict__ x2,
+         struct data* __restrict__ x3, struct data* __restrict__ x4,
+         struct data* __restrict__ x5, struct data* __restrict__ x6,
+         struct data* __restrict__ x7, struct data* __restrict__ x8,
+         struct data* __restrict__ x9, struct data* __restrict__ c, long n )
 {
     long i;
     int j;
@@ -138,23 +138,23 @@ TEST( cpp, simple )
     long n = static_cast<long>( CABANA_PERFORMANCE_ITERATIONS );
     long seed = CABANA_PERFORMANCE_SEED;
 
-    data *a_ = new data();
-    data *x_ = new data();
-    data *x1_ = new data();
-    data *x2_ = new data();
-    data *x3_ = new data();
-    data *x4_ = new data();
-    data *x5_ = new data();
-    data *x6_ = new data();
-    data *x7_ = new data();
-    data *x8_ = new data();
-    data *x9_ = new data();
-    data *c_ = new data();
+    data* a_ = new data();
+    data* x_ = new data();
+    data* x1_ = new data();
+    data* x2_ = new data();
+    data* x3_ = new data();
+    data* x4_ = new data();
+    data* x5_ = new data();
+    data* x6_ = new data();
+    data* x7_ = new data();
+    data* x8_ = new data();
+    data* x9_ = new data();
+    data* c_ = new data();
 
     long i;
-    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
-                             static_cast<unsigned short>( seed >> 8 ),
-                             static_cast<unsigned short>( seed ) };
+    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
+                            static_cast<unsigned short>( seed >> 8 ),
+                            static_cast<unsigned short>( seed )};
 
     for ( i = 0; i < CABANA_PERFORMANCE_VECLENGTH; i++ )
     {

--- a/core/performance_test/peakflops/02_kokkos_simple_view.cpp
+++ b/core/performance_test/peakflops/02_kokkos_simple_view.cpp
@@ -71,9 +71,9 @@ TEST( kokkos, simple )
     view_type c_( "c" );
 
     long i;
-    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
-                            static_cast<unsigned short>( seed >> 8 ),
-                            static_cast<unsigned short>( seed )};
+    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
+                             static_cast<unsigned short>( seed >> 8 ),
+                             static_cast<unsigned short>( seed ) };
 
     for ( i = 0; i < CABANA_PERFORMANCE_VECLENGTH; i++ )
     {

--- a/core/performance_test/peakflops/02_kokkos_simple_view.cpp
+++ b/core/performance_test/peakflops/02_kokkos_simple_view.cpp
@@ -13,12 +13,12 @@ typedef Kokkos::View<float[CABANA_PERFORMANCE_VECLENGTH],
 __attribute__( ( noinline ) )
 #endif
 view_type
-axpy_10( const view_type &__restrict__ a, const view_type &__restrict__ x0,
-         const view_type &__restrict__ x1, const view_type &__restrict__ x2,
-         const view_type &__restrict__ x3, const view_type &__restrict__ x4,
-         const view_type &__restrict__ x5, const view_type &__restrict__ x6,
-         const view_type &__restrict__ x7, const view_type &__restrict__ x8,
-         const view_type &__restrict__ x9, const view_type &__restrict__ c,
+axpy_10( const view_type& __restrict__ a, const view_type& __restrict__ x0,
+         const view_type& __restrict__ x1, const view_type& __restrict__ x2,
+         const view_type& __restrict__ x3, const view_type& __restrict__ x4,
+         const view_type& __restrict__ x5, const view_type& __restrict__ x6,
+         const view_type& __restrict__ x7, const view_type& __restrict__ x8,
+         const view_type& __restrict__ x9, const view_type& __restrict__ c,
          long n )
 {
     long i;
@@ -71,9 +71,9 @@ TEST( kokkos, simple )
     view_type c_( "c" );
 
     long i;
-    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
-                             static_cast<unsigned short>( seed >> 8 ),
-                             static_cast<unsigned short>( seed ) };
+    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
+                            static_cast<unsigned short>( seed >> 8 ),
+                            static_cast<unsigned short>( seed )};
 
     for ( i = 0; i < CABANA_PERFORMANCE_VECLENGTH; i++ )
     {

--- a/core/performance_test/peakflops/03_Cabana_peakflops.cpp
+++ b/core/performance_test/peakflops/03_Cabana_peakflops.cpp
@@ -295,9 +295,9 @@ TEST( cabana, simple )
     auto m9 = Cabana::slice<PositionX>( x9_ );
 
     // Initialize particle data.
-    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
-                            static_cast<unsigned short>( seed >> 8 ),
-                            static_cast<unsigned short>( seed )};
+    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
+                             static_cast<unsigned short>( seed >> 8 ),
+                             static_cast<unsigned short>( seed ) };
     for ( int idx = 0; idx < num_particle; ++idx )
     {
         ma( idx ) = erand48( rg );

--- a/core/performance_test/peakflops/03_Cabana_peakflops.cpp
+++ b/core/performance_test/peakflops/03_Cabana_peakflops.cpp
@@ -295,9 +295,9 @@ TEST( cabana, simple )
     auto m9 = Cabana::slice<PositionX>( x9_ );
 
     // Initialize particle data.
-    unsigned short rg[3] = { static_cast<unsigned short>( seed >> 16 ),
-                             static_cast<unsigned short>( seed >> 8 ),
-                             static_cast<unsigned short>( seed ) };
+    unsigned short rg[3] = {static_cast<unsigned short>( seed >> 16 ),
+                            static_cast<unsigned short>( seed >> 8 ),
+                            static_cast<unsigned short>( seed )};
     for ( int idx = 0; idx < num_particle; ++idx )
     {
         ma( idx ) = erand48( rg );
@@ -315,18 +315,18 @@ TEST( cabana, simple )
     }
 
     // Cast particle data to an explicit array-of-struct-of-arrays.
-    auto *pa = (data_t *)( a_.data() );
-    auto *px = (data_t *)( x_.data() );
-    auto *pc = (data_t *)( c_.data() );
-    auto *px1 = (data_t *)( x1_.data() );
-    auto *px2 = (data_t *)( x2_.data() );
-    auto *px3 = (data_t *)( x3_.data() );
-    auto *px4 = (data_t *)( x4_.data() );
-    auto *px5 = (data_t *)( x5_.data() );
-    auto *px6 = (data_t *)( x6_.data() );
-    auto *px7 = (data_t *)( x7_.data() );
-    auto *px8 = (data_t *)( x8_.data() );
-    auto *px9 = (data_t *)( x9_.data() );
+    auto* pa = (data_t*)( a_.data() );
+    auto* px = (data_t*)( x_.data() );
+    auto* pc = (data_t*)( c_.data() );
+    auto* px1 = (data_t*)( x1_.data() );
+    auto* px2 = (data_t*)( x2_.data() );
+    auto* px3 = (data_t*)( x3_.data() );
+    auto* px4 = (data_t*)( x4_.data() );
+    auto* px5 = (data_t*)( x5_.data() );
+    auto* px6 = (data_t*)( x6_.data() );
+    auto* px7 = (data_t*)( x7_.data() );
+    auto* px8 = (data_t*)( x8_.data() );
+    auto* px9 = (data_t*)( x9_.data() );
 
     // Print initial conditions.
     for ( int idx = 0; idx < array_size; ++idx )

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -58,7 +58,7 @@ struct is_aosoa : public is_aosoa_impl<typename std::remove_cv<T>::type>::type
 // Slice template helper.
 template <std::size_t M, class AoSoA_t>
 typename AoSoA_t::template member_slice_type<M>
-slice( const AoSoA_t &aosoa, const std::string &slice_label = "" )
+slice( const AoSoA_t& aosoa, const std::string& slice_label = "" )
 {
     static_assert(
         0 == sizeof( typename AoSoA_t::soa_type ) %
@@ -143,7 +143,7 @@ class AoSoA
     using soa_type = SoA<member_types, vector_length>;
 
     // Managed data view.
-    using soa_view = Kokkos::View<soa_type *, device_type, memory_traits>;
+    using soa_view = Kokkos::View<soa_type*, device_type, memory_traits>;
 
     // Number of member types.
     static constexpr std::size_t number_of_members = member_types::size;
@@ -188,7 +188,7 @@ class AoSoA
 
       The container size is zero and no memory is allocated.
     */
-    AoSoA( const std::string &label = "" )
+    AoSoA( const std::string& label = "" )
         : _size( 0 )
         , _capacity( 0 )
         , _num_soa( 0 )
@@ -227,7 +227,7 @@ class AoSoA
 
       \param n The number of tuples in the container.
     */
-    AoSoA( soa_type *ptr, const size_type num_soa, const size_type n )
+    AoSoA( soa_type* ptr, const size_type num_soa, const size_type n )
         : _size( n )
         , _capacity( num_soa * vector_length )
         , _num_soa( num_soa )
@@ -444,7 +444,7 @@ class AoSoA
       \return The SoA reference at the given index.
     */
     KOKKOS_FORCEINLINE_FUNCTION
-    soa_type &access( const size_type s ) const { return _data( s ); }
+    soa_type& access( const size_type s ) const { return _data( s ); }
 
     /*!
       \brief Get a tuple at a given index via a deep copy.
@@ -470,7 +470,7 @@ class AoSoA
       \param tpl The tuple to get the data from.
     */
     KOKKOS_INLINE_FUNCTION
-    void setTuple( const size_type i, const tuple_type &tpl ) const
+    void setTuple( const size_type i, const tuple_type& tpl ) const
     {
         Impl::tupleCopy( _data( index_type::s( i ) ), index_type::a( i ), tpl,
                          0 );
@@ -480,7 +480,7 @@ class AoSoA
       \brief Get a typed raw pointer to the entire data block.
       \return A typed raw-pointer to the entire data block.
     */
-    soa_type *data() const { return _data.data(); }
+    soa_type* data() const { return _data.data(); }
 
   private:
     // Total number of tuples in the container.

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -73,8 +73,8 @@ template <class ExportRankView>
 auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
                                   const int comm_size,
                                   CountSendsAndCreateSteeringAtomic )
-    -> std::pair<Kokkos::View<int *, typename ExportRankView::device_type>,
-                 Kokkos::View<typename ExportRankView::size_type *,
+    -> std::pair<Kokkos::View<int*, typename ExportRankView::device_type>,
+                 Kokkos::View<typename ExportRankView::size_type*,
                               typename ExportRankView::device_type>>
 {
     using device_type = typename ExportRankView::device_type;
@@ -82,9 +82,9 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
     using size_type = typename ExportRankView::size_type;
 
     // Create views.
-    Kokkos::View<int *, device_type> neighbor_counts( "neighbor_counts",
-                                                      comm_size );
-    Kokkos::View<size_type *, device_type> neighbor_ids(
+    Kokkos::View<int*, device_type> neighbor_counts( "neighbor_counts",
+                                                     comm_size );
+    Kokkos::View<size_type*, device_type> neighbor_ids(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_ids" ),
         element_export_ranks.size() );
 
@@ -108,8 +108,8 @@ template <class ExportRankView>
 auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
                                   const int comm_size,
                                   CountSendsAndCreateSteeringDuplicated )
-    -> std::pair<Kokkos::View<int *, typename ExportRankView::device_type>,
-                 Kokkos::View<typename ExportRankView::size_type *,
+    -> std::pair<Kokkos::View<int*, typename ExportRankView::device_type>,
+                 Kokkos::View<typename ExportRankView::size_type*,
                               typename ExportRankView::device_type>>
 {
     using device_type = typename ExportRankView::device_type;
@@ -122,15 +122,15 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
         unique_token;
 
     // Create views.
-    Kokkos::View<int *, device_type> neighbor_counts(
+    Kokkos::View<int*, device_type> neighbor_counts(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_counts" ),
         comm_size );
-    Kokkos::View<size_type *, device_type> neighbor_ids(
+    Kokkos::View<size_type*, device_type> neighbor_ids(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_ids" ),
         element_export_ranks.size() );
-    Kokkos::View<int **, device_type> neighbor_counts_dup(
+    Kokkos::View<int**, device_type> neighbor_counts_dup(
         "neighbor_counts", unique_token.size(), comm_size );
-    Kokkos::View<size_type **, device_type> neighbor_ids_dup(
+    Kokkos::View<size_type**, device_type> neighbor_ids_dup(
         "neighbor_ids", unique_token.size(), element_export_ranks.size() );
 
     // Compute initial duplicated sends and steering.
@@ -170,7 +170,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
     Kokkos::parallel_for(
         "Cabana::CommunicationPlan::finalCount",
         team_policy( neighbor_counts.extent( 0 ), Kokkos::AUTO ),
-        KOKKOS_LAMBDA( const typename team_policy::member_type &team ) {
+        KOKKOS_LAMBDA( const typename team_policy::member_type& team ) {
             // Get the element id.
             auto i = team.league_rank();
 
@@ -179,7 +179,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadRange( team,
                                          neighbor_counts_dup.extent( 0 ) ),
-                [&]( const index_type thread_id, int &result ) {
+                [&]( const index_type thread_id, int& result ) {
                     result += neighbor_counts_dup( thread_id, i );
                 },
                 thread_counts );
@@ -192,7 +192,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
     Kokkos::parallel_for(
         "Cabana::CommunicationPlan::createSteering",
         team_policy( element_export_ranks.size(), Kokkos::AUTO ),
-        KOKKOS_LAMBDA( const typename team_policy::member_type &team ) {
+        KOKKOS_LAMBDA( const typename team_policy::member_type& team ) {
             // Get the element id.
             auto i = team.league_rank();
 
@@ -206,7 +206,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
                 Kokkos::parallel_reduce(
                     Kokkos::TeamThreadRange( team,
                                              neighbor_ids_dup.extent( 0 ) ),
-                    [&]( const index_type thread_id, index_type &result ) {
+                    [&]( const index_type thread_id, index_type& result ) {
                         if ( neighbor_ids_dup( thread_id, i ) > 0 )
                             result += thread_id;
                     },
@@ -220,7 +220,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
                 size_type thread_offset = 0;
                 Kokkos::parallel_reduce(
                     Kokkos::TeamThreadRange( team, dup_thread ),
-                    [&]( const index_type thread_id, size_type &result ) {
+                    [&]( const index_type thread_id, size_type& result ) {
                         result += neighbor_counts_dup(
                             thread_id, element_export_ranks( i ) );
                     },
@@ -305,7 +305,7 @@ class CommunicationPlan
                 return p.release();
             }(),
             // Custom deleter to mark the communicator for deallocation
-            []( MPI_Comm *p ) {
+            []( MPI_Comm* p ) {
                 MPI_Comm_free( p );
                 delete p;
             } );
@@ -405,7 +405,7 @@ class CommunicationPlan
       (i.e. all elements going to neighbor with local id 0 first, then all
       elements going to neighbor with local id 1, etc.).
     */
-    Kokkos::View<std::size_t *, device_type> getExportSteering() const
+    Kokkos::View<std::size_t*, device_type> getExportSteering() const
     {
         return _export_steering;
     }
@@ -450,9 +450,9 @@ class CommunicationPlan
       will be efficiently migrated.
     */
     template <class ViewType>
-    Kokkos::View<size_type *, device_type>
-    createFromExportsAndTopology( const ViewType &element_export_ranks,
-                                  const std::vector<int> &neighbor_ranks )
+    Kokkos::View<size_type*, device_type>
+    createFromExportsAndTopology( const ViewType& element_export_ranks,
+                                  const std::vector<int>& neighbor_ranks )
     {
         // Store the number of export elements.
         _num_export_element = element_export_ranks.size();
@@ -478,7 +478,7 @@ class CommunicationPlan
 
         // If we are sending to ourself put that one first in the neighbor
         // list.
-        for ( auto &n : _neighbors )
+        for ( auto& n : _neighbors )
             if ( n == my_rank )
             {
                 std::swap( n, _neighbors[0] );
@@ -572,8 +572,8 @@ class CommunicationPlan
       will be efficiently migrated.
     */
     template <class ViewType>
-    Kokkos::View<size_type *, device_type>
-    createFromExportsOnly( const ViewType &element_export_ranks )
+    Kokkos::View<size_type*, device_type>
+    createFromExportsOnly( const ViewType& element_export_ranks )
     {
         // Store the number of export elements.
         _num_export_element = element_export_ranks.size();
@@ -720,8 +720,8 @@ class CommunicationPlan
       communication plan.
     */
     template <class PackViewType, class RankViewType>
-    void createExportSteering( const PackViewType &neighbor_ids,
-                               const RankViewType &element_export_ranks )
+    void createExportSteering( const PackViewType& neighbor_ids,
+                               const RankViewType& element_export_ranks )
     {
         // passing in element_export_ranks here as a dummy argument.
         createSteering( true, neighbor_ids, element_export_ranks,
@@ -748,9 +748,9 @@ class CommunicationPlan
       Cabana slice in the same memory space as the communication plan.
     */
     template <class PackViewType, class RankViewType, class IdViewType>
-    void createExportSteering( const PackViewType &neighbor_ids,
-                               const RankViewType &element_export_ranks,
-                               const IdViewType &element_export_ids )
+    void createExportSteering( const PackViewType& neighbor_ids,
+                               const RankViewType& element_export_ranks,
+                               const IdViewType& element_export_ids )
     {
         createSteering( false, neighbor_ids, element_export_ranks,
                         element_export_ids );
@@ -758,9 +758,9 @@ class CommunicationPlan
 
     // Create the export steering vector.
     template <class PackViewType, class RankViewType, class IdViewType>
-    void createSteering( const bool use_iota, const PackViewType &neighbor_ids,
-                         const RankViewType &element_export_ranks,
-                         const IdViewType &element_export_ids )
+    void createSteering( const bool use_iota, const PackViewType& neighbor_ids,
+                         const RankViewType& element_export_ranks,
+                         const IdViewType& element_export_ids )
     {
         if ( !use_iota &&
              ( element_export_ids.size() != element_export_ranks.size() ) )
@@ -778,7 +778,7 @@ class CommunicationPlan
             offsets[n] = offsets[n - 1] + _num_export[n - 1];
 
         // Map the offsets to the device.
-        Kokkos::View<std::size_t *, Kokkos::HostSpace> rank_offsets_host(
+        Kokkos::View<std::size_t*, Kokkos::HostSpace> rank_offsets_host(
             Kokkos::ViewAllocateWithoutInitializing( "rank_map" ), comm_size );
         for ( int n = 0; n < num_n; ++n )
             rank_offsets_host( _neighbors[n] ) = offsets[n];
@@ -788,11 +788,11 @@ class CommunicationPlan
         // Create the export steering vector for writing local elements into
         // the send buffer. Note we create a local, shallow copy - this is a
         // CUDA workaround for handling class private data.
-        _export_steering = Kokkos::View<std::size_t *, memory_space>(
+        _export_steering = Kokkos::View<std::size_t*, memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "export_steering" ),
             _total_num_export );
         auto steer_vec = _export_steering;
-        Kokkos::View<std::size_t *, memory_space> counts( "counts", num_n );
+        Kokkos::View<std::size_t*, memory_space> counts( "counts", num_n );
         Kokkos::parallel_for(
             "Cabana::createSteering",
             Kokkos::RangePolicy<execution_space>( 0, _num_export_element ),
@@ -813,7 +813,7 @@ class CommunicationPlan
     std::vector<std::size_t> _num_export;
     std::vector<std::size_t> _num_import;
     std::size_t _num_export_element;
-    Kokkos::View<std::size_t *, device_type> _export_steering;
+    Kokkos::View<std::size_t*, device_type> _export_steering;
 };
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -31,10 +31,10 @@ namespace Cabana
 template <class Space, class SrcAoSoA>
 inline AoSoA<typename SrcAoSoA::member_types, Space, SrcAoSoA::vector_length>
 create_mirror(
-    const Space &, const SrcAoSoA &src,
+    const Space&, const SrcAoSoA& src,
     typename std::enable_if<
         ( !std::is_same<typename SrcAoSoA::memory_space,
-                        typename Space::memory_space>::value )>::type * = 0 )
+                        typename Space::memory_space>::value )>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
                    "create_mirror() requires an AoSoA" );
@@ -54,10 +54,10 @@ create_mirror(
  */
 template <class Space, class SrcAoSoA>
 inline SrcAoSoA create_mirror_view(
-    const Space &, const SrcAoSoA &src,
+    const Space&, const SrcAoSoA& src,
     typename std::enable_if<
         ( std::is_same<typename SrcAoSoA::memory_space,
-                       typename Space::memory_space>::value )>::type * = 0 )
+                       typename Space::memory_space>::value )>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
                    "create_mirror_view() requires an AoSoA" );
@@ -76,10 +76,10 @@ inline SrcAoSoA create_mirror_view(
 template <class Space, class SrcAoSoA>
 inline AoSoA<typename SrcAoSoA::member_types, Space, SrcAoSoA::vector_length>
 create_mirror_view(
-    const Space &space, const SrcAoSoA &src,
+    const Space& space, const SrcAoSoA& src,
     typename std::enable_if<
         ( !std::is_same<typename SrcAoSoA::memory_space,
-                        typename Space::memory_space>::value )>::type * = 0 )
+                        typename Space::memory_space>::value )>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
                    "create_mirror_view() requires an AoSoA" );
@@ -98,10 +98,10 @@ create_mirror_view(
  */
 template <class Space, class SrcAoSoA>
 inline SrcAoSoA create_mirror_view_and_copy(
-    const Space &, const SrcAoSoA &src,
+    const Space&, const SrcAoSoA& src,
     typename std::enable_if<
         ( std::is_same<typename SrcAoSoA::memory_space,
-                       typename Space::memory_space>::value )>::type * = 0 )
+                       typename Space::memory_space>::value )>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
                    "create_mirror_view_and_copy() requires an AoSoA" );
@@ -121,10 +121,10 @@ inline SrcAoSoA create_mirror_view_and_copy(
 template <class Space, class SrcAoSoA>
 inline AoSoA<typename SrcAoSoA::member_types, Space, SrcAoSoA::vector_length>
 create_mirror_view_and_copy(
-    const Space &space, const SrcAoSoA &src,
+    const Space& space, const SrcAoSoA& src,
     typename std::enable_if<
         ( !std::is_same<typename SrcAoSoA::memory_space,
-                        typename Space::memory_space>::value )>::type * = 0 )
+                        typename Space::memory_space>::value )>::type* = 0 )
 {
     static_assert( is_aosoa<SrcAoSoA>::value,
                    "create_mirror_view_and_copy() requires an AoSoA" );
@@ -152,9 +152,9 @@ create_mirror_view_and_copy(
 */
 template <class DstAoSoA, class SrcAoSoA>
 inline void
-deep_copy( DstAoSoA &dst, const SrcAoSoA &src,
+deep_copy( DstAoSoA& dst, const SrcAoSoA& src,
            typename std::enable_if<( is_aosoa<DstAoSoA>::value &&
-                                     is_aosoa<SrcAoSoA>::value )>::type * = 0 )
+                                     is_aosoa<SrcAoSoA>::value )>::type* = 0 )
 {
     using dst_type = DstAoSoA;
     using src_type = SrcAoSoA;
@@ -177,8 +177,8 @@ deep_copy( DstAoSoA &dst, const SrcAoSoA &src,
     }
 
     // Get the pointers to the beginning of the data blocks.
-    void *dst_data = dst.data();
-    const void *src_data = src.data();
+    void* dst_data = dst.data();
+    const void* src_data = src.data();
 
     // Return if both pointers are null.
     if ( dst_data == nullptr && src_data == nullptr )
@@ -236,8 +236,8 @@ deep_copy( DstAoSoA &dst, const SrcAoSoA &src,
   value.
 */
 template <class AoSoA_t>
-inline void deep_copy( AoSoA_t &aosoa,
-                       const typename AoSoA_t::tuple_type &tuple )
+inline void deep_copy( AoSoA_t& aosoa,
+                       const typename AoSoA_t::tuple_type& tuple )
 {
     static_assert( is_aosoa<AoSoA_t>::value,
                    "Only AoSoAs can be assigned tuples" );
@@ -264,9 +264,9 @@ inline void deep_copy( AoSoA_t &aosoa,
 */
 template <class DstSlice, class SrcSlice>
 inline void
-deep_copy( DstSlice &dst, const SrcSlice &src,
+deep_copy( DstSlice& dst, const SrcSlice& src,
            typename std::enable_if<( is_slice<DstSlice>::value &&
-                                     is_slice<SrcSlice>::value )>::type * = 0 )
+                                     is_slice<SrcSlice>::value )>::type* = 0 )
 {
     using dst_type = DstSlice;
     using src_type = SrcSlice;
@@ -326,11 +326,11 @@ deep_copy( DstSlice &dst, const SrcSlice &src,
 
     // Gather the slice data in a flat view in the source space and copy it to
     // the destination space.
-    Kokkos::View<typename dst_type::value_type *,
+    Kokkos::View<typename dst_type::value_type*,
                  typename dst_type::memory_space>
         gather_dst( "gather_dst", num_comp * dst.size() );
     {
-        Kokkos::View<typename src_type::value_type *,
+        Kokkos::View<typename src_type::value_type*,
                      typename src_type::memory_space>
             gather_src( "gather_src", num_comp * src.size() );
         auto gather_func = KOKKOS_LAMBDA( const std::size_t i )
@@ -375,7 +375,7 @@ deep_copy( DstSlice &dst, const SrcSlice &src,
   value.
 */
 template <class Slice_t>
-inline void deep_copy( Slice_t &slice,
+inline void deep_copy( Slice_t& slice,
                        const typename Slice_t::value_type scalar )
 {
     static_assert( is_slice<Slice_t>::value,

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -228,7 +228,7 @@ void distributeData(
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
     requests.reserve( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
@@ -251,7 +251,7 @@ void distributeData(
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = {0, 0};
+    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         if ( ( distributor.numExport( n ) > 0 ) &&
@@ -500,7 +500,7 @@ void migrate( const Distributor_t& distributor, const Slice_t& src,
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
     requests.reserve( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
@@ -524,7 +524,7 @@ void migrate( const Distributor_t& distributor, const Slice_t& src,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = {0, 0};
+    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         if ( ( distributor.numExport( n ) > 0 ) &&

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -94,8 +94,8 @@ class Distributor : public CommunicationPlan<DeviceType>
       will be efficiently migrated.
     */
     template <class ViewType>
-    Distributor( MPI_Comm comm, const ViewType &element_export_ranks,
-                 const std::vector<int> &neighbor_ranks )
+    Distributor( MPI_Comm comm, const ViewType& element_export_ranks,
+                 const std::vector<int>& neighbor_ranks )
         : CommunicationPlan<DeviceType>( comm )
     {
         auto neighbor_ids = this->createFromExportsAndTopology(
@@ -131,7 +131,7 @@ class Distributor : public CommunicationPlan<DeviceType>
       will be efficiently migrated.
     */
     template <class ViewType>
-    Distributor( MPI_Comm comm, const ViewType &element_export_ranks )
+    Distributor( MPI_Comm comm, const ViewType& element_export_ranks )
         : CommunicationPlan<DeviceType>( comm )
     {
         auto neighbor_ids = this->createFromExportsOnly( element_export_ranks );
@@ -166,10 +166,10 @@ namespace Impl
 // the forward communication plan.
 template <class Distributor_t, class AoSoA_t>
 void distributeData(
-    const Distributor_t &distributor, const AoSoA_t &src, AoSoA_t &dst,
+    const Distributor_t& distributor, const AoSoA_t& src, AoSoA_t& dst,
     typename std::enable_if<( is_distributor<Distributor_t>::value &&
                               is_aosoa<AoSoA_t>::value ),
-                            int>::type * = 0 )
+                            int>::type* = 0 )
 {
     // Get the MPI rank we are currently on.
     int my_rank = -1;
@@ -188,14 +188,14 @@ void distributeData(
 
     // Allocate a send buffer.
     std::size_t num_send = distributor.totalNumExport() - num_stay;
-    Kokkos::View<typename AoSoA_t::tuple_type *,
+    Kokkos::View<typename AoSoA_t::tuple_type*,
                  typename Distributor_t::memory_space>
         send_buffer( Kokkos::ViewAllocateWithoutInitializing(
                          "distributor_send_buffer" ),
                      num_send );
 
     // Allocate a receive buffer.
-    Kokkos::View<typename AoSoA_t::tuple_type *,
+    Kokkos::View<typename AoSoA_t::tuple_type*,
                  typename Distributor_t::memory_space>
         recv_buffer( Kokkos::ViewAllocateWithoutInitializing(
                          "distributor_recv_buffer" ),
@@ -228,7 +228,7 @@ void distributeData(
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
     requests.reserve( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
@@ -251,7 +251,7 @@ void distributeData(
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> send_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         if ( ( distributor.numExport( n ) > 0 ) &&
@@ -320,11 +320,11 @@ void distributeData(
   rank. Call totalNumImport() on the distributor to get this size value.
 */
 template <class Distributor_t, class AoSoA_t>
-void migrate( const Distributor_t &distributor, const AoSoA_t &src,
-              AoSoA_t &dst,
+void migrate( const Distributor_t& distributor, const AoSoA_t& src,
+              AoSoA_t& dst,
               typename std::enable_if<( is_distributor<Distributor_t>::value &&
                                         is_aosoa<AoSoA_t>::value ),
-                                      int>::type * = 0 )
+                                      int>::type* = 0 )
 {
     // Check that src and dst are the right size.
     if ( src.size() != distributor.exportSize() )
@@ -362,10 +362,10 @@ void migrate( const Distributor_t &distributor, const AoSoA_t &src,
   reallocating is not necessary.
 */
 template <class Distributor_t, class AoSoA_t>
-void migrate( const Distributor_t &distributor, AoSoA_t &aosoa,
+void migrate( const Distributor_t& distributor, AoSoA_t& aosoa,
               typename std::enable_if<( is_distributor<Distributor_t>::value &&
                                         is_aosoa<AoSoA_t>::value ),
-                                      int>::type * = 0 )
+                                      int>::type* = 0 )
 {
     // Check that the AoSoA is the right size.
     if ( aosoa.size() != distributor.exportSize() )
@@ -414,11 +414,11 @@ void migrate( const Distributor_t &distributor, AoSoA_t &aosoa,
   rank. Call totalNumImport() on the distributor to get this size value.
 */
 template <class Distributor_t, class Slice_t>
-void migrate( const Distributor_t &distributor, const Slice_t &src,
-              Slice_t &dst,
+void migrate( const Distributor_t& distributor, const Slice_t& src,
+              Slice_t& dst,
               typename std::enable_if<( is_distributor<Distributor_t>::value &&
                                         is_slice<Slice_t>::value ),
-                                      int>::type * = 0 )
+                                      int>::type* = 0 )
 {
     // Check that src and dst are the right size.
     if ( src.size() != distributor.exportSize() )
@@ -454,7 +454,7 @@ void migrate( const Distributor_t &distributor, const Slice_t &src,
     // Allocate a send buffer. Note this one is layout right so the components
     // of each element are consecutive in memory.
     std::size_t num_send = distributor.totalNumExport() - num_stay;
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Distributor_t::memory_space>
         send_buffer( Kokkos::ViewAllocateWithoutInitializing(
                          "distributor_send_buffer" ),
@@ -462,7 +462,7 @@ void migrate( const Distributor_t &distributor, const Slice_t &src,
 
     // Allocate a receive buffer. Note this one is layout right so the
     // components of each element are consecutive in memory.
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Distributor_t::memory_space>
         recv_buffer( Kokkos::ViewAllocateWithoutInitializing(
                          "distributor_recv_buffer" ),
@@ -500,7 +500,7 @@ void migrate( const Distributor_t &distributor, const Slice_t &src,
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
     requests.reserve( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
@@ -524,7 +524,7 @@ void migrate( const Distributor_t &distributor, const Slice_t &src,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> send_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         if ( ( distributor.numExport( n ) > 0 ) &&

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -61,8 +61,7 @@ auto makePredicates(
     typename stdcxx20::remove_cvref_t<Slice>::value_type radius )
 {
     return Impl::SubsliceAndRadius<stdcxx20::remove_cvref_t<Slice>>{
-        std::forward<Slice>( slice ), first, last, radius
-    };
+        std::forward<Slice>( slice ), first, last, radius };
 }
 } // namespace Impl
 } // namespace Experimental

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -61,7 +61,8 @@ auto makePredicates(
     typename stdcxx20::remove_cvref_t<Slice>::value_type radius )
 {
     return Impl::SubsliceAndRadius<stdcxx20::remove_cvref_t<Slice>>{
-        std::forward<Slice>( slice ), first, last, radius};
+        std::forward<Slice>( slice ), first, last, radius
+    };
 }
 } // namespace Impl
 } // namespace Experimental
@@ -78,9 +79,9 @@ struct AccessTraits<Slice, PrimitivesTag,
     static KOKKOS_FUNCTION size_type size( Slice const& x ) { return x.size(); }
     static KOKKOS_FUNCTION Point get( Slice const& x, size_type i )
     {
-        return {static_cast<float>( x( i, 0 ) ),
-                static_cast<float>( x( i, 1 ) ),
-                static_cast<float>( x( i, 2 ) )};
+        return { static_cast<float>( x( i, 0 ) ),
+                 static_cast<float>( x( i, 1 ) ),
+                 static_cast<float>( x( i, 2 ) ) };
     }
 };
 template <typename SliceLike>
@@ -98,7 +99,7 @@ struct AccessTraits<SliceLike, PredicatesTag>
         auto const point =
             AccessTraits<typename SliceLike::slice_type, PrimitivesTag>::get(
                 x.slice, x.first + i );
-        return attach( intersects( Sphere{point, x.radius} ), (int)i );
+        return attach( intersects( Sphere{ point, x.radius } ), (int)i );
     }
 };
 } // namespace ArborX
@@ -241,8 +242,8 @@ auto makeNeighborList( Tag, Slice const& coordinate_slice,
         Impl::NeighborDiscriminatorCallback<Tag>{}, indices, offset,
         ArborX::Experimental::TraversalPolicy().setBufferSize( buffer_size ) );
 
-    return CrsGraph<MemorySpace, Tag>{std::move( indices ), std::move( offset ),
-                                      first, bvh.size()};
+    return CrsGraph<MemorySpace, Tag>{ std::move( indices ),
+                                       std::move( offset ), first, bvh.size() };
 }
 
 template <typename MemorySpace, typename Tag>
@@ -286,15 +287,15 @@ auto make2DNeighborList( Tag, Slice const& coordinate_slice,
         bvh.query(
             space, predicates,
             Impl::NeighborDiscriminatorCallback2D_FirstPass_BufferOptimization<
-                decltype( counts ), decltype( neighbors ), Tag>{counts,
-                                                                neighbors} );
+                decltype( counts ), decltype( neighbors ), Tag>{ counts,
+                                                                 neighbors } );
     }
     else
     {
         bvh.query(
             space, predicates,
             Impl::NeighborDiscriminatorCallback2D_FirstPass<decltype( counts ),
-                                                            Tag>{counts} );
+                                                            Tag>{ counts } );
     }
 
     auto const max_neighbors = ArborX::max( space, counts );
@@ -304,7 +305,7 @@ auto make2DNeighborList( Tag, Slice const& coordinate_slice,
         // NOTE If buffer_size is 0, neighbors is default constructed.  This is
         // fine with the current design/implementation of NeighborList access
         // traits.
-        return Dense<MemorySpace, Tag>{counts, neighbors, first, bvh.size()};
+        return Dense<MemorySpace, Tag>{ counts, neighbors, first, bvh.size() };
     }
 
     neighbors = Kokkos::View<int**, DeviceType>(
@@ -313,10 +314,10 @@ auto make2DNeighborList( Tag, Slice const& coordinate_slice,
     Kokkos::deep_copy( counts, 0 ); // reset counts to zero
     bvh.query( space, predicates,
                Impl::NeighborDiscriminatorCallback2D_SecondPass<
-                   decltype( counts ), decltype( neighbors ), Tag>{counts,
-                                                                   neighbors} );
+                   decltype( counts ), decltype( neighbors ), Tag>{
+                   counts, neighbors } );
 
-    return Dense<MemorySpace, Tag>{counts, neighbors, first, bvh.size()};
+    return Dense<MemorySpace, Tag>{ counts, neighbors, first, bvh.size() };
 }
 
 } // namespace Experimental

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -56,12 +56,12 @@ struct SubsliceAndRadius
 template <typename Slice, typename = std::enable_if_t<Cabana::is_slice<
                               std::remove_reference_t<Slice>>::value>>
 auto makePredicates(
-    Slice &&slice, typename stdcxx20::remove_cvref_t<Slice>::size_type first,
+    Slice&& slice, typename stdcxx20::remove_cvref_t<Slice>::size_type first,
     typename stdcxx20::remove_cvref_t<Slice>::size_type last,
     typename stdcxx20::remove_cvref_t<Slice>::value_type radius )
 {
     return Impl::SubsliceAndRadius<stdcxx20::remove_cvref_t<Slice>>{
-        std::forward<Slice>( slice ), first, last, radius };
+        std::forward<Slice>( slice ), first, last, radius};
 }
 } // namespace Impl
 } // namespace Experimental
@@ -75,12 +75,12 @@ struct AccessTraits<Slice, PrimitivesTag,
 {
     using memory_space = typename Slice::memory_space;
     using size_type = typename Slice::size_type;
-    static KOKKOS_FUNCTION size_type size( Slice const &x ) { return x.size(); }
-    static KOKKOS_FUNCTION Point get( Slice const &x, size_type i )
+    static KOKKOS_FUNCTION size_type size( Slice const& x ) { return x.size(); }
+    static KOKKOS_FUNCTION Point get( Slice const& x, size_type i )
     {
-        return { static_cast<float>( x( i, 0 ) ),
-                 static_cast<float>( x( i, 1 ) ),
-                 static_cast<float>( x( i, 2 ) ) };
+        return {static_cast<float>( x( i, 0 ) ),
+                static_cast<float>( x( i, 1 ) ),
+                static_cast<float>( x( i, 2 ) )};
     }
 };
 template <typename SliceLike>
@@ -88,17 +88,17 @@ struct AccessTraits<SliceLike, PredicatesTag>
 {
     using memory_space = typename SliceLike::memory_space;
     using size_type = typename SliceLike::size_type;
-    static KOKKOS_FUNCTION size_type size( SliceLike const &x )
+    static KOKKOS_FUNCTION size_type size( SliceLike const& x )
     {
         return x.last - x.first;
     }
-    static KOKKOS_FUNCTION auto get( SliceLike const &x, size_type i )
+    static KOKKOS_FUNCTION auto get( SliceLike const& x, size_type i )
     {
         assert( i < size( x ) );
         auto const point =
             AccessTraits<typename SliceLike::slice_type, PrimitivesTag>::get(
                 x.slice, x.first + i );
-        return attach( intersects( Sphere{ point, x.radius } ), (int)i );
+        return attach( intersects( Sphere{point, x.radius} ), (int)i );
     }
 };
 } // namespace ArborX
@@ -133,9 +133,9 @@ template <typename Tag>
 struct NeighborDiscriminatorCallback
 {
     template <typename Predicate, typename OutputFunctor>
-    KOKKOS_FUNCTION void operator()( Predicate const &predicate,
+    KOKKOS_FUNCTION void operator()( Predicate const& predicate,
                                      int primitive_index,
-                                     OutputFunctor const &out ) const
+                                     OutputFunctor const& out ) const
     {
         int const predicate_index = getData( predicate );
         if ( CollisionFilter<Tag>::keep( predicate_index, primitive_index ) )
@@ -151,7 +151,7 @@ struct NeighborDiscriminatorCallback2D_FirstPass
 {
     Counts counts;
     template <typename Predicate>
-    KOKKOS_FUNCTION void operator()( Predicate const &predicate,
+    KOKKOS_FUNCTION void operator()( Predicate const& predicate,
                                      int primitive_index ) const
     {
         int const predicate_index = getData( predicate );
@@ -169,7 +169,7 @@ struct NeighborDiscriminatorCallback2D_FirstPass_BufferOptimization
     Counts counts;
     Neighbors neighbors;
     template <typename Predicate>
-    KOKKOS_FUNCTION void operator()( Predicate const &predicate,
+    KOKKOS_FUNCTION void operator()( Predicate const& predicate,
                                      int primitive_index ) const
     {
         int const predicate_index = getData( predicate );
@@ -191,7 +191,7 @@ struct NeighborDiscriminatorCallback2D_SecondPass
     Counts counts;
     Neighbors neighbors;
     template <typename Predicate>
-    KOKKOS_FUNCTION void operator()( Predicate const &predicate,
+    KOKKOS_FUNCTION void operator()( Predicate const& predicate,
                                      int primitive_index ) const
     {
         int const predicate_index = getData( predicate );
@@ -212,14 +212,14 @@ struct NeighborDiscriminatorCallback2D_SecondPass
 template <typename MemorySpace, typename Tag>
 struct CrsGraph
 {
-    Kokkos::View<int *, MemorySpace> col_ind;
-    Kokkos::View<int *, MemorySpace> row_ptr;
+    Kokkos::View<int*, MemorySpace> col_ind;
+    Kokkos::View<int*, MemorySpace> row_ptr;
     typename MemorySpace::size_type shift;
     typename MemorySpace::size_type total;
 };
 
 template <typename DeviceType, typename Slice, typename Tag>
-auto makeNeighborList( Tag, Slice const &coordinate_slice,
+auto makeNeighborList( Tag, Slice const& coordinate_slice,
                        typename Slice::size_type first,
                        typename Slice::size_type last,
                        typename Slice::value_type radius, int buffer_size = 0 )
@@ -232,30 +232,30 @@ auto makeNeighborList( Tag, Slice const &coordinate_slice,
 
     ArborX::BVH<MemorySpace> bvh( space, coordinate_slice );
 
-    Kokkos::View<int *, DeviceType> indices(
+    Kokkos::View<int*, DeviceType> indices(
         Kokkos::view_alloc( "indices", Kokkos::WithoutInitializing ), 0 );
-    Kokkos::View<int *, DeviceType> offset(
+    Kokkos::View<int*, DeviceType> offset(
         Kokkos::view_alloc( "offset", Kokkos::WithoutInitializing ), 0 );
     bvh.query(
         space, Impl::makePredicates( coordinate_slice, first, last, radius ),
         Impl::NeighborDiscriminatorCallback<Tag>{}, indices, offset,
         ArborX::Experimental::TraversalPolicy().setBufferSize( buffer_size ) );
 
-    return CrsGraph<MemorySpace, Tag>{ std::move( indices ),
-                                       std::move( offset ), first, bvh.size() };
+    return CrsGraph<MemorySpace, Tag>{std::move( indices ), std::move( offset ),
+                                      first, bvh.size()};
 }
 
 template <typename MemorySpace, typename Tag>
 struct Dense
 {
-    Kokkos::View<int *, MemorySpace> cnt;
-    Kokkos::View<int **, MemorySpace> val;
+    Kokkos::View<int*, MemorySpace> cnt;
+    Kokkos::View<int**, MemorySpace> val;
     typename MemorySpace::size_type shift;
     typename MemorySpace::size_type total;
 };
 
 template <typename DeviceType, typename Slice, typename Tag>
-auto make2DNeighborList( Tag, Slice const &coordinate_slice,
+auto make2DNeighborList( Tag, Slice const& coordinate_slice,
                          typename Slice::size_type first,
                          typename Slice::size_type last,
                          typename Slice::value_type radius,
@@ -276,25 +276,25 @@ auto make2DNeighborList( Tag, Slice const &coordinate_slice,
         ArborX::AccessTraits<decltype( predicates ),
                              ArborX::PredicatesTag>::size( predicates );
 
-    Kokkos::View<int **, DeviceType> neighbors;
-    Kokkos::View<int *, DeviceType> counts( "counts", n_queries );
+    Kokkos::View<int**, DeviceType> neighbors;
+    Kokkos::View<int*, DeviceType> counts( "counts", n_queries );
     if ( buffer_size > 0 )
     {
-        neighbors = Kokkos::View<int **, DeviceType>(
+        neighbors = Kokkos::View<int**, DeviceType>(
             Kokkos::view_alloc( "neighbors", Kokkos::WithoutInitializing ),
             n_queries, buffer_size );
         bvh.query(
             space, predicates,
             Impl::NeighborDiscriminatorCallback2D_FirstPass_BufferOptimization<
-                decltype( counts ), decltype( neighbors ), Tag>{ counts,
-                                                                 neighbors } );
+                decltype( counts ), decltype( neighbors ), Tag>{counts,
+                                                                neighbors} );
     }
     else
     {
         bvh.query(
             space, predicates,
             Impl::NeighborDiscriminatorCallback2D_FirstPass<decltype( counts ),
-                                                            Tag>{ counts } );
+                                                            Tag>{counts} );
     }
 
     auto const max_neighbors = ArborX::max( space, counts );
@@ -304,19 +304,19 @@ auto make2DNeighborList( Tag, Slice const &coordinate_slice,
         // NOTE If buffer_size is 0, neighbors is default constructed.  This is
         // fine with the current design/implementation of NeighborList access
         // traits.
-        return Dense<MemorySpace, Tag>{ counts, neighbors, first, bvh.size() };
+        return Dense<MemorySpace, Tag>{counts, neighbors, first, bvh.size()};
     }
 
-    neighbors = Kokkos::View<int **, DeviceType>(
+    neighbors = Kokkos::View<int**, DeviceType>(
         Kokkos::view_alloc( "neighbors", Kokkos::WithoutInitializing ),
         n_queries, max_neighbors ); // realloc storage for neighbors
     Kokkos::deep_copy( counts, 0 ); // reset counts to zero
     bvh.query( space, predicates,
                Impl::NeighborDiscriminatorCallback2D_SecondPass<
-                   decltype( counts ), decltype( neighbors ), Tag>{
-                   counts, neighbors } );
+                   decltype( counts ), decltype( neighbors ), Tag>{counts,
+                                                                   neighbors} );
 
-    return Dense<MemorySpace, Tag>{ counts, neighbors, first, bvh.size() };
+    return Dense<MemorySpace, Tag>{counts, neighbors, first, bvh.size()};
 }
 
 } // namespace Experimental
@@ -330,7 +330,7 @@ class NeighborList<Experimental::CrsGraph<MemorySpace, Tag>>
   public:
     using memory_space = MemorySpace;
     static KOKKOS_FUNCTION size_type
-    numNeighbor( crs_graph_type const &crs_graph, size_type p )
+    numNeighbor( crs_graph_type const& crs_graph, size_type p )
     {
         assert( (int)p >= 0 && p < crs_graph.total );
         p -= crs_graph.shift;
@@ -339,7 +339,7 @@ class NeighborList<Experimental::CrsGraph<MemorySpace, Tag>>
         return crs_graph.row_ptr( p + 1 ) - crs_graph.row_ptr( p );
     }
     static KOKKOS_FUNCTION size_type
-    getNeighbor( crs_graph_type const &crs_graph, size_type p, size_type n )
+    getNeighbor( crs_graph_type const& crs_graph, size_type p, size_type n )
     {
         assert( n < numNeighbor( crs_graph, p ) );
         p -= crs_graph.shift;
@@ -355,7 +355,7 @@ class NeighborList<Experimental::Dense<MemorySpace, Tag>>
 
   public:
     using memory_space = MemorySpace;
-    static KOKKOS_FUNCTION size_type numNeighbor( specialization_type const &d,
+    static KOKKOS_FUNCTION size_type numNeighbor( specialization_type const& d,
                                                   size_type p )
     {
         assert( (int)p >= 0 && p < d.total );
@@ -364,7 +364,7 @@ class NeighborList<Experimental::Dense<MemorySpace, Tag>>
             return 0;
         return d.cnt( p );
     }
-    static KOKKOS_FUNCTION size_type getNeighbor( specialization_type const &d,
+    static KOKKOS_FUNCTION size_type getNeighbor( specialization_type const& d,
                                                   size_type p, size_type n )
     {
         assert( n < numNeighbor( d, p ) );

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -265,7 +265,7 @@ void gather( const Halo_t& halo, AoSoA_t& aosoa,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numImport( n );
@@ -281,7 +281,7 @@ void gather( const Halo_t& halo, AoSoA_t& aosoa,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = {0, 0};
+    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numExport( n );
@@ -403,7 +403,7 @@ void gather( const Halo_t& halo, Slice_t& slice,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numImport( n );
@@ -420,7 +420,7 @@ void gather( const Halo_t& halo, Slice_t& slice,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = {0, 0};
+    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numExport( n );
@@ -551,7 +551,7 @@ void scatter( const Halo_t& halo, Slice_t& slice,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numExport( n );
@@ -568,7 +568,7 @@ void scatter( const Halo_t& halo, Slice_t& slice,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = {0, 0};
+    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numImport( n );

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -99,9 +99,9 @@ class Halo : public CommunicationPlan<DeviceType>
     */
     template <class IdViewType, class RankViewType>
     Halo( MPI_Comm comm, const std::size_t num_local,
-          const IdViewType &element_export_ids,
-          const RankViewType &element_export_ranks,
-          const std::vector<int> &neighbor_ranks )
+          const IdViewType& element_export_ids,
+          const RankViewType& element_export_ranks,
+          const std::vector<int>& neighbor_ranks )
         : CommunicationPlan<DeviceType>( comm )
         , _num_local( num_local )
     {
@@ -149,8 +149,8 @@ class Halo : public CommunicationPlan<DeviceType>
     */
     template <class IdViewType, class RankViewType>
     Halo( MPI_Comm comm, const std::size_t num_local,
-          const IdViewType &element_export_ids,
-          const RankViewType &element_export_ranks )
+          const IdViewType& element_export_ids,
+          const RankViewType& element_export_ranks )
         : CommunicationPlan<DeviceType>( comm )
         , _num_local( num_local )
     {
@@ -224,17 +224,17 @@ struct is_halo : public is_halo_impl<typename std::remove_cv<T>::type>::type
   the next halo.numGhost() elements()).
 */
 template <class Halo_t, class AoSoA_t>
-void gather( const Halo_t &halo, AoSoA_t &aosoa,
+void gather( const Halo_t& halo, AoSoA_t& aosoa,
              typename std::enable_if<( is_halo<Halo_t>::value &&
                                        is_aosoa<AoSoA_t>::value ),
-                                     int>::type * = 0 )
+                                     int>::type* = 0 )
 {
     // Check that the AoSoA is the right size.
     if ( aosoa.size() != halo.numLocal() + halo.numGhost() )
         throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
     // Allocate a send buffer.
-    Kokkos::View<typename AoSoA_t::tuple_type *, typename Halo_t::memory_space>
+    Kokkos::View<typename AoSoA_t::tuple_type*, typename Halo_t::memory_space>
         send_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_send_buffer" ),
             halo.totalNumExport() );
@@ -254,7 +254,7 @@ void gather( const Halo_t &halo, AoSoA_t &aosoa,
     Kokkos::fence();
 
     // Allocate a receive buffer.
-    Kokkos::View<typename AoSoA_t::tuple_type *, typename Halo_t::memory_space>
+    Kokkos::View<typename AoSoA_t::tuple_type*, typename Halo_t::memory_space>
         recv_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_recv_buffer" ),
             halo.totalNumImport() );
@@ -265,7 +265,7 @@ void gather( const Halo_t &halo, AoSoA_t &aosoa,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numImport( n );
@@ -281,7 +281,7 @@ void gather( const Halo_t &halo, AoSoA_t &aosoa,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> send_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numExport( n );
@@ -345,10 +345,10 @@ void gather( const Halo_t &halo, AoSoA_t &aosoa,
   the next halo.numGhost() elements()).
 */
 template <class Halo_t, class Slice_t>
-void gather( const Halo_t &halo, Slice_t &slice,
+void gather( const Halo_t& halo, Slice_t& slice,
              typename std::enable_if<( is_halo<Halo_t>::value &&
                                        is_slice<Slice_t>::value ),
-                                     int>::type * = 0 )
+                                     int>::type* = 0 )
 {
     // Check that the Slice is the right size.
     if ( slice.size() != halo.numLocal() + halo.numGhost() )
@@ -364,7 +364,7 @@ void gather( const Halo_t &halo, Slice_t &slice,
 
     // Allocate a send buffer. Note this one is layout right so the components
     // are consecutive.
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Halo_t::memory_space>
         send_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_send_buffer" ),
@@ -391,7 +391,7 @@ void gather( const Halo_t &halo, Slice_t &slice,
 
     // Allocate a receive buffer. Note this one is layout right so the
     // components are consecutive.
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Halo_t::memory_space>
         recv_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_recv_buffer" ),
@@ -403,7 +403,7 @@ void gather( const Halo_t &halo, Slice_t &slice,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numImport( n );
@@ -420,7 +420,7 @@ void gather( const Halo_t &halo, Slice_t &slice,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> send_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numExport( n );
@@ -490,10 +490,10 @@ void gather( const Halo_t &halo, Slice_t &slice,
   the next halo.numGhost() elements()).
 */
 template <class Halo_t, class Slice_t>
-void scatter( const Halo_t &halo, Slice_t &slice,
+void scatter( const Halo_t& halo, Slice_t& slice,
               typename std::enable_if<( is_halo<Halo_t>::value &&
                                         is_slice<Slice_t>::value ),
-                                      int>::type * = 0 )
+                                      int>::type* = 0 )
 {
     // Check that the Slice is the right size.
     if ( slice.size() != halo.numLocal() + halo.numGhost() )
@@ -506,13 +506,13 @@ void scatter( const Halo_t &halo, Slice_t &slice,
 
     // Get the raw slice data. Wrap in a 1D Kokkos View so we can unroll the
     // components of each slice element.
-    Kokkos::View<typename Slice_t::value_type *, typename Slice_t::memory_space,
+    Kokkos::View<typename Slice_t::value_type*, typename Slice_t::memory_space,
                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>
         slice_data( slice.data(), slice.numSoA() * slice.stride( 0 ) );
 
     // Allocate a send buffer. Note this one is layout right so the components
     // are consecutive.
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Halo_t::memory_space>
         send_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_send_buffer" ),
@@ -539,7 +539,7 @@ void scatter( const Halo_t &halo, Slice_t &slice,
 
     // Allocate a receive buffer. Note this one is layout right so the
     // components are consecutive.
-    Kokkos::View<typename Slice_t::value_type **, Kokkos::LayoutRight,
+    Kokkos::View<typename Slice_t::value_type**, Kokkos::LayoutRight,
                  typename Halo_t::memory_space>
         recv_buffer(
             Kokkos::ViewAllocateWithoutInitializing( "halo_recv_buffer" ),
@@ -551,7 +551,7 @@ void scatter( const Halo_t &halo, Slice_t &slice,
     // Post non-blocking receives.
     int num_n = halo.numNeighbor();
     std::vector<MPI_Request> requests( num_n );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> recv_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + halo.numExport( n );
@@ -568,7 +568,7 @@ void scatter( const Halo_t &halo, Slice_t &slice,
     }
 
     // Do blocking sends.
-    std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
+    std::pair<std::size_t, std::size_t> send_range = {0, 0};
     for ( int n = 0; n < num_n; ++n )
     {
         send_range.second = send_range.first + halo.numImport( n );

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -35,7 +35,7 @@ class LinkedCellList
     using memory_space = typename device_type::memory_space;
     using execution_space = typename device_type::execution_space;
     using size_type = typename memory_space::size_type;
-    using OffsetView = Kokkos::View<size_type *, device_type>;
+    using OffsetView = Kokkos::View<size_type*, device_type>;
 
     /*!
       \brief Default constructor.
@@ -60,7 +60,7 @@ class LinkedCellList
         SliceType positions, const typename SliceType::value_type grid_delta[3],
         const typename SliceType::value_type grid_min[3],
         const typename SliceType::value_type grid_max[3],
-        typename std::enable_if<( is_slice<SliceType>::value ), int>::type * =
+        typename std::enable_if<( is_slice<SliceType>::value ), int>::type* =
             0 )
         : _grid( grid_min[0], grid_min[1], grid_min[2], grid_max[0],
                  grid_max[1], grid_max[2], grid_delta[0], grid_delta[1],
@@ -92,7 +92,7 @@ class LinkedCellList
         const typename SliceType::value_type grid_delta[3],
         const typename SliceType::value_type grid_min[3],
         const typename SliceType::value_type grid_max[3],
-        typename std::enable_if<( is_slice<SliceType>::value ), int>::type * =
+        typename std::enable_if<( is_slice<SliceType>::value ), int>::type* =
             0 )
         : _grid( grid_min[0], grid_min[1], grid_min[2], grid_max[0],
                  grid_max[1], grid_max[2], grid_delta[0], grid_delta[1],
@@ -143,7 +143,7 @@ class LinkedCellList
       the slowest and the k index mvoes the fastest.
     */
     KOKKOS_INLINE_FUNCTION
-    void ijkBinIndex( const int cardinal, int &i, int &j, int &k ) const
+    void ijkBinIndex( const int cardinal, int& i, int& j, int& k ) const
     {
         _grid.ijkBinIndex( cardinal, i, j, k );
     }
@@ -214,7 +214,7 @@ class LinkedCellList
         // Allocate the binning data. Note that the permutation vector spans
         // only the length of begin-end;
         std::size_t ncell = totalBins();
-        Kokkos::View<int *, memory_space> counts(
+        Kokkos::View<int*, memory_space> counts(
             Kokkos::view_alloc( Kokkos::WithoutInitializing, "counts" ),
             ncell );
         OffsetView offsets(
@@ -247,7 +247,7 @@ class LinkedCellList
 
         // Compute offsets.
         Kokkos::RangePolicy<execution_space> cell_range( 0, ncell );
-        auto offset_scan = KOKKOS_LAMBDA( const std::size_t c, int &update,
+        auto offset_scan = KOKKOS_LAMBDA( const std::size_t c, int& update,
                                           const bool final_pass )
         {
             if ( final_pass )
@@ -318,10 +318,10 @@ struct is_linked_cell_list
  */
 template <class LinkedCellListType, class AoSoA_t>
 void permute(
-    const LinkedCellListType &linked_cell_list, AoSoA_t &aosoa,
+    const LinkedCellListType& linked_cell_list, AoSoA_t& aosoa,
     typename std::enable_if<( is_linked_cell_list<LinkedCellListType>::value &&
                               is_aosoa<AoSoA_t>::value ),
-                            int>::type * = 0 )
+                            int>::type* = 0 )
 {
     permute( linked_cell_list.binningData(), aosoa );
 }
@@ -340,10 +340,10 @@ void permute(
  */
 template <class LinkedCellListType, class SliceType>
 void permute(
-    const LinkedCellListType &linked_cell_list, SliceType &slice,
+    const LinkedCellListType& linked_cell_list, SliceType& slice,
     typename std::enable_if<( is_linked_cell_list<LinkedCellListType>::value &&
                               is_slice<SliceType>::value ),
-                            int>::type * = 0 )
+                            int>::type* = 0 )
 {
     permute( linked_cell_list.binningData(), slice );
 }

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -60,13 +60,13 @@ class NeighborList
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t numNeighbor( const NeighborListType &list,
+    static std::size_t numNeighbor( const NeighborListType& list,
                                     const std::size_t particle_index );
 
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t getNeighbor( const NeighborListType &list,
+    static std::size_t getNeighbor( const NeighborListType& list,
                                     const std::size_t particle_index,
                                     const std::size_t neighbor_index );
 };

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -31,7 +31,7 @@ namespace Impl
 template <class WorkTag, class FunctorType, class... IndexTypes>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<std::is_same<WorkTag, void>::value>::type
-    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices )
+    functorTagDispatch( const FunctorType& functor, IndexTypes&&... indices )
 {
     functor( std::forward<IndexTypes>( indices )... );
 }
@@ -40,7 +40,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 template <class WorkTag, class FunctorType, class... IndexTypes>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<!std::is_same<WorkTag, void>::value>::type
-    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices )
+    functorTagDispatch( const FunctorType& functor, IndexTypes&&... indices )
 {
     const WorkTag t{};
     functor( t, std::forward<IndexTypes>( indices )... );
@@ -51,8 +51,8 @@ template <class WorkTag, class FunctorType, class... IndexTypes,
           class ReduceType>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<std::is_same<WorkTag, void>::value>::type
-    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices,
-                        ReduceType &reduce_val )
+    functorTagDispatch( const FunctorType& functor, IndexTypes&&... indices,
+                        ReduceType& reduce_val )
 {
     functor( std::forward<IndexTypes>( indices )..., reduce_val );
 }
@@ -62,8 +62,8 @@ template <class WorkTag, class FunctorType, class... IndexTypes,
           class ReduceType>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<!std::is_same<WorkTag, void>::value>::type
-    functorTagDispatch( const FunctorType &functor, IndexTypes &&... indices,
-                        ReduceType &reduce_val )
+    functorTagDispatch( const FunctorType& functor, IndexTypes&&... indices,
+                        ReduceType& reduce_val )
 {
     const WorkTag t{};
     functor( t, std::forward<IndexTypes>( indices )..., reduce_val );
@@ -116,8 +116,8 @@ KOKKOS_FORCEINLINE_FUNCTION
 */
 template <class FunctorType, int VectorLength, class... ExecParameters>
 inline void simd_parallel_for(
-    const SimdPolicy<VectorLength, ExecParameters...> &exec_policy,
-    const FunctorType &functor, const std::string &str = "" )
+    const SimdPolicy<VectorLength, ExecParameters...>& exec_policy,
+    const FunctorType& functor, const std::string& str = "" )
 {
     using simd_policy = SimdPolicy<VectorLength, ExecParameters...>;
 
@@ -128,7 +128,7 @@ inline void simd_parallel_for(
     using index_type = typename team_policy::index_type;
 
     auto simd_func =
-        KOKKOS_LAMBDA( const typename team_policy::member_type &team )
+        KOKKOS_LAMBDA( const typename team_policy::member_type& team )
     {
         index_type s = team.league_rank() + exec_policy.structBegin();
         Kokkos::parallel_for(
@@ -139,11 +139,11 @@ inline void simd_parallel_for(
             } );
     };
     if ( str.empty() )
-        Kokkos::parallel_for( dynamic_cast<const team_policy &>( exec_policy ),
+        Kokkos::parallel_for( dynamic_cast<const team_policy&>( exec_policy ),
                               simd_func );
     else
         Kokkos::parallel_for(
-            str, dynamic_cast<const team_policy &>( exec_policy ), simd_func );
+            str, dynamic_cast<const team_policy&>( exec_policy ), simd_func );
 }
 
 //---------------------------------------------------------------------------//
@@ -222,9 +222,9 @@ class TeamVectorOpTag
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const FirstNeighborsTag, const SerialOpTag, const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const FirstNeighborsTag, const SerialOpTag, const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -283,9 +283,9 @@ inline void neighbor_parallel_for(
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const SecondNeighborsTag, const SerialOpTag, const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const SecondNeighborsTag, const SerialOpTag, const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -370,9 +370,9 @@ inline void neighbor_parallel_for(
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const FirstNeighborsTag, const TeamOpTag, const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const FirstNeighborsTag, const TeamOpTag, const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -395,7 +395,7 @@ inline void neighbor_parallel_for(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_func =
-        KOKKOS_LAMBDA( const typename kokkos_policy::member_type &team )
+        KOKKOS_LAMBDA( const typename kokkos_policy::member_type& team )
     {
         index_type i = team.league_rank() + range_begin;
         Kokkos::parallel_for(
@@ -444,9 +444,9 @@ inline void neighbor_parallel_for(
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const SecondNeighborsTag, const TeamOpTag, const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const SecondNeighborsTag, const TeamOpTag, const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -469,7 +469,7 @@ inline void neighbor_parallel_for(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_func =
-        KOKKOS_LAMBDA( const typename kokkos_policy::member_type &team )
+        KOKKOS_LAMBDA( const typename kokkos_policy::member_type& team )
     {
         index_type i = team.league_rank() + range_begin;
 
@@ -523,10 +523,10 @@ inline void neighbor_parallel_for(
 */
 template <class FunctorType, class NeighborListType, class... ExecParameters>
 inline void neighbor_parallel_for(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
     const SecondNeighborsTag, const TeamVectorOpTag,
-    const std::string &str = "" )
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -549,7 +549,7 @@ inline void neighbor_parallel_for(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_func =
-        KOKKOS_LAMBDA( const typename kokkos_policy::member_type &team )
+        KOKKOS_LAMBDA( const typename kokkos_policy::member_type& team )
     {
         index_type i = team.league_rank() + range_begin;
 
@@ -610,10 +610,10 @@ inline void neighbor_parallel_for(
 template <class FunctorType, class NeighborListType, class ReduceType,
           class... ExecParameters>
 inline void neighbor_parallel_reduce(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const FirstNeighborsTag, const SerialOpTag, ReduceType &reduce_val,
-    const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const FirstNeighborsTag, const SerialOpTag, ReduceType& reduce_val,
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -629,7 +629,7 @@ inline void neighbor_parallel_reduce(
 
     static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
 
-    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType &ival )
+    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType& ival )
     {
         for ( index_type n = 0;
               n < neighbor_list_traits::numNeighbor( list, i ); ++n )
@@ -680,10 +680,10 @@ inline void neighbor_parallel_reduce(
 template <class FunctorType, class NeighborListType, class ReduceType,
           class... ExecParameters>
 inline void neighbor_parallel_reduce(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const SecondNeighborsTag, const SerialOpTag, ReduceType &reduce_val,
-    const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const SecondNeighborsTag, const SerialOpTag, ReduceType& reduce_val,
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -699,7 +699,7 @@ inline void neighbor_parallel_reduce(
 
     static_assert( is_accessible_from<memory_space, execution_space>{}, "" );
 
-    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType &ival )
+    auto neigh_reduce = KOKKOS_LAMBDA( const index_type i, ReduceType& ival )
     {
         const index_type nn = neighbor_list_traits::numNeighbor( list, i );
 
@@ -756,10 +756,10 @@ inline void neighbor_parallel_reduce(
 template <class FunctorType, class NeighborListType, class ReduceType,
           class... ExecParameters>
 inline void neighbor_parallel_reduce(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const FirstNeighborsTag, const TeamOpTag, ReduceType &reduce_val,
-    const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const FirstNeighborsTag, const TeamOpTag, ReduceType& reduce_val,
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -782,7 +782,7 @@ inline void neighbor_parallel_reduce(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_reduce = KOKKOS_LAMBDA(
-        const typename kokkos_policy::member_type &team, ReduceType &ival )
+        const typename kokkos_policy::member_type& team, ReduceType& ival )
     {
         index_type i = team.league_rank() + range_begin;
         ReduceType reduce_n = 0;
@@ -790,7 +790,7 @@ inline void neighbor_parallel_reduce(
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange(
                 team, neighbor_list_traits::numNeighbor( list, i ) ),
-            [&]( const index_type n, ReduceType &nval ) {
+            [&]( const index_type n, ReduceType& nval ) {
                 Impl::functorTagDispatch<work_tag>(
                     functor, i,
                     static_cast<index_type>(
@@ -841,10 +841,10 @@ inline void neighbor_parallel_reduce(
 template <class FunctorType, class NeighborListType, class ReduceType,
           class... ExecParameters>
 inline void neighbor_parallel_reduce(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const SecondNeighborsTag, const TeamOpTag, ReduceType &reduce_val,
-    const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const SecondNeighborsTag, const TeamOpTag, ReduceType& reduce_val,
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -867,7 +867,7 @@ inline void neighbor_parallel_reduce(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_reduce = KOKKOS_LAMBDA(
-        const typename kokkos_policy::member_type &team, ReduceType &ival )
+        const typename kokkos_policy::member_type& team, ReduceType& ival )
     {
         index_type i = team.league_rank() + range_begin;
         ReduceType reduce_n = 0;
@@ -875,7 +875,7 @@ inline void neighbor_parallel_reduce(
         const index_type nn = neighbor_list_traits::numNeighbor( list, i );
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange( team, nn ),
-            [&]( const index_type n, ReduceType &nval ) {
+            [&]( const index_type n, ReduceType& nval ) {
                 const index_type j =
                     neighbor_list_traits::getNeighbor( list, i, n );
 
@@ -931,10 +931,10 @@ inline void neighbor_parallel_reduce(
 template <class FunctorType, class NeighborListType, class ReduceType,
           class... ExecParameters>
 inline void neighbor_parallel_reduce(
-    const Kokkos::RangePolicy<ExecParameters...> &exec_policy,
-    const FunctorType &functor, const NeighborListType &list,
-    const SecondNeighborsTag, const TeamVectorOpTag, ReduceType &reduce_val,
-    const std::string &str = "" )
+    const Kokkos::RangePolicy<ExecParameters...>& exec_policy,
+    const FunctorType& functor, const NeighborListType& list,
+    const SecondNeighborsTag, const TeamVectorOpTag, ReduceType& reduce_val,
+    const std::string& str = "" )
 {
     using work_tag = typename Kokkos::RangePolicy<ExecParameters...>::work_tag;
 
@@ -957,7 +957,7 @@ inline void neighbor_parallel_reduce(
     const auto range_begin = exec_policy.begin();
 
     auto neigh_reduce = KOKKOS_LAMBDA(
-        const typename kokkos_policy::member_type &team, ReduceType &ival )
+        const typename kokkos_policy::member_type& team, ReduceType& ival )
     {
         index_type i = team.league_rank() + range_begin;
         ReduceType reduce_n = 0;
@@ -965,14 +965,14 @@ inline void neighbor_parallel_reduce(
         const index_type nn = neighbor_list_traits::numNeighbor( list, i );
         Kokkos::parallel_reduce(
             Kokkos::TeamThreadRange( team, nn ),
-            [&]( const index_type n, ReduceType &nval ) {
+            [&]( const index_type n, ReduceType& nval ) {
                 const index_type j =
                     neighbor_list_traits::getNeighbor( list, i, n );
                 ReduceType reduce_a = 0;
 
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange( team, n + 1, nn ),
-                    [&]( const index_type a, ReduceType &aval ) {
+                    [&]( const index_type a, ReduceType& aval ) {
                         const index_type k =
                             neighbor_list_traits::getNeighbor( list, i, a );
                         Impl::functorTagDispatch<work_tag>( functor, i, j, k,

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -60,7 +60,7 @@ struct LayoutCabanaSlice
                                           size_t d0 = D0, size_t d1 = D1,
                                           size_t d2 = D2, size_t d3 = D3,
                                           size_t d4 = D4, size_t d5 = D5 )
-        : dimension{num_soa, vector_length, d0, d1, d2, d3, d4, d5}
+        : dimension{ num_soa, vector_length, d0, d1, d2, d3, d4, d5 }
     {
     }
 };

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -49,10 +49,10 @@ struct LayoutCabanaSlice
 
     size_t dimension[ARRAY_LAYOUT_MAX_RANK];
 
-    LayoutCabanaSlice( LayoutCabanaSlice const & ) = default;
-    LayoutCabanaSlice( LayoutCabanaSlice && ) = default;
-    LayoutCabanaSlice &operator=( LayoutCabanaSlice const & ) = default;
-    LayoutCabanaSlice &operator=( LayoutCabanaSlice && ) = default;
+    LayoutCabanaSlice( LayoutCabanaSlice const& ) = default;
+    LayoutCabanaSlice( LayoutCabanaSlice&& ) = default;
+    LayoutCabanaSlice& operator=( LayoutCabanaSlice const& ) = default;
+    LayoutCabanaSlice& operator=( LayoutCabanaSlice&& ) = default;
 
     KOKKOS_INLINE_FUNCTION
     explicit constexpr LayoutCabanaSlice( size_t num_soa = 0,
@@ -60,7 +60,7 @@ struct LayoutCabanaSlice
                                           size_t d0 = D0, size_t d1 = D1,
                                           size_t d2 = D2, size_t d3 = D3,
                                           size_t d4 = D4, size_t d5 = D5 )
-        : dimension{ num_soa, vector_length, d0, d1, d2, d3, d4, d5 }
+        : dimension{num_soa, vector_length, d0, d1, d2, d3, d4, d5}
     {
     }
 };
@@ -96,15 +96,15 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
 
     // rank 1
     template <typename S>
-    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const &s ) const
+    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const& s ) const
     {
         return Stride * s;
     }
 
     // rank 2
     template <typename S, typename A>
-    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const &s,
-                                                           A const &a ) const
+    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const& s,
+                                                           A const& a ) const
     {
         return Stride * s + a;
     }
@@ -112,7 +112,7 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     // rank 3
     template <typename S, typename A, typename I0>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0 ) const
+    operator()( S const& s, A const& a, I0 const& i0 ) const
     {
         return Stride * s + a + VectorLength * i0;
     }
@@ -120,7 +120,7 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     // rank 4
     template <typename S, typename A, typename I0, typename I1>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0, I1 const &i1 ) const
+    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1 ) const
     {
         return Stride * s + a + VectorLength * ( i1 + D1 * i0 );
     }
@@ -128,8 +128,8 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     // rank 5
     template <typename S, typename A, typename I0, typename I1, typename I2>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0, I1 const &i1,
-                I2 const &i2 ) const
+    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
+                I2 const& i2 ) const
     {
         return Stride * s + a + VectorLength * ( i2 + D2 * ( i1 + D1 * i0 ) );
     }
@@ -138,8 +138,8 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     template <typename S, typename A, typename I0, typename I1, typename I2,
               typename I3>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0, I1 const &i1,
-                I2 const &i2, I3 const &i3 ) const
+    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
+                I2 const& i2, I3 const& i3 ) const
     {
         return Stride * s + a +
                VectorLength * ( i3 + D3 * i2 + D2 * ( i1 + D1 * i0 ) );
@@ -149,8 +149,8 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     template <typename S, typename A, typename I0, typename I1, typename I2,
               typename I3, typename I4>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0, I1 const &i1,
-                I2 const &i2, I3 const &i3, I4 const &i4 ) const
+    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
+                I2 const& i2, I3 const& i3, I4 const& i4 ) const
     {
         return Stride * s + a +
                VectorLength *
@@ -161,8 +161,8 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     template <typename S, typename A, typename I0, typename I1, typename I2,
               typename I3, typename I4, typename I5>
     KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const &s, A const &a, I0 const &i0, I1 const &i1,
-                I2 const &i2, I3 const &i3, I4 const &i4, I5 const &i5 ) const
+    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
+                I2 const& i2, I3 const& i3, I4 const& i4, I5 const& i5 ) const
     {
         return Stride * s + a +
                VectorLength *
@@ -266,7 +266,7 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
 
     // Stride with [ rank ] value is the total length
     template <typename iType>
-    KOKKOS_INLINE_FUNCTION void stride( iType *const s ) const
+    KOKKOS_INLINE_FUNCTION void stride( iType* const s ) const
     {
         if ( 0 < dimension_type::rank )
         {
@@ -306,12 +306,12 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
     //----------------------------------------
 
     ViewOffset() = default;
-    ViewOffset( const ViewOffset & ) = default;
-    ViewOffset &operator=( const ViewOffset & ) = default;
+    ViewOffset( const ViewOffset& ) = default;
+    ViewOffset& operator=( const ViewOffset& ) = default;
 
     KOKKOS_INLINE_FUNCTION
-    constexpr ViewOffset( std::integral_constant<unsigned, 0> const &,
-                          Kokkos::LayoutCabanaSlice<LayoutDims...> const &rhs )
+    constexpr ViewOffset( std::integral_constant<unsigned, 0> const&,
+                          Kokkos::LayoutCabanaSlice<LayoutDims...> const& rhs )
         : m_dim( rhs.dimension[0], rhs.dimension[1], rhs.dimension[2],
                  rhs.dimension[3], rhs.dimension[4], rhs.dimension[5],
                  rhs.dimension[6], rhs.dimension[7] )
@@ -320,7 +320,7 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
 
     template <class DimRHS, class LayoutRHS>
     KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
-        const ViewOffset<DimRHS, LayoutRHS, void> &rhs )
+        const ViewOffset<DimRHS, LayoutRHS, void>& rhs )
         : m_dim( rhs.m_dim.N0, rhs.m_dim.N1, rhs.m_dim.N2, rhs.m_dim.N3,
                  rhs.m_dim.N4, rhs.m_dim.N5, rhs.m_dim.N6, rhs.m_dim.N7 )
     {
@@ -333,8 +333,8 @@ struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
 
     template <class DimRHS, class LayoutRHS>
     KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
-        const ViewOffset<DimRHS, LayoutRHS, void> &,
-        const SubviewExtents<DimRHS::rank, dimension_type::rank> &sub )
+        const ViewOffset<DimRHS, LayoutRHS, void>&,
+        const SubviewExtents<DimRHS::rank, dimension_type::rank>& sub )
         : m_dim( sub.range_extent( 0 ), sub.range_extent( 1 ),
                  sub.range_extent( 2 ), sub.range_extent( 3 ),
                  sub.range_extent( 4 ), sub.range_extent( 5 ),
@@ -367,7 +367,7 @@ template <typename T, int VectorLength, int Stride>
 struct KokkosDataTypeImpl<T, 0, VectorLength, Stride>
 {
     using value_type = typename std::remove_all_extents<T>::type;
-    using data_type = value_type *[VectorLength];
+    using data_type = value_type* [VectorLength];
     using cabana_layout = Kokkos::LayoutCabanaSlice<Stride, VectorLength>;
 
     inline static cabana_layout createLayout( const std::size_t num_soa )
@@ -382,7 +382,7 @@ struct KokkosDataTypeImpl<T, 1, VectorLength, Stride>
 {
     using value_type = typename std::remove_all_extents<T>::type;
     static constexpr std::size_t D0 = std::extent<T, 0>::value;
-    using data_type = value_type *[VectorLength][D0];
+    using data_type = value_type* [VectorLength][D0];
     using cabana_layout = Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0>;
 
     inline static cabana_layout createLayout( const std::size_t num_soa )
@@ -398,7 +398,7 @@ struct KokkosDataTypeImpl<T, 2, VectorLength, Stride>
     using value_type = typename std::remove_all_extents<T>::type;
     static constexpr std::size_t D0 = std::extent<T, 0>::value;
     static constexpr std::size_t D1 = std::extent<T, 1>::value;
-    using data_type = value_type *[VectorLength][D0][D1];
+    using data_type = value_type* [VectorLength][D0][D1];
     using cabana_layout =
         Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0, D1>;
 
@@ -416,7 +416,7 @@ struct KokkosDataTypeImpl<T, 3, VectorLength, Stride>
     static constexpr std::size_t D0 = std::extent<T, 0>::value;
     static constexpr std::size_t D1 = std::extent<T, 1>::value;
     static constexpr std::size_t D2 = std::extent<T, 2>::value;
-    using data_type = value_type *[VectorLength][D0][D1][D2];
+    using data_type = value_type* [VectorLength][D0][D1][D2];
     using cabana_layout =
         Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0, D1, D2>;
 
@@ -576,7 +576,7 @@ class Slice
       \param label An optional label for the slice.
     */
     Slice( const pointer_type data, const size_type size,
-           const size_type num_soa, const std::string &label = "" )
+           const size_type num_soa, const std::string& label = "" )
         : _view( data, view_wrapper::createLayout( num_soa ) )
         , _size( size )
     {
@@ -591,7 +591,7 @@ class Slice
       space.
     */
     template <class MAT>
-    Slice( const Slice<DataType, DeviceType, MAT, VectorLength, Stride> &rhs )
+    Slice( const Slice<DataType, DeviceType, MAT, VectorLength, Stride>& rhs )
         : _view( rhs._view )
         , _size( rhs._size )
     {
@@ -608,8 +608,8 @@ class Slice
       space.
      */
     template <class MAT>
-    Slice &operator=(
-        const Slice<DataType, DeviceType, MAT, VectorLength, Stride> &rhs )
+    Slice& operator=(
+        const Slice<DataType, DeviceType, MAT, VectorLength, Stride>& rhs )
     {
         _view = rhs._view;
         _size = rhs._size;

--- a/core/src/Cabana_SoA.hpp
+++ b/core/src/Cabana_SoA.hpp
@@ -130,28 +130,28 @@ struct SoAImpl<VectorLength, std::index_sequence<Indices...>, Types...>
 //---------------------------------------------------------------------------//
 // Given an SoA cast it to to one of its member types.
 template <std::size_t M, class SoA_t>
-KOKKOS_FORCEINLINE_FUNCTION const typename SoA_t::template base<M> &
-soaMemberCast( const SoA_t &soa )
+KOKKOS_FORCEINLINE_FUNCTION const typename SoA_t::template base<M>&
+soaMemberCast( const SoA_t& soa )
 {
     static_assert( is_soa<SoA_t>::value, "soaMemberCast only for SoAs" );
-    return static_cast<const typename SoA_t::template base<M> &>( soa );
+    return static_cast<const typename SoA_t::template base<M>&>( soa );
 }
 
 template <std::size_t M, class SoA_t>
-KOKKOS_FORCEINLINE_FUNCTION typename SoA_t::template base<M> &
-soaMemberCast( SoA_t &soa )
+KOKKOS_FORCEINLINE_FUNCTION typename SoA_t::template base<M>&
+soaMemberCast( SoA_t& soa )
 {
     static_assert( is_soa<SoA_t>::value, "soaMemberCast only for SoAs" );
-    return static_cast<typename SoA_t::template base<M> &>( soa );
+    return static_cast<typename SoA_t::template base<M>&>( soa );
 }
 
 //---------------------------------------------------------------------------//
 // Get a pointer to the first element of a member in a given SoA.
 template <std::size_t M, class SoA_t>
-typename SoA_t::template member_pointer_type<M> soaMemberPtr( SoA_t *p )
+typename SoA_t::template member_pointer_type<M> soaMemberPtr( SoA_t* p )
 {
     static_assert( is_soa<SoA_t>::value, "soaMemberPtr only for SoAs" );
-    void *member = static_cast<typename SoA_t::template base<M> *>( p );
+    void* member = static_cast<typename SoA_t::template base<M>*>( p );
     return static_cast<typename SoA_t::template member_pointer_type<M>>(
         member );
 }
@@ -168,7 +168,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M>>::type
-get( SoA_t &soa, const std::size_t a )
+get( SoA_t& soa, const std::size_t a )
 {
     return Impl::soaMemberCast<M>( soa )._data[a];
 }
@@ -178,7 +178,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<is_soa<SoA_t>::value,
                             typename SoA_t::template member_value_type<M>>::type
-    get( const SoA_t &soa, const std::size_t a )
+    get( const SoA_t& soa, const std::size_t a )
 {
     return Impl::soaMemberCast<M>( soa )._data[a];
 }
@@ -188,7 +188,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M>>::type
-get( SoA_t &soa, const std::size_t a, const std::size_t d0 )
+get( SoA_t& soa, const std::size_t a, const std::size_t d0 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][a];
 }
@@ -198,7 +198,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<is_soa<SoA_t>::value,
                             typename SoA_t::template member_value_type<M>>::type
-    get( const SoA_t &soa, const std::size_t a, const std::size_t d0 )
+    get( const SoA_t& soa, const std::size_t a, const std::size_t d0 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][a];
 }
@@ -208,7 +208,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M>>::type
-get( SoA_t &soa, const std::size_t a, const std::size_t d0,
+get( SoA_t& soa, const std::size_t a, const std::size_t d0,
      const std::size_t d1 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][d1][a];
@@ -219,7 +219,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<is_soa<SoA_t>::value,
                             typename SoA_t::template member_value_type<M>>::type
-    get( const SoA_t &soa, const std::size_t a, const std::size_t d0,
+    get( const SoA_t& soa, const std::size_t a, const std::size_t d0,
          const std::size_t d1 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][d1][a];
@@ -230,7 +230,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_soa<SoA_t>::value,
     typename SoA_t::template member_reference_type<M>>::type
-get( SoA_t &soa, const std::size_t a, const std::size_t d0,
+get( SoA_t& soa, const std::size_t a, const std::size_t d0,
      const std::size_t d1, const std::size_t d2 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][d1][d2][a];
@@ -241,7 +241,7 @@ template <std::size_t M, class SoA_t>
 KOKKOS_FORCEINLINE_FUNCTION
     typename std::enable_if<is_soa<SoA_t>::value,
                             typename SoA_t::template member_value_type<M>>::type
-    get( const SoA_t &soa, const std::size_t a, const std::size_t d0,
+    get( const SoA_t& soa, const std::size_t a, const std::size_t d0,
          const std::size_t d1, const std::size_t d2 )
 {
     return Impl::soaMemberCast<M>( soa )._data[d0][d1][d2][a];
@@ -346,9 +346,9 @@ KOKKOS_INLINE_FUNCTION typename std::enable_if<
     ( 0 == std::rank<typename MemberTypeAtIndex<
                M, MemberTypes<Types...>>::type>::value ),
     void>::type
-soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
+soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength>& dst,
                       const std::size_t dst_idx,
-                      const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+                      const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
                       const std::size_t src_idx )
 {
     get<M>( dst, dst_idx ) = get<M>( src, src_idx );
@@ -361,9 +361,9 @@ KOKKOS_INLINE_FUNCTION typename std::enable_if<
     ( 1 == std::rank<typename MemberTypeAtIndex<
                M, MemberTypes<Types...>>::type>::value ),
     void>::type
-soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
+soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength>& dst,
                       const std::size_t dst_idx,
-                      const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+                      const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
                       const std::size_t src_idx )
 {
     for ( std::size_t i0 = 0; i0 < dst.template extent<M, 0>(); ++i0 )
@@ -377,9 +377,9 @@ KOKKOS_INLINE_FUNCTION typename std::enable_if<
     ( 2 == std::rank<typename MemberTypeAtIndex<
                M, MemberTypes<Types...>>::type>::value ),
     void>::type
-soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
+soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength>& dst,
                       const std::size_t dst_idx,
-                      const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+                      const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
                       const std::size_t src_idx )
 {
     for ( std::size_t i0 = 0; i0 < dst.template extent<M, 0>(); ++i0 )
@@ -394,9 +394,9 @@ KOKKOS_INLINE_FUNCTION typename std::enable_if<
     ( 3 == std::rank<typename MemberTypeAtIndex<
                M, MemberTypes<Types...>>::type>::value ),
     void>::type
-soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
+soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength>& dst,
                       const std::size_t dst_idx,
-                      const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+                      const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
                       const std::size_t src_idx )
 {
     for ( std::size_t i0 = 0; i0 < dst.template extent<M, 0>(); ++i0 )
@@ -411,8 +411,8 @@ soaElementMemberCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
 template <std::size_t M, int DstVectorLength, int SrcVectorLength,
           typename... Types>
 KOKKOS_INLINE_FUNCTION void soaElementCopy(
-    SoA<MemberTypes<Types...>, DstVectorLength> &dst, const std::size_t dst_idx,
-    const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+    SoA<MemberTypes<Types...>, DstVectorLength>& dst, const std::size_t dst_idx,
+    const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
     const std::size_t src_idx, std::integral_constant<std::size_t, M> )
 {
     soaElementMemberCopy<M>( dst, dst_idx, src, src_idx );
@@ -422,8 +422,8 @@ KOKKOS_INLINE_FUNCTION void soaElementCopy(
 
 template <int DstVectorLength, int SrcVectorLength, typename... Types>
 KOKKOS_INLINE_FUNCTION void soaElementCopy(
-    SoA<MemberTypes<Types...>, DstVectorLength> &dst, const std::size_t dst_idx,
-    const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+    SoA<MemberTypes<Types...>, DstVectorLength>& dst, const std::size_t dst_idx,
+    const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
     const std::size_t src_idx, std::integral_constant<std::size_t, 0> )
 {
     soaElementMemberCopy<0>( dst, dst_idx, src, src_idx );
@@ -432,9 +432,9 @@ KOKKOS_INLINE_FUNCTION void soaElementCopy(
 // Copy the data from one struct at a given index to another.
 template <int DstVectorLength, int SrcVectorLength, typename... Types>
 KOKKOS_INLINE_FUNCTION void
-tupleCopy( SoA<MemberTypes<Types...>, DstVectorLength> &dst,
+tupleCopy( SoA<MemberTypes<Types...>, DstVectorLength>& dst,
            const std::size_t dst_idx,
-           const SoA<MemberTypes<Types...>, SrcVectorLength> &src,
+           const SoA<MemberTypes<Types...>, SrcVectorLength>& src,
            const std::size_t src_idx )
 {
     soaElementCopy(

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -37,8 +37,8 @@ class BinningData
     using memory_space = typename device_type::memory_space;
     using execution_space = typename device_type::execution_space;
     using size_type = typename memory_space::size_type;
-    using CountView = Kokkos::View<const int *, device_type>;
-    using OffsetView = Kokkos::View<size_type *, device_type>;
+    using CountView = Kokkos::View<const int*, device_type>;
+    using OffsetView = Kokkos::View<size_type*, device_type>;
 
     BinningData()
         : _nbin( 0 )
@@ -193,11 +193,11 @@ kokkosBinSort1d( KeyViewType keys, const int nbin, const bool sort_within_bins,
 //---------------------------------------------------------------------------//
 // Copy the a 1D slice into a Kokkos view.
 template <class SliceType, class DeviceType = typename SliceType::device_type>
-Kokkos::View<typename SliceType::value_type *, typename SliceType::device_type>
+Kokkos::View<typename SliceType::value_type*, typename SliceType::device_type>
 copySliceToKeys( SliceType slice )
 {
     using KeyViewType =
-        Kokkos::View<typename SliceType::value_type *, DeviceType>;
+        Kokkos::View<typename SliceType::value_type*, DeviceType>;
     KeyViewType keys( Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ),
                       slice.size() );
     Kokkos::RangePolicy<typename DeviceType::execution_space> exec_policy(
@@ -242,8 +242,8 @@ template <class KeyViewType, class Comparator,
 BinningData<DeviceType> sortByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
-    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ), int>::type
-        * = 0 )
+    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                            int>::type* = 0 )
 {
     auto bin_data = Impl::kokkosBinSort<KeyViewType, DeviceType>(
         keys, comp, true, begin, end );
@@ -271,8 +271,8 @@ template <class KeyViewType, class Comparator,
           class DeviceType = typename KeyViewType::device_type>
 BinningData<DeviceType> sortByKeyWithComparator(
     KeyViewType keys, Comparator comp,
-    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ), int>::type
-        * = 0 )
+    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                            int>::type* = 0 )
 {
     Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, true, 0,
                                                   keys.extent( 0 ) );
@@ -304,8 +304,8 @@ template <class KeyViewType, class Comparator,
 BinningData<DeviceType> binByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
-    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ), int>::type
-        * = 0 )
+    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                            int>::type* = 0 )
 {
     return Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, false,
                                                          begin, end );
@@ -332,8 +332,8 @@ template <class KeyViewType, class Comparator,
           class DeviceType = typename KeyViewType::device_type>
 BinningData<DeviceType> binByKeyWithComparator(
     KeyViewType keys, Comparator comp,
-    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ), int>::type
-        * = 0 )
+    typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                            int>::type* = 0 )
 {
     return Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, false, 0,
                                                          keys.extent( 0 ) );
@@ -360,7 +360,7 @@ template <class KeyViewType,
 BinningData<DeviceType>
 sortByKey( KeyViewType keys, const std::size_t begin, const std::size_t end,
            typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                   int>::type * = 0 )
+                                   int>::type* = 0 )
 {
     int nbin = ( end - begin ) / 2;
     return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, true,
@@ -384,7 +384,7 @@ template <class KeyViewType,
 BinningData<DeviceType>
 sortByKey( KeyViewType keys,
            typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                   int>::type * = 0 )
+                                   int>::type* = 0 )
 {
     return sortByKey<KeyViewType, DeviceType>( keys, 0, keys.extent( 0 ) );
 }
@@ -415,7 +415,7 @@ BinningData<DeviceType>
 binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
           const std::size_t end,
           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                  int>::type * = 0 )
+                                  int>::type* = 0 )
 {
     return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, false,
                                                            begin, end );
@@ -441,7 +441,7 @@ template <class KeyViewType,
 BinningData<DeviceType>
 binByKey( KeyViewType keys, const int nbin,
           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                  int>::type * = 0 )
+                                  int>::type* = 0 )
 {
     return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, false, 0,
                                                            keys.extent( 0 ) );
@@ -465,7 +465,7 @@ binByKey( KeyViewType keys, const int nbin,
 template <class SliceType, class DeviceType = typename SliceType::device_type>
 BinningData<DeviceType> sortByKey(
     SliceType slice, const std::size_t begin, const std::size_t end,
-    typename std::enable_if<( is_slice<SliceType>::value ), int>::type * = 0 )
+    typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
     auto keys = Impl::copySliceToKeys<SliceType, DeviceType>( slice );
     return sortByKey<decltype( keys ), DeviceType>( keys, begin, end );
@@ -484,7 +484,7 @@ BinningData<DeviceType> sortByKey(
 template <class SliceType, class DeviceType = typename SliceType::device_type>
 BinningData<DeviceType> sortByKey(
     SliceType slice,
-    typename std::enable_if<( is_slice<SliceType>::value ), int>::type * = 0 )
+    typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
     return sortByKey<SliceType, DeviceType>( slice, 0, slice.size() );
 }
@@ -511,7 +511,7 @@ template <class SliceType, class DeviceType = typename SliceType::device_type>
 BinningData<DeviceType> binByKey(
     SliceType slice, const int nbin, const std::size_t begin,
     const std::size_t end,
-    typename std::enable_if<( is_slice<SliceType>::value ), int>::type * = 0 )
+    typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
     auto keys = Impl::copySliceToKeys<SliceType, DeviceType>( slice );
     return binByKey<decltype( keys ), DeviceType>( keys, nbin, begin, end );
@@ -533,7 +533,7 @@ BinningData<DeviceType> binByKey(
 template <class SliceType, class DeviceType = typename SliceType::device_type>
 BinningData<DeviceType> binByKey(
     SliceType slice, const int nbin,
-    typename std::enable_if<( is_slice<SliceType>::value ), int>::type * = 0 )
+    typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
     return binByKey<SliceType, DeviceType>( slice, nbin, 0, slice.size() );
 }
@@ -553,15 +553,15 @@ BinningData<DeviceType> binByKey(
 template <class BinningDataType, class AoSoA_t,
           class DeviceType = typename BinningDataType::device_type>
 void permute(
-    const BinningDataType &binning_data, AoSoA_t &aosoa,
+    const BinningDataType& binning_data, AoSoA_t& aosoa,
     typename std::enable_if<( is_binning_data<BinningDataType>::value &&
                               is_aosoa<AoSoA_t>::value ),
-                            int>::type * = 0 )
+                            int>::type* = 0 )
 {
     auto begin = binning_data.rangeBegin();
     auto end = binning_data.rangeEnd();
 
-    Kokkos::View<typename AoSoA_t::tuple_type *, DeviceType> scratch_tuples(
+    Kokkos::View<typename AoSoA_t::tuple_type*, DeviceType> scratch_tuples(
         Kokkos::ViewAllocateWithoutInitializing( "scratch_tuples" ),
         end - begin );
 
@@ -602,10 +602,10 @@ void permute(
 template <class BinningDataType, class SliceType,
           class DeviceType = typename BinningDataType::device_type>
 void permute(
-    const BinningDataType &binning_data, SliceType &slice,
+    const BinningDataType& binning_data, SliceType& slice,
     typename std::enable_if<( is_binning_data<BinningDataType>::value &&
                               is_slice<SliceType>::value ),
-                            int>::type * = 0 )
+                            int>::type* = 0 )
 {
 
     auto begin = binning_data.rangeBegin();
@@ -619,7 +619,7 @@ void permute(
     // Get the raw slice data.
     auto slice_data = slice.data();
 
-    Kokkos::View<typename SliceType::value_type **, DeviceType> scratch_array(
+    Kokkos::View<typename SliceType::value_type**, DeviceType> scratch_array(
         Kokkos::ViewAllocateWithoutInitializing( "scratch_array" ), end - begin,
         num_comp );
 

--- a/core/src/Cabana_Tuple.hpp
+++ b/core/src/Cabana_Tuple.hpp
@@ -52,17 +52,17 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M>>::type
-get( Tuple_t &tp )
+get( Tuple_t& tp )
 {
-    return get<M>( static_cast<typename Tuple_t::base &>( tp ), 0 );
+    return get<M>( static_cast<typename Tuple_t::base&>( tp ), 0 );
 }
 
 // Rank-0 const
 template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename Tuple_t::template member_value_type<M>
-get( const Tuple_t &tp )
+get( const Tuple_t& tp )
 {
-    return get<M>( static_cast<const typename Tuple_t::base &>( tp ), 0 );
+    return get<M>( static_cast<const typename Tuple_t::base&>( tp ), 0 );
 }
 
 // Rank-1 non-const
@@ -70,9 +70,9 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M>>::type
-get( Tuple_t &tp, const std::size_t d0 )
+get( Tuple_t& tp, const std::size_t d0 )
 {
-    return get<M>( static_cast<typename Tuple_t::base &>( tp ), 0, d0 );
+    return get<M>( static_cast<typename Tuple_t::base&>( tp ), 0, d0 );
 }
 
 // Rank-1 const
@@ -80,9 +80,9 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M>>::type
-get( const Tuple_t &tp, const std::size_t d0 )
+get( const Tuple_t& tp, const std::size_t d0 )
 {
-    return get<M>( static_cast<const typename Tuple_t::base &>( tp ), 0, d0 );
+    return get<M>( static_cast<const typename Tuple_t::base&>( tp ), 0, d0 );
 }
 
 // Rank-2 non-const
@@ -90,9 +90,9 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M>>::type
-get( Tuple_t &tp, const std::size_t d0, const std::size_t d1 )
+get( Tuple_t& tp, const std::size_t d0, const std::size_t d1 )
 {
-    return get<M>( static_cast<typename Tuple_t::base &>( tp ), 0, d0, d1 );
+    return get<M>( static_cast<typename Tuple_t::base&>( tp ), 0, d0, d1 );
 }
 
 // Rank-2 const
@@ -100,9 +100,9 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M>>::type
-get( const Tuple_t &tp, const std::size_t d0, const std::size_t d1 )
+get( const Tuple_t& tp, const std::size_t d0, const std::size_t d1 )
 {
-    return get<M>( static_cast<const typename Tuple_t::base &>( tp ), 0, d0,
+    return get<M>( static_cast<const typename Tuple_t::base&>( tp ), 0, d0,
                    d1 );
 }
 
@@ -111,10 +111,10 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_reference_type<M>>::type
-get( Tuple_t &tp, const std::size_t d0, const std::size_t d1,
+get( Tuple_t& tp, const std::size_t d0, const std::size_t d1,
      const std::size_t d2 )
 {
-    return get<M>( static_cast<typename Tuple_t::base &>( tp ), 0, d0, d1, d2 );
+    return get<M>( static_cast<typename Tuple_t::base&>( tp ), 0, d0, d1, d2 );
 }
 
 // Rank-3 const
@@ -122,10 +122,10 @@ template <std::size_t M, class Tuple_t>
 KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
     is_tuple<Tuple_t>::value,
     typename Tuple_t::template member_value_type<M>>::type
-get( const Tuple_t &tp, const std::size_t d0, const std::size_t d1,
+get( const Tuple_t& tp, const std::size_t d0, const std::size_t d1,
      const std::size_t d2 )
 {
-    return get<M>( static_cast<const typename Tuple_t::base &>( tp ), 0, d0, d1,
+    return get<M>( static_cast<const typename Tuple_t::base&>( tp ), 0, d0, d1,
                    d2 );
 }
 
@@ -146,23 +146,23 @@ struct Tuple<MemberTypes<Types...>> : SoA<MemberTypes<Types...>, 1>
 
     KOKKOS_DEFAULTED_FUNCTION Tuple() = default;
 
-    KOKKOS_FORCEINLINE_FUNCTION Tuple( const Tuple &t )
+    KOKKOS_FORCEINLINE_FUNCTION Tuple( const Tuple& t )
     {
         Impl::tupleCopy( *this, 0, t, 0 );
     }
 
-    KOKKOS_FORCEINLINE_FUNCTION Tuple( Tuple &&t )
+    KOKKOS_FORCEINLINE_FUNCTION Tuple( Tuple&& t )
     {
         Impl::tupleCopy( *this, 0, t, 0 );
     }
 
-    KOKKOS_FORCEINLINE_FUNCTION Tuple &operator=( const Tuple &t )
+    KOKKOS_FORCEINLINE_FUNCTION Tuple& operator=( const Tuple& t )
     {
         Impl::tupleCopy( *this, 0, t, 0 );
         return *this;
     }
 
-    KOKKOS_FORCEINLINE_FUNCTION Tuple &operator=( Tuple &&t )
+    KOKKOS_FORCEINLINE_FUNCTION Tuple& operator=( Tuple&& t )
     {
         Impl::tupleCopy( *this, 0, t, 0 );
         return *this;

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -255,7 +255,7 @@ struct VerletListBuilder
         // not just the requested range. This is because all particles are
         // treated as candidates for neighbors.
         double grid_size = cell_size_ratio * neighborhood_radius;
-        PositionValueType grid_delta[3] = {grid_size, grid_size, grid_size};
+        PositionValueType grid_delta[3] = { grid_size, grid_size, grid_size };
         linked_cell_list =
             LinkedCellList<device>( position, grid_delta, grid_min, grid_max );
         bin_data_1d = linked_cell_list.binningData();

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -47,13 +47,13 @@ struct VerletListData<DeviceType, VerletLayoutCSR>
     using device_type = DeviceType;
 
     // Number of neighbors per particle.
-    Kokkos::View<int *, device_type> counts;
+    Kokkos::View<int*, device_type> counts;
 
     // Offsets into the neighbor list.
-    Kokkos::View<int *, device_type> offsets;
+    Kokkos::View<int*, device_type> offsets;
 
     // Neighbor list.
-    Kokkos::View<int *, device_type> neighbors;
+    Kokkos::View<int*, device_type> neighbors;
 
     // Add a neighbor to the list.
     KOKKOS_INLINE_FUNCTION
@@ -71,10 +71,10 @@ struct VerletListData<DeviceType, VerletLayout2D>
     using device_type = DeviceType;
 
     // Number of neighbors per particle.
-    Kokkos::View<int *, device_type> counts;
+    Kokkos::View<int*, device_type> counts;
 
     // Neighbor list.
-    Kokkos::View<int **, device_type> neighbors;
+    Kokkos::View<int**, device_type> neighbors;
 
     // Add a neighbor to the list.
     KOKKOS_INLINE_FUNCTION
@@ -164,8 +164,8 @@ struct LinkedCellStencil
 
     // Given a cell, get the index bounds of the cell stencil.
     KOKKOS_INLINE_FUNCTION
-    void getCells( const int cell, int &imin, int &imax, int &jmin, int &jmax,
-                   int &kmin, int &kmax ) const
+    void getCells( const int cell, int& imin, int& imax, int& jmin, int& jmax,
+                   int& kmin, int& kmax ) const
     {
         int i, j, k;
         grid.ijkBinIndex( cell, i, j, k );
@@ -242,7 +242,7 @@ struct VerletListBuilder
 
         // Create the count view.
         _data.counts =
-            Kokkos::View<int *, memory_space>( "num_neighbors", slice.size() );
+            Kokkos::View<int*, memory_space>( "num_neighbors", slice.size() );
 
         // Make a guess for the number of neighbors per particle for 2D lists.
         initCounts( LayoutTag() );
@@ -255,7 +255,7 @@ struct VerletListBuilder
         // not just the requested range. This is because all particles are
         // treated as candidates for neighbors.
         double grid_size = cell_size_ratio * neighborhood_radius;
-        PositionValueType grid_delta[3] = { grid_size, grid_size, grid_size };
+        PositionValueType grid_delta[3] = {grid_size, grid_size, grid_size};
         linked_cell_list =
             LinkedCellList<device>( position, grid_delta, grid_min, grid_max );
         bin_data_1d = linked_cell_list.binningData();
@@ -275,8 +275,8 @@ struct VerletListBuilder
 
     KOKKOS_INLINE_FUNCTION
     void
-    operator()( const CountNeighborsTag &,
-                const typename CountNeighborsPolicy::member_type &team ) const
+    operator()( const CountNeighborsTag&,
+                const typename CountNeighborsPolicy::member_type& team ) const
     {
         // The league rank of the team is the cardinal cell index we are
         // working on.
@@ -337,14 +337,14 @@ struct VerletListBuilder
 
     // Neighbor count team vector loop (only used for CSR lists).
     KOKKOS_INLINE_FUNCTION void
-    neighbor_reduce( const typename CountNeighborsPolicy::member_type &team,
+    neighbor_reduce( const typename CountNeighborsPolicy::member_type& team,
                      const std::size_t pid, const double x_p, const double y_p,
                      const double z_p, const int n_offset, const int num_n,
-                     int &cell_count, TeamVectorOpTag ) const
+                     int& cell_count, TeamVectorOpTag ) const
     {
         Kokkos::parallel_reduce(
             Kokkos::ThreadVectorRange( team, num_n ),
-            [&]( const int n, int &local_count ) {
+            [&]( const int n, int& local_count ) {
                 neighbor_kernel( pid, x_p, y_p, z_p, n_offset, n, local_count );
             },
             cell_count );
@@ -355,7 +355,7 @@ struct VerletListBuilder
     void neighbor_reduce( const typename CountNeighborsPolicy::member_type,
                           const std::size_t pid, const double x_p,
                           const double y_p, const double z_p,
-                          const int n_offset, const int num_n, int &cell_count,
+                          const int n_offset, const int num_n, int& cell_count,
                           TeamOpTag ) const
     {
         for ( int n = 0; n < num_n; n++ )
@@ -366,7 +366,7 @@ struct VerletListBuilder
     KOKKOS_INLINE_FUNCTION
     void neighbor_kernel( const int pid, const double x_p, const double y_p,
                           const double z_p, const int n_offset, const int n,
-                          int &local_count ) const
+                          int& local_count ) const
     {
         //  Get the true id of the candidate  neighbor.
         std::size_t nid = linked_cell_list.permutation( n_offset + n );
@@ -399,10 +399,10 @@ struct VerletListBuilder
     struct OffsetScanOp
     {
         using kokkos_mem_space = KokkosMemorySpace;
-        Kokkos::View<int *, kokkos_mem_space> counts;
-        Kokkos::View<int *, kokkos_mem_space> offsets;
+        Kokkos::View<int*, kokkos_mem_space> counts;
+        Kokkos::View<int*, kokkos_mem_space> offsets;
         KOKKOS_INLINE_FUNCTION
-        void operator()( const int i, int &update, const bool final_pass ) const
+        void operator()( const int i, int& update, const bool final_pass ) const
         {
             if ( final_pass )
                 offsets( i ) = update;
@@ -418,7 +418,7 @@ struct VerletListBuilder
         {
             count = false;
 
-            _data.neighbors = Kokkos::View<int **, memory_space>(
+            _data.neighbors = Kokkos::View<int**, memory_space>(
                 Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
                 _data.counts.size(), max_n );
         }
@@ -427,7 +427,7 @@ struct VerletListBuilder
     void processCounts( VerletLayoutCSR )
     {
         // Allocate offsets.
-        _data.offsets = Kokkos::View<int *, memory_space>(
+        _data.offsets = Kokkos::View<int*, memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "neighbor_offsets" ),
             _data.counts.size() );
 
@@ -443,7 +443,7 @@ struct VerletListBuilder
         Kokkos::fence();
 
         // Allocate the neighbor list.
-        _data.neighbors = Kokkos::View<int *, memory_space>(
+        _data.neighbors = Kokkos::View<int*, memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
             total_num_neighbor );
 
@@ -462,7 +462,7 @@ struct VerletListBuilder
         Kokkos::parallel_reduce(
             "Cabana::VerletListBuilder::reduce_max",
             Kokkos::RangePolicy<execution_space>( 0, _data.counts.size() ),
-            KOKKOS_LAMBDA( const int i, int &value ) {
+            KOKKOS_LAMBDA( const int i, int& value ) {
                 if ( counts( i ) > value )
                     value = counts( i );
             },
@@ -475,7 +475,7 @@ struct VerletListBuilder
         {
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );
-            _data.neighbors = Kokkos::View<int **, memory_space>(
+            _data.neighbors = Kokkos::View<int**, memory_space>(
                 Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
                 _data.counts.size(), max_num_neighbor );
         }
@@ -491,8 +491,8 @@ struct VerletListBuilder
                            Kokkos::Schedule<Kokkos::Dynamic>>;
     KOKKOS_INLINE_FUNCTION
     void
-    operator()( const FillNeighborsTag &,
-                const typename FillNeighborsPolicy::member_type &team ) const
+    operator()( const FillNeighborsTag&,
+                const typename FillNeighborsPolicy::member_type& team ) const
     {
         // The league rank of the team is the cardinal cell index we are
         // working on.
@@ -545,7 +545,7 @@ struct VerletListBuilder
 
     // Neighbor fill team vector loop.
     KOKKOS_INLINE_FUNCTION void
-    neighbor_for( const typename FillNeighborsPolicy::member_type &team,
+    neighbor_for( const typename FillNeighborsPolicy::member_type& team,
                   const std::size_t pid, const double x_p, const double y_p,
                   const double z_p, const int n_offset, const int num_n,
                   TeamVectorOpTag ) const
@@ -692,7 +692,7 @@ class VerletList
                 const typename PositionSlice::value_type grid_max[3],
                 const std::size_t max_neigh = 0,
                 typename std::enable_if<( is_slice<PositionSlice>::value ),
-                                        int>::type * = 0 )
+                                        int>::type* = 0 )
     {
         // Create a builder functor.
         using builder_type =
@@ -758,14 +758,14 @@ class NeighborList<
 
     // Get the total number of neighbors (maximum size of CSR list).
     KOKKOS_INLINE_FUNCTION
-    static std::size_t maxNeighbor( const list_type &list )
+    static std::size_t maxNeighbor( const list_type& list )
     {
         return list._data.neighbors.extent( 0 );
     }
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t numNeighbor( const list_type &list,
+    static std::size_t numNeighbor( const list_type& list,
                                     const std::size_t particle_index )
     {
         return list._data.counts( particle_index );
@@ -774,7 +774,7 @@ class NeighborList<
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t getNeighbor( const list_type &list,
+    static std::size_t getNeighbor( const list_type& list,
                                     const std::size_t particle_index,
                                     const std::size_t neighbor_index )
     {
@@ -796,14 +796,14 @@ class NeighborList<
 
     // Get the maximum number of neighbors per particle.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t maxNeighbor( const list_type &list )
+    static std::size_t maxNeighbor( const list_type& list )
     {
         return list._data.neighbors.extent( 1 );
     }
 
     // Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t numNeighbor( const list_type &list,
+    static std::size_t numNeighbor( const list_type& list,
                                     const std::size_t particle_index )
     {
         return list._data.counts( particle_index );
@@ -812,7 +812,7 @@ class NeighborList<
     // Get the id for a neighbor for a given particle index and the index of
     // the neighbor relative to the particle.
     KOKKOS_INLINE_FUNCTION
-    static std::size_t getNeighbor( const list_type &list,
+    static std::size_t getNeighbor( const list_type& list,
                                     const std::size_t particle_index,
                                     const std::size_t neighbor_index )
     {

--- a/core/src/impl/Cabana_CartesianGrid.hpp
+++ b/core/src/impl/Cabana_CartesianGrid.hpp
@@ -75,7 +75,7 @@ class CartesianGrid
 
     // Get the number of cells in each direction.
     KOKKOS_INLINE_FUNCTION
-    void numCells( int &num_x, int &num_y, int &num_z )
+    void numCells( int& num_x, int& num_y, int& num_z )
     {
         num_x = _nx;
         num_y = _ny;
@@ -98,8 +98,8 @@ class CartesianGrid
 
     // Given a position get the ijk indices of the cell in which
     KOKKOS_INLINE_FUNCTION
-    void locatePoint( const Real xp, const Real yp, const Real zp, int &ic,
-                      int &jc, int &kc ) const
+    void locatePoint( const Real xp, const Real yp, const Real zp, int& ic,
+                      int& jc, int& kc ) const
     {
         ic = cellsBetween( xp, _min_x, _rdx );
         jc = cellsBetween( yp, _min_y, _rdy );
@@ -136,7 +136,7 @@ class CartesianGrid
     }
 
     KOKKOS_INLINE_FUNCTION
-    void ijkBinIndex( const int cardinal, int &i, int &j, int &k ) const
+    void ijkBinIndex( const int cardinal, int& i, int& j, int& k ) const
     {
         i = cardinal / ( _ny * _nz );
         j = ( cardinal / _nz ) % _ny;

--- a/core/unit_test/mpi_unit_test_main.cpp
+++ b/core/unit_test/mpi_unit_test_main.cpp
@@ -15,7 +15,7 @@
 
 #include <mpi.h>
 
-int main( int argc, char *argv[] )
+int main( int argc, char* argv[] )
 {
     MPI_Init( &argc, &argv );
     Kokkos::initialize( argc, argv );

--- a/core/unit_test/neighbor_unit_test.hpp
+++ b/core/unit_test/neighbor_unit_test.hpp
@@ -29,13 +29,13 @@ namespace Test
 template <class... Params>
 struct TestNeighborList
 {
-    Kokkos::View<int *, Params...> counts;
-    Kokkos::View<int **, Params...> neighbors;
+    Kokkos::View<int*, Params...> counts;
+    Kokkos::View<int**, Params...> neighbors;
 };
 
 template <class KokkosMemorySpace>
 TestNeighborList<typename TEST_EXECSPACE::array_layout, Kokkos::HostSpace>
-createTestListHostCopy( const TestNeighborList<KokkosMemorySpace> &test_list )
+createTestListHostCopy( const TestNeighborList<KokkosMemorySpace>& test_list )
 {
     using data_layout = typename decltype( test_list.counts )::array_layout;
     TestNeighborList<data_layout, Kokkos::HostSpace> list_copy;
@@ -50,13 +50,13 @@ createTestListHostCopy( const TestNeighborList<KokkosMemorySpace> &test_list )
 // Create a host copy of a list that implements the neighbor list interface.
 template <class ListType>
 TestNeighborList<typename TEST_EXECSPACE::array_layout, Kokkos::HostSpace>
-copyListToHost( const ListType &list, const int num_particle, const int max_n )
+copyListToHost( const ListType& list, const int num_particle, const int max_n )
 {
     TestNeighborList<TEST_MEMSPACE> list_copy;
     list_copy.counts =
-        Kokkos::View<int *, TEST_MEMSPACE>( "counts", num_particle );
+        Kokkos::View<int*, TEST_MEMSPACE>( "counts", num_particle );
     list_copy.neighbors =
-        Kokkos::View<int **, TEST_MEMSPACE>( "neighbors", num_particle, max_n );
+        Kokkos::View<int**, TEST_MEMSPACE>( "neighbors", num_particle, max_n );
     Kokkos::parallel_for(
         "copy list", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_particle ),
         KOKKOS_LAMBDA( const int p ) {
@@ -101,7 +101,7 @@ createParticles( const int num_particle, const double box_min,
 //---------------------------------------------------------------------------//
 template <class PositionSlice>
 TestNeighborList<TEST_MEMSPACE>
-computeFullNeighborList( const PositionSlice &position,
+computeFullNeighborList( const PositionSlice& position,
                          const double neighborhood_radius )
 {
     // Build a neighbor list with a brute force n^2 implementation. Count
@@ -109,8 +109,8 @@ computeFullNeighborList( const PositionSlice &position,
     TestNeighborList<TEST_MEMSPACE> list;
     int num_particle = position.size();
     double rsqr = neighborhood_radius * neighborhood_radius;
-    list.counts = Kokkos::View<int *, TEST_MEMSPACE>( "test_neighbor_count",
-                                                      num_particle );
+    list.counts = Kokkos::View<int*, TEST_MEMSPACE>( "test_neighbor_count",
+                                                     num_particle );
     Kokkos::deep_copy( list.counts, 0 );
     auto count_op = KOKKOS_LAMBDA( const int i )
     {
@@ -132,7 +132,7 @@ computeFullNeighborList( const PositionSlice &position,
     Kokkos::fence();
 
     // Allocate.
-    auto max_op = KOKKOS_LAMBDA( const int i, int &max_val )
+    auto max_op = KOKKOS_LAMBDA( const int i, int& max_val )
     {
         if ( max_val < list.counts( i ) )
             max_val = list.counts( i );
@@ -140,8 +140,8 @@ computeFullNeighborList( const PositionSlice &position,
     int max_n;
     Kokkos::parallel_reduce( exec_policy, max_op, Kokkos::Max<int>( max_n ) );
     Kokkos::fence();
-    list.neighbors = Kokkos::View<int **, TEST_MEMSPACE>( "test_neighbors",
-                                                          num_particle, max_n );
+    list.neighbors = Kokkos::View<int**, TEST_MEMSPACE>( "test_neighbors",
+                                                         num_particle, max_n );
 
     // Fill.
     auto fill_op = KOKKOS_LAMBDA( const int i )
@@ -171,8 +171,8 @@ computeFullNeighborList( const PositionSlice &position,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType>
-void checkFullNeighborList( const ListType &nlist,
-                            const TestListType &N2_list_copy,
+void checkFullNeighborList( const ListType& nlist,
+                            const TestListType& N2_list_copy,
                             const int num_particle )
 {
     // Create host neighbor list copy.
@@ -207,8 +207,8 @@ void checkFullNeighborList( const ListType &nlist,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType>
-void checkHalfNeighborList( const ListType &nlist,
-                            const TestListType &N2_list_copy,
+void checkHalfNeighborList( const ListType& nlist,
+                            const TestListType& N2_list_copy,
                             const int num_particle )
 {
     // Create host neighbor list copy.
@@ -248,7 +248,7 @@ void checkHalfNeighborList( const ListType &nlist,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType>
-void checkFullNeighborListPartialRange( const ListType &nlist,
+void checkFullNeighborListPartialRange( const ListType& nlist,
                                         const TestListType N2_list_copy,
                                         const int num_particle,
                                         const int num_ignore )
@@ -292,18 +292,17 @@ void checkFullNeighborListPartialRange( const ListType &nlist,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType>
-void checkFirstNeighborParallelFor( const ListType &nlist,
-                                    const TestListType &N2_list_copy,
+void checkFirstNeighborParallelFor( const ListType& nlist,
+                                    const TestListType& N2_list_copy,
                                     const int num_particle )
 {
     // Create Kokkos views for the write operation.
     using memory_space = typename TEST_MEMSPACE::memory_space;
-    Kokkos::View<int *, Kokkos::HostSpace> N2_result( "N2_result",
-                                                      num_particle );
-    Kokkos::View<int *, memory_space> serial_result( "serial_result",
+    Kokkos::View<int*, Kokkos::HostSpace> N2_result( "N2_result",
                                                      num_particle );
-    Kokkos::View<int *, memory_space> team_result( "team_result",
-                                                   num_particle );
+    Kokkos::View<int*, memory_space> serial_result( "serial_result",
+                                                    num_particle );
+    Kokkos::View<int*, memory_space> team_result( "team_result", num_particle );
 
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
@@ -343,20 +342,19 @@ void checkFirstNeighborParallelFor( const ListType &nlist,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType>
-void checkSecondNeighborParallelFor( const ListType &nlist,
-                                     const TestListType &N2_list_copy,
+void checkSecondNeighborParallelFor( const ListType& nlist,
+                                     const TestListType& N2_list_copy,
                                      const int num_particle )
 {
     // Create Kokkos views for the write operation.
     using memory_space = typename TEST_MEMSPACE::memory_space;
-    Kokkos::View<int *, Kokkos::HostSpace> N2_result( "N2_result",
-                                                      num_particle );
-    Kokkos::View<int *, memory_space> serial_result( "serial_result",
+    Kokkos::View<int*, Kokkos::HostSpace> N2_result( "N2_result",
                                                      num_particle );
-    Kokkos::View<int *, memory_space> team_result( "team_result",
-                                                   num_particle );
-    Kokkos::View<int *, memory_space> vector_result( "vector_result",
-                                                     num_particle );
+    Kokkos::View<int*, memory_space> serial_result( "serial_result",
+                                                    num_particle );
+    Kokkos::View<int*, memory_space> team_result( "team_result", num_particle );
+    Kokkos::View<int*, memory_space> vector_result( "vector_result",
+                                                    num_particle );
 
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
@@ -414,14 +412,14 @@ void checkSecondNeighborParallelFor( const ListType &nlist,
 }
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType, class AoSoAType>
-void checkFirstNeighborParallelReduce( const ListType &nlist,
-                                       const TestListType &N2_list_copy,
-                                       const AoSoAType &aosoa )
+void checkFirstNeighborParallelReduce( const ListType& nlist,
+                                       const TestListType& N2_list_copy,
+                                       const AoSoAType& aosoa )
 {
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
     auto position = Cabana::slice<0>( aosoa );
-    auto sum_op = KOKKOS_LAMBDA( const int i, const int n, double &sum )
+    auto sum_op = KOKKOS_LAMBDA( const int i, const int n, double& sum )
     {
         sum += position( i, 0 ) + position( n, 0 );
     };
@@ -461,15 +459,15 @@ void checkFirstNeighborParallelReduce( const ListType &nlist,
 
 //---------------------------------------------------------------------------//
 template <class ListType, class TestListType, class AoSoAType>
-void checkSecondNeighborParallelReduce( const ListType &nlist,
-                                        const TestListType &N2_list_copy,
-                                        const AoSoAType &aosoa )
+void checkSecondNeighborParallelReduce( const ListType& nlist,
+                                        const TestListType& N2_list_copy,
+                                        const AoSoAType& aosoa )
 {
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
     auto position = Cabana::slice<0>( aosoa );
     auto sum_op =
-        KOKKOS_LAMBDA( const int i, const int n, const int a, double &sum )
+        KOKKOS_LAMBDA( const int i, const int n, const int a, double& sum )
     {
         sum += position( i, 0 ) + position( n, 0 ) + position( a, 0 );
     };
@@ -525,8 +523,8 @@ struct NeighborListTestData
     double box_max = 4.7 * test_radius;
 
     double cell_size_ratio = 0.5;
-    double grid_min[3] = { box_min, box_min, box_min };
-    double grid_max[3] = { box_max, box_max, box_max };
+    double grid_min[3] = {box_min, box_min, box_min};
+    double grid_max[3] = {box_max, box_max, box_max};
 
     Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE> aosoa;
     TestNeighborList<typename TEST_EXECSPACE::array_layout, Kokkos::HostSpace>

--- a/core/unit_test/neighbor_unit_test.hpp
+++ b/core/unit_test/neighbor_unit_test.hpp
@@ -523,8 +523,8 @@ struct NeighborListTestData
     double box_max = 4.7 * test_radius;
 
     double cell_size_ratio = 0.5;
-    double grid_min[3] = {box_min, box_min, box_min};
-    double grid_max[3] = {box_max, box_max, box_max};
+    double grid_min[3] = { box_min, box_min, box_min };
+    double grid_max[3] = { box_max, box_max, box_max };
 
     Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE> aosoa;
     TestNeighborList<typename TEST_EXECSPACE::array_layout, Kokkos::HostSpace>

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -267,11 +267,11 @@ void testRawData()
 
     // Get raw pointers to the data as one would in a C interface (no
     // templates).
-    float *p0 = slice_0.data();
-    int *p1 = slice_1.data();
-    double *p2 = slice_2.data();
-    int *p3 = slice_3.data();
-    double *p4 = slice_4.data();
+    float* p0 = slice_0.data();
+    int* p1 = slice_1.data();
+    double* p2 = slice_2.data();
+    int* p3 = slice_3.data();
+    double* p4 = slice_4.data();
 
     // Get the strides between the member arrays.
     int st0 = slice_0.stride( 0 );
@@ -365,8 +365,8 @@ void testTuple()
     AoSoA_t aosoa( "label", num_data );
 
     // Create a slice of tuples with the same data types.
-    Kokkos::View<Tuple_t *, typename AoSoA_t::memory_space> tuples( "tuples",
-                                                                    num_data );
+    Kokkos::View<Tuple_t*, typename AoSoA_t::memory_space> tuples( "tuples",
+                                                                   num_data );
 
     // Initialize aosoa data.
     auto slice_0 = Cabana::slice<0>( aosoa );
@@ -480,7 +480,7 @@ void testAccess()
     Kokkos::parallel_for(
         "data_fill", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.numSoA() ),
         KOKKOS_LAMBDA( const int s ) {
-            auto &soa = aosoa.access( s );
+            auto& soa = aosoa.access( s );
 
             for ( std::size_t a = 0; a < aosoa.arraySize( s ); ++a )
             {
@@ -540,7 +540,7 @@ void testUnmanaged()
     using soa_type = MySoA<vector_length, dim_1, dim_2, dim_3>;
     int num_soa = 3;
     int size = 35;
-    Kokkos::View<soa_type *, TEST_MEMSPACE> user_data( "user_aosoa", 3 );
+    Kokkos::View<soa_type*, TEST_MEMSPACE> user_data( "user_aosoa", 3 );
 
     // Declare the AoSoA type.
     using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE, vector_length,
@@ -548,7 +548,7 @@ void testUnmanaged()
 
     // Create an AoSoA.
     auto user_ptr =
-        reinterpret_cast<typename AoSoA_t::soa_type *>( user_data.data() );
+        reinterpret_cast<typename AoSoA_t::soa_type*>( user_data.data() );
     AoSoA_t aosoa( user_ptr, num_soa, size );
 
     // Check sizes.

--- a/core/unit_test/tstCartesianGrid.cpp
+++ b/core/unit_test/tstCartesianGrid.cpp
@@ -21,9 +21,9 @@ namespace Test
 
 TEST( cabana_cartesian_grid, grid_test )
 {
-    double min[3] = {-1.0, -0.5, -0.6};
-    double max[3] = {2.5, 1.5, 1.9};
-    double delta[3] = {0.5, 0.125, 0.25};
+    double min[3] = { -1.0, -0.5, -0.6 };
+    double max[3] = { 2.5, 1.5, 1.9 };
+    double delta[3] = { 0.5, 0.125, 0.25 };
 
     Cabana::Impl::CartesianGrid<double> grid( min[0], min[1], min[2], max[0],
                                               max[1], max[2], delta[0],

--- a/core/unit_test/tstCartesianGrid.cpp
+++ b/core/unit_test/tstCartesianGrid.cpp
@@ -21,9 +21,9 @@ namespace Test
 
 TEST( cabana_cartesian_grid, grid_test )
 {
-    double min[3] = { -1.0, -0.5, -0.6 };
-    double max[3] = { 2.5, 1.5, 1.9 };
-    double delta[3] = { 0.5, 0.125, 0.25 };
+    double min[3] = {-1.0, -0.5, -0.6};
+    double max[3] = {2.5, 1.5, 1.9};
+    double delta[3] = {0.5, 0.125, 0.25};
 
     Cabana::Impl::CartesianGrid<double> grid( min[0], min[1], min[2], max[0],
                                               max[1], max[2], delta[0],

--- a/core/unit_test/tstCommunicationPlan.hpp
+++ b/core/unit_test/tstCommunicationPlan.hpp
@@ -38,32 +38,32 @@ class CommPlanTester : public Cabana::CommunicationPlan<
     }
 
     template <class ViewType>
-    Kokkos::View<size_type *, device_type>
-    createFromExportsAndNeighbors( const ViewType &element_export_ranks,
-                                   const std::vector<int> &neighbor_ranks )
+    Kokkos::View<size_type*, device_type>
+    createFromExportsAndNeighbors( const ViewType& element_export_ranks,
+                                   const std::vector<int>& neighbor_ranks )
     {
         return this->createFromExportsAndTopology( element_export_ranks,
                                                    neighbor_ranks );
     }
 
     template <class ViewType>
-    Kokkos::View<size_type *, device_type>
-    createFromExports( const ViewType &element_export_ranks )
+    Kokkos::View<size_type*, device_type>
+    createFromExports( const ViewType& element_export_ranks )
     {
         return this->createFromExportsOnly( element_export_ranks );
     }
 
     template <class ViewType>
-    void createSteering( Kokkos::View<size_type *, device_type> neighbor_ids,
-                         const ViewType &element_export_ranks )
+    void createSteering( Kokkos::View<size_type*, device_type> neighbor_ids,
+                         const ViewType& element_export_ranks )
     {
         this->createExportSteering( neighbor_ids, element_export_ranks );
     }
 
     template <class RankViewType, class IdViewType>
-    void createSteering( Kokkos::View<size_type *, device_type> neighbor_ids,
-                         const RankViewType &element_export_ranks,
-                         const IdViewType &element_export_ids )
+    void createSteering( Kokkos::View<size_type*, device_type> neighbor_ids,
+                         const RankViewType& element_export_ranks,
+                         const IdViewType& element_export_ids )
     {
         this->createExportSteering( neighbor_ids, element_export_ranks,
                                     element_export_ids );
@@ -83,14 +83,14 @@ void test1( const bool use_topology )
 
     // Every rank will communicate with itself and send all of its data.
     int num_data = 10;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, my_rank );
     std::vector<int> neighbor_ranks( 1, my_rank );
 
     // Create the plan.
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -136,8 +136,8 @@ void test2( const bool use_topology )
     // Every rank will communicate with itself and send every other piece of
     // data.
     int num_data = 10;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     for ( int n = 0; n < num_data; ++n )
         export_ranks_host( n ) = ( 0 == n % 2 ) ? my_rank : -1;
     auto export_ranks = Kokkos::create_mirror_view_and_copy(
@@ -147,7 +147,7 @@ void test2( const bool use_topology )
     // Create the plan
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -163,7 +163,7 @@ void test2( const bool use_topology )
     EXPECT_EQ( comm_plan.totalNumImport(), num_data / 2 );
 
     // Create the export steering vector.
-    Kokkos::View<std::size_t *, Kokkos::HostSpace> export_ids_host(
+    Kokkos::View<std::size_t*, Kokkos::HostSpace> export_ids_host(
         "export_ids", export_ranks.size() );
     std::iota( export_ids_host.data(),
                export_ids_host.data() + export_ranks.size(), 0 );
@@ -205,14 +205,14 @@ void test3( const bool use_topology )
 
     // Every rank will communicate with the rank that is its inverse.
     int num_data = 10;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, inverse_rank );
     std::vector<int> neighbor_ranks( 1, inverse_rank );
 
     // Create the plan with both export ranks and the topology.
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -260,8 +260,8 @@ void test4( const bool use_topology )
 
     // Every rank will communicate with all other ranks. Interleave the sends.
     int num_data = 2 * my_size;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     std::vector<int> neighbor_ranks( my_size );
     for ( int n = 0; n < my_size; ++n )
     {
@@ -275,7 +275,7 @@ void test4( const bool use_topology )
     // Create the plan
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -380,8 +380,8 @@ void test5( const bool use_topology )
     // Every rank will communicate with all other ranks. Interleave the sends
     // and only send every other value.
     int num_data = 2 * my_size;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     std::vector<int> neighbor_ranks( my_size );
     for ( int n = 0; n < my_size; ++n )
     {
@@ -395,7 +395,7 @@ void test5( const bool use_topology )
     // Create the plan
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -465,7 +465,7 @@ void test6( const bool use_topology )
 
     // Every has one element and will send that element to rank 0.
     int num_data = 1;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, 0 );
     std::vector<int> neighbor_ranks;
     if ( 0 == my_rank )
@@ -481,7 +481,7 @@ void test6( const bool use_topology )
     // Create the plan.
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -543,7 +543,7 @@ void test7( const bool use_topology )
     // Create the plan.
     using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type *, device_type> neighbor_ids;
+    Kokkos::View<size_type*, device_type> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -39,7 +39,7 @@ void test1( const bool use_topology )
 
     // Every rank will communicate with itself and send all of its data.
     int num_data = 10;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, my_rank );
     std::vector<int> neighbor_ranks( 1, my_rank );
 
@@ -108,8 +108,8 @@ void test2( const bool use_topology )
     // Every rank will communicate with itself and send every other piece of
     // data.
     int num_data = 10;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     for ( int n = 0; n < num_data; ++n )
         export_ranks_host( n ) = ( 0 == n % 2 ) ? my_rank : -1;
     auto export_ranks = Kokkos::create_mirror_view_and_copy(
@@ -185,7 +185,7 @@ void test3( const bool use_topology )
 
     // Every rank will communicate with the rank that is its inverse.
     int num_data = 10;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, inverse_rank );
     std::vector<int> neighbor_ranks( 1, inverse_rank );
 
@@ -228,7 +228,7 @@ void test3( const bool use_topology )
     // they sent us stuff in. We thread the creation of the steering vector so
     // its order is not deterministic.
     auto my_steering = distributor->getExportSteering();
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> inverse_steering(
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> inverse_steering(
         "inv_steering", distributor->totalNumImport() );
     int mpi_tag = 1030;
     MPI_Request request;
@@ -274,8 +274,8 @@ void test4( const bool use_topology )
 
     // Every rank will communicate with all other ranks. Interleave the sends.
     int num_data = 2 * my_size;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     std::vector<int> neighbor_ranks( my_size );
     for ( int n = 0; n < my_size; ++n )
     {
@@ -379,8 +379,8 @@ void test5( const bool use_topology )
     // Every rank will communicate with all other ranks. Interleave the sends
     // and only send every other value.
     int num_data = 2 * my_size;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              num_data );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             num_data );
     std::vector<int> neighbor_ranks( my_size );
     for ( int n = 0; n < my_size; ++n )
     {
@@ -472,7 +472,7 @@ void test6( const bool use_topology )
 
     // Every has one element and will send that element to rank 0.
     int num_data = 1;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     Kokkos::deep_copy( export_ranks, 0 );
     std::vector<int> neighbor_ranks;
     if ( 0 == my_rank )
@@ -554,7 +554,7 @@ void test7( const bool use_topology )
 
     // Rank 0 starts with all the data and sends one element to every rank.
     int num_data = ( 0 == my_rank ) ? my_size : 0;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     auto fill_ranks = KOKKOS_LAMBDA( const int i ) { export_ranks( i ) = i; };
     Kokkos::RangePolicy<TEST_EXECSPACE> range_policy( 0, num_data );
     Kokkos::parallel_for( range_policy, fill_ranks );
@@ -633,7 +633,7 @@ void test8( const bool use_topology )
     // where rank 0 receives from rank with id (my_size-1) but does not send
     // data to that rank.
     int num_data = 2;
-    Kokkos::View<int *, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
+    Kokkos::View<int*, TEST_MEMSPACE> export_ranks( "export_ranks", num_data );
     auto fill_ranks = KOKKOS_LAMBDA( const int )
     {
         export_ranks( 0 ) = ( my_rank == 0 ) ? 0 : my_rank - 1;

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -45,10 +45,10 @@ void test1( const bool use_topology )
     // each rank including yourself. Interleave the sends. The resulting
     // communication plan has ghosts that have one unique destination.
     int num_local = 2 * my_size;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              my_size );
-    Kokkos::View<std::size_t *, Kokkos::HostSpace> export_ids_host(
-        "export_ids", my_size );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             my_size );
+    Kokkos::View<std::size_t*, Kokkos::HostSpace> export_ids_host( "export_ids",
+                                                                   my_size );
     std::vector<int> neighbors( my_size );
     for ( int n = 0; n < my_size; ++n )
     {
@@ -244,10 +244,10 @@ void test2( const bool use_topology )
     // ranks. This will create collisions in the scatter as every rank will
     // have data for this rank in the summation.
     int num_local = 1;
-    Kokkos::View<int *, Kokkos::HostSpace> export_ranks_host( "export_ranks",
-                                                              my_size );
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> export_ids( "export_ids",
-                                                           my_size );
+    Kokkos::View<int*, Kokkos::HostSpace> export_ranks_host( "export_ranks",
+                                                             my_size );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> export_ids( "export_ids",
+                                                          my_size );
     Kokkos::deep_copy( export_ids, 0 );
     std::vector<int> neighbors( my_size );
     for ( int n = 0; n < my_size; ++n )

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -63,9 +63,9 @@ void testLinkedList()
         } );
 
     // Create a grid.
-    double grid_delta[3] = { dx, dx, dx };
-    double grid_min[3] = { x_min, x_min, x_min };
-    double grid_max[3] = { x_max, x_max, x_max };
+    double grid_delta[3] = {dx, dx, dx};
+    double grid_min[3] = {x_min, x_min, x_min};
+    double grid_max[3] = {x_max, x_max, x_max};
 
     // Bin and permute the particles in the grid. First do this by only
     // operating on a subset of the particles.
@@ -83,11 +83,11 @@ void testLinkedList()
         EXPECT_EQ( cell_list.numBin( 2 ), nx );
 
         // Copy data to the host for testing.
-        Kokkos::View<int *[3], TEST_MEMSPACE> ids( "cell_ids", num_p );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                             nx );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                               nx, nx );
+        Kokkos::View<int* [3], TEST_MEMSPACE> ids( "cell_ids", num_p );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
+                                                            nx );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
+                                                              nx, nx );
         Kokkos::parallel_for(
             "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
             KOKKOS_LAMBDA( const int i ) {
@@ -184,11 +184,11 @@ void testLinkedList()
         Cabana::permute( cell_list, aosoa );
 
         // Copy data to the host for testing.
-        Kokkos::View<int *[3], TEST_MEMSPACE> ids( "cell_ids", num_p );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                             nx );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                               nx, nx );
+        Kokkos::View<int* [3], TEST_MEMSPACE> ids( "cell_ids", num_p );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
+                                                            nx );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
+                                                              nx, nx );
         Kokkos::parallel_for(
             "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
             KOKKOS_LAMBDA( const int i ) {
@@ -284,9 +284,9 @@ void testLinkedListSlice()
         } );
 
     // Create a grid.
-    double grid_delta[3] = { dx, dx, dx };
-    double grid_min[3] = { x_min, x_min, x_min };
-    double grid_max[3] = { x_max, x_max, x_max };
+    double grid_delta[3] = {dx, dx, dx};
+    double grid_min[3] = {x_min, x_min, x_min};
+    double grid_max[3] = {x_max, x_max, x_max};
 
     // Bin the particles in the grid and permute only the position slice.
     // First do this by only operating on a subset of the particles.
@@ -304,12 +304,12 @@ void testLinkedListSlice()
         EXPECT_EQ( cell_list.numBin( 2 ), nx );
 
         // Copy data to the host for testing.
-        Kokkos::View<int *[3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
-        Kokkos::View<double *[3], TEST_MEMSPACE> pos_view( "positions", num_p );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                             nx );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                               nx, nx );
+        Kokkos::View<int* [3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
+        Kokkos::View<double* [3], TEST_MEMSPACE> pos_view( "positions", num_p );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
+                                                            nx );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
+                                                              nx, nx );
         Kokkos::parallel_for(
             "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
             KOKKOS_LAMBDA( const int i ) {
@@ -428,12 +428,12 @@ void testLinkedListSlice()
         EXPECT_EQ( cell_list.numBin( 2 ), nx );
 
         // Copy data to the host for testing.
-        Kokkos::View<int *[3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
-        Kokkos::View<double *[3], TEST_MEMSPACE> pos_view( "positions", num_p );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                             nx );
-        Kokkos::View<size_type ***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                               nx, nx );
+        Kokkos::View<int* [3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
+        Kokkos::View<double* [3], TEST_MEMSPACE> pos_view( "positions", num_p );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
+                                                            nx );
+        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
+                                                              nx, nx );
         Kokkos::parallel_for(
             "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
             KOKKOS_LAMBDA( const int i ) {

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -63,9 +63,9 @@ void testLinkedList()
         } );
 
     // Create a grid.
-    double grid_delta[3] = {dx, dx, dx};
-    double grid_min[3] = {x_min, x_min, x_min};
-    double grid_max[3] = {x_max, x_max, x_max};
+    double grid_delta[3] = { dx, dx, dx };
+    double grid_min[3] = { x_min, x_min, x_min };
+    double grid_max[3] = { x_max, x_max, x_max };
 
     // Bin and permute the particles in the grid. First do this by only
     // operating on a subset of the particles.
@@ -284,9 +284,9 @@ void testLinkedListSlice()
         } );
 
     // Create a grid.
-    double grid_delta[3] = {dx, dx, dx};
-    double grid_min[3] = {x_min, x_min, x_min};
-    double grid_max[3] = {x_max, x_max, x_max};
+    double grid_delta[3] = { dx, dx, dx };
+    double grid_min[3] = { x_min, x_min, x_min };
+    double grid_max[3] = { x_max, x_max, x_max };
 
     // Bin the particles in the grid and permute only the position slice.
     // First do this by only operating on a subset of the particles.

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -28,8 +28,8 @@ void testLinkedCellStencil()
 {
     // Point in the middle
     {
-        double min[3] = {0.0, 0.0, 0.0};
-        double max[3] = {10.0, 10.0, 10.0};
+        double min[3] = { 0.0, 0.0, 0.0 };
+        double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
@@ -53,8 +53,8 @@ void testLinkedCellStencil()
 
     // Point in the lower right corner
     {
-        double min[3] = {0.0, 0.0, 0.0};
-        double max[3] = {10.0, 10.0, 10.0};
+        double min[3] = { 0.0, 0.0, 0.0 };
+        double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
@@ -78,8 +78,8 @@ void testLinkedCellStencil()
 
     // Point in the upper left corner
     {
-        double min[3] = {0.0, 0.0, 0.0};
-        double max[3] = {10.0, 10.0, 10.0};
+        double min[3] = { 0.0, 0.0, 0.0 };
+        double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -28,8 +28,8 @@ void testLinkedCellStencil()
 {
     // Point in the middle
     {
-        double min[3] = { 0.0, 0.0, 0.0 };
-        double max[3] = { 10.0, 10.0, 10.0 };
+        double min[3] = {0.0, 0.0, 0.0};
+        double max[3] = {10.0, 10.0, 10.0};
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
@@ -53,8 +53,8 @@ void testLinkedCellStencil()
 
     // Point in the lower right corner
     {
-        double min[3] = { 0.0, 0.0, 0.0 };
-        double max[3] = { 10.0, 10.0, 10.0 };
+        double min[3] = {0.0, 0.0, 0.0};
+        double max[3] = {10.0, 10.0, 10.0};
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
@@ -78,8 +78,8 @@ void testLinkedCellStencil()
 
     // Point in the upper left corner
     {
-        double min[3] = { 0.0, 0.0, 0.0 };
-        double max[3] = { 10.0, 10.0, 10.0 };
+        double min[3] = {0.0, 0.0, 0.0};
+        double max[3] = {10.0, 10.0, 10.0};
         double radius = 1.0;
         double ratio = 1.0;
         Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -85,7 +85,7 @@ class AssignmentOp
     }
 
     // tagged version that assigns only half the value..
-    KOKKOS_INLINE_FUNCTION void operator()( const HalfValueWorkTag &,
+    KOKKOS_INLINE_FUNCTION void operator()( const HalfValueWorkTag&,
                                             const int s, const int a ) const
     {
         // Member 0.

--- a/core/unit_test/tstSort.hpp
+++ b/core/unit_test/tstSort.hpp
@@ -37,7 +37,7 @@ void testSortByKey()
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
-    using KeyViewType = Kokkos::View<int *, typename AoSoA_t::memory_space>;
+    using KeyViewType = Kokkos::View<int*, typename AoSoA_t::memory_space>;
     KeyViewType keys( "keys", num_data );
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
@@ -67,8 +67,8 @@ void testSortByKey()
     Cabana::permute( binning_data, aosoa );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
+                                                           aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -120,7 +120,7 @@ void testBinByKey()
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
-    using KeyViewType = Kokkos::View<int *, typename AoSoA_t::memory_space>;
+    using KeyViewType = Kokkos::View<int*, typename AoSoA_t::memory_space>;
     KeyViewType keys( "keys", num_data );
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
@@ -152,11 +152,11 @@ void testBinByKey()
     Cabana::permute( bin_data, aosoa );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_offset( "bin_offset",
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
                                                            aosoa.size() );
-    Kokkos::View<int *, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_offset( "bin_offset",
+                                                          aosoa.size() );
+    Kokkos::View<int*, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -242,8 +242,8 @@ void testSortBySlice()
     Cabana::permute( binning_data, aosoa );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
+                                                           aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -319,8 +319,8 @@ void testSortBySliceDataOnly()
     auto binning_data = Cabana::sortByKey( Cabana::slice<1>( aosoa ) );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
+                                                           aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -399,11 +399,11 @@ void testBinBySlice()
     Cabana::permute( bin_data, aosoa );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_offset( "bin_offset",
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
                                                            aosoa.size() );
-    Kokkos::View<int *, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_offset( "bin_offset",
+                                                          aosoa.size() );
+    Kokkos::View<int*, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -490,11 +490,11 @@ void testBinBySliceDataOnly()
     auto bin_data = Cabana::binByKey( Cabana::slice<1>( aosoa ), num_data - 1 );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_offset( "bin_offset",
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
                                                            aosoa.size() );
-    Kokkos::View<int *, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_offset( "bin_offset",
+                                                          aosoa.size() );
+    Kokkos::View<int*, TEST_MEMSPACE> bin_size( "bin_size", aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {
@@ -556,7 +556,7 @@ void testSortByKeySlice()
     AoSoA_t aosoa( "aosoa", num_data );
 
     // Create a Kokkos view for the keys.
-    using KeyViewType = Kokkos::View<int *, typename AoSoA_t::memory_space>;
+    using KeyViewType = Kokkos::View<int*, typename AoSoA_t::memory_space>;
     KeyViewType keys( "keys", num_data );
 
     // Create the AoSoA data and keys. Create the data in reverse order so we
@@ -586,8 +586,8 @@ void testSortByKeySlice()
     Cabana::permute( binning_data, v0 );
 
     // Copy the bin data so we can check it.
-    Kokkos::View<std::size_t *, TEST_MEMSPACE> bin_permute( "bin_permute",
-                                                            aosoa.size() );
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> bin_permute( "bin_permute",
+                                                           aosoa.size() );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, aosoa.size() ),
         KOKKOS_LAMBDA( const int p ) {

--- a/core/unit_test/tstTuple.hpp
+++ b/core/unit_test/tstTuple.hpp
@@ -75,7 +75,7 @@ void runTest()
 
     // Create a view of tuples.
     std::size_t num_data = 453;
-    Kokkos::View<Tuple_t *, TEST_MEMSPACE> tuples( "tuples", num_data );
+    Kokkos::View<Tuple_t*, TEST_MEMSPACE> tuples( "tuples", num_data );
 
     // Initialize data.
     float fval = 3.4;

--- a/core/unit_test/unit_test_main.cpp
+++ b/core/unit_test/unit_test_main.cpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 
-int main( int argc, char *argv[] )
+int main( int argc, char* argv[] )
 {
     Kokkos::initialize( argc, argv );
     ::testing::InitGoogleTest( &argc, argv );


### PR DESCRIPTION
Previously pointer alignment was "derived" based on context in the code.
This PR explicitly specifies it should be left binding, which should
give more consistent behaviour across clang format versions

The changes in this PR are cosmetic only.

Fixes #297

There is still a difference between how clang 9 and clang 10 format code. We can make 10 act like 9 by specifying `Cpp11BracedListStyle = false`, but I can't find a way to make 9 act like 10....

I'll try up the minimum version in another PR 