### PR TITLE
Add OpenMPTarget support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(Kokkos 3.2 REQUIRED)
 
 # set supported kokkos devices
-set(CABANA_SUPPORTED_DEVICES SERIAL PTHREAD OPENMP CUDA HIP)
+set(CABANA_SUPPORTED_DEVICES SERIAL PTHREAD OPENMP CUDA HIP OPENMPTARGET)
 
 # check user required kokkos device types
 foreach(_device ${CABANA_SUPPORTED_DEVICES})

--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -23,6 +23,10 @@ set(HEADERS_PUBLIC
   Cajita_UniformDimPartitioner.hpp
   )
 
+if(Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET
+  list(REMOVE_ITEM HEADERS_PUBLIC Cajita_Parallel.hpp)
+endif()
+
 set(SOURCES_PUBLIC
   Cajita_LocalGrid.cpp
   Cajita_GlobalGrid.cpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -26,7 +26,11 @@
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_MpiTraits.hpp>
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
 #include <Cajita_Parallel.hpp>
+#endif
+
 #include <Cajita_ParameterPack.hpp>
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_ReferenceStructuredSolver.hpp>

--- a/cajita/src/Cajita_Array.hpp
+++ b/cajita/src/Cajita_Array.hpp
@@ -518,6 +518,7 @@ struct DotFunctor
   array. This vector should be pre-sized to the number of degrees-of-freedom
   per entity.
 */
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
 template <class Array_t>
 void dot( const Array_t& a, const Array_t& b,
           std::vector<typename Array_t::value_type>& products )
@@ -541,6 +542,7 @@ void dot( const Array_t& a, const Array_t& b,
                    MpiTraits<typename Array_t::value_type>::type(), MPI_SUM,
                    a.layout()->localGrid()->globalGrid().comm() );
 }
+#endif
 
 //---------------------------------------------------------------------------//
 // Infinity norm
@@ -588,6 +590,7 @@ struct NormInfFunctor
   \param norms The norms for each degree-of-freedom in the array. This vector
   should be pre-sized to the number of degrees-of-freedom per entity.
 */
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
 template <class Array_t>
 void normInf( const Array_t& array,
               std::vector<typename Array_t::value_type>& norms )
@@ -611,6 +614,7 @@ void normInf( const Array_t& array,
                    MpiTraits<typename Array_t::value_type>::type(), MPI_MAX,
                    array.layout()->localGrid()->globalGrid().comm() );
 }
+#endif
 
 //---------------------------------------------------------------------------//
 // One norm
@@ -655,6 +659,7 @@ struct Norm1Functor
   \param norms The norms for each degree-of-freedom in the array. This vector
   should be pre-sized to the number of degrees-of-freedom per entity.
 */
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
 template <class Array_t>
 void norm1( const Array_t& array,
             std::vector<typename Array_t::value_type>& norms )
@@ -678,6 +683,7 @@ void norm1( const Array_t& array,
                    MpiTraits<typename Array_t::value_type>::type(), MPI_SUM,
                    array.layout()->localGrid()->globalGrid().comm() );
 }
+#endif
 
 //---------------------------------------------------------------------------//
 // Two norm
@@ -722,6 +728,7 @@ struct Norm2Functor
   \param norms The norms for each entity degree-of-freedom in the array. This
   vector should be pre-sized to the number of degrees-of-freedom per entity.
 */
+#ifndef KOKKOS_ENABLE_OPENMPTARGET
 template <class Array_t>
 void norm2( const Array_t& array,
             std::vector<typename Array_t::value_type>& norms )
@@ -748,7 +755,7 @@ void norm2( const Array_t& array,
     for ( auto& n : norms )
         n = std::sqrt( n );
 }
-
+#endif
 //---------------------------------------------------------------------------//
 
 } // end namespace ArrayOp

--- a/cajita/src/Cajita_Parallel.hpp
+++ b/cajita/src/Cajita_Parallel.hpp
@@ -17,6 +17,10 @@
 
 #include <string>
 
+#ifdef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+#error Not supported when Kokkos::Experimental::OpenMPTarget backend enabled.
+#endif
+
 namespace Cajita
 {
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_Parallel.hpp
+++ b/cajita/src/Cajita_Parallel.hpp
@@ -17,10 +17,6 @@
 
 #include <string>
 
-#ifdef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-#error Not supported when Kokkos::Experimental::OpenMPTarget backend enabled.
-#endif
-
 namespace Cajita
 {
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -76,10 +76,13 @@ endmacro()
 set(SERIAL_TESTS
   GlobalMesh
   IndexSpace
-  Parallel
   ParameterPack
   Splines
   )
+
+if(NOT Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET
+  list(APPEND SERIAL_TESTS Parallel)
+endif()
 
 set(MPI_TESTS
   GlobalGrid

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -76,12 +76,13 @@ endmacro()
 set(SERIAL_TESTS
   GlobalMesh
   IndexSpace
+  Parallel
   ParameterPack
   Splines
   )
 
-if(NOT Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET
-  list(APPEND SERIAL_TESTS Parallel)
+if(Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET
+  list(REMOVE_ITEM SERIAL_TESTS Parallel)
 endif()
 
 set(MPI_TESTS

--- a/cajita/unit_test/tstArray.hpp
+++ b/cajita/unit_test/tstArray.hpp
@@ -315,6 +315,7 @@ void arrayOpTest()
                     EXPECT_EQ( host_subview( i, j, k, l ),
                                3.0 * scales[l + 2] + 1.0 );
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     // Compute the dot product of the two arrays.
     std::vector<double> dots( dofs_per_cell );
     ArrayOp::dot( *array, *array_2, dots );
@@ -350,6 +351,7 @@ void arrayOpTest()
     ArrayOp::normInf( *array, norm_inf );
     for ( int n = 0; n < dofs_per_cell; ++n )
         EXPECT_FLOAT_EQ( norm_inf[n], fabs( large_vals[n] ) );
+#endif
 
     // Check the copy.
     ArrayOp::copy( *array, *array_2, Own() );

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -59,6 +59,13 @@ struct CountSendsAndCreateSteeringAlgorithm<Kokkos::Experimental::HIP>
     using type = CountSendsAndCreateSteeringAtomic;
 };
 #endif // end KOKKOS_ENABLE_HIP
+#ifdef KOKKOS_ENABLE_OPENMPTARGET
+template <>
+struct CountSendsAndCreateSteeringAlgorithm<Kokkos::Experimental::OpenMPTarget>
+{
+    using type = CountSendsAndCreateSteeringAtomic;
+};
+#endif // end KOKKOS_ENABLE_OPENMPTARGET
 
 // The default is to use duplication.
 template <class ExecutionSpace>

--- a/core/src/impl/Cabana_PerformanceTraits.hpp
+++ b/core/src/impl/Cabana_PerformanceTraits.hpp
@@ -89,7 +89,7 @@ template <>
 class PerformanceTraits<Kokkos::Experimental::OpenMPTarget>
 {
   public:
-    static constexpr int vector_length = 16;
+    static constexpr int vector_length = 16; // FIXME_OPENMPTARGET
 };
 #endif
 

--- a/core/src/impl/Cabana_PerformanceTraits.hpp
+++ b/core/src/impl/Cabana_PerformanceTraits.hpp
@@ -84,6 +84,16 @@ class PerformanceTraits<Kokkos::Experimental::HIP>
 #endif
 
 //---------------------------------------------------------------------------//
+#if defined( KOKKOS_ENABLE_OPENMPTARGET )
+template <>
+class PerformanceTraits<Kokkos::Experimental::OpenMPTarget>
+{
+  public:
+    static constexpr int vector_length = 16;
+};
+#endif
+
+//---------------------------------------------------------------------------//
 
 } // end namespace Impl
 } // end namespace Cabana

--- a/core/unit_test/TestOPENMPTARGET_Category.hpp
+++ b/core/unit_test/TestOPENMPTARGET_Category.hpp
@@ -1,0 +1,22 @@
+/****************************************************************************
+ * Copyright (c) 2018-2020 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CABANA_TEST_OPENMPTARGET_CATEGORY_HPP
+#define CABANA_TEST_OPENMPTARGET_CATEGORY_HPP
+
+#define TEST_CATEGORY openmptarget
+#define TEST_EXECSPACE Kokkos::Experimental::OpenMPTarget
+#define TEST_MEMSPACE Kokkos::Experimental::OpenMPTargetSpace
+#define TEST_DEVICE                                                            \
+    Kokkos::Device<Kokkos::Experimental::OpenMPTarget,                         \
+                   Kokkos::Experimental::OpenMPTargetSpace>
+
+#endif // end CABANA_TEST_OPENMP_CATEGORY_HPP

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -263,32 +263,44 @@ TEST( TEST_CATEGORY, linked_cell_stencil_test ) { testLinkedCellStencil(); }
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, verlet_list_full_test )
 {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListFull<Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+#endif
     testVerletListFull<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListFull<Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+#endif
     testVerletListFull<Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, verlet_list_half_test )
 {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListHalf<Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+#endif
     testVerletListHalf<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListHalf<Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+#endif
     testVerletListHalf<Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, verlet_list_full_range_test )
 {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListFullPartialRange<Cabana::VerletLayoutCSR,
                                    Cabana::TeamOpTag>();
+#endif
     testVerletListFullPartialRange<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
 
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testVerletListFullPartialRange<Cabana::VerletLayoutCSR,
                                    Cabana::TeamVectorOpTag>();
+#endif
     testVerletListFullPartialRange<Cabana::VerletLayout2D,
                                    Cabana::TeamVectorOpTag>();
 }
@@ -296,14 +308,18 @@ TEST( TEST_CATEGORY, verlet_list_full_range_test )
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, parallel_for_test )
 {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testNeighborParallelFor<Cabana::VerletLayoutCSR>();
+#endif
     testNeighborParallelFor<Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, parallel_reduce_test )
 {
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     testNeighborParallelReduce<Cabana::VerletLayoutCSR>();
+#endif
     testNeighborParallelReduce<Cabana::VerletLayout2D>();
 }
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Add specializations for OpenMPTarget 
- `PerformanceTrait`
- `CommunicationPlan`

And disable a few things for now:
- CSR `VerletList`
- Some `ArrayOp`
- `grid_parallel_for`
- Create neighbor test random particles on the host

Needs #312 to be merged. Still needs CI testing (not all tests pass yet)
