### PR TITLE
Raise minimum clang format version to 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ Cabana_add_dependency( PACKAGE MPI )
 Cabana_add_dependency( PACKAGE ArborX )
 
 # find Clang Format
-find_package( CLANG_FORMAT )
+find_package( CLANG_FORMAT 10)
 
 # find hypre
 Cabana_add_dependency( PACKAGE HYPRE )

--- a/cmake/FindCLANG_FORMAT.cmake
+++ b/cmake/FindCLANG_FORMAT.cmake
@@ -18,6 +18,9 @@
 
 find_program(CLANG_FORMAT_EXECUTABLE
              NAMES clang-format
+                   clang-format-10
+                   clang-format-9
+                   clang-format-8
                    clang-format-7
                    clang-format-6.0
                    clang-format-5.0


### PR DESCRIPTION
This is to deal with the situation where cmake finds an older version of clang format locally. Currently in that situation users can run `make format` but will get a version that is inconsistent with what travis requires