### PR TITLE
Do not attempt to pull a newer version of image in CUDA CI build

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -12,7 +12,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile'
                             dir 'docker'
-                            additionalBuildArgs '--pull --build-arg BASE=nvidia/cuda:10.2-devel'
+                            additionalBuildArgs '--build-arg BASE=nvidia/cuda:10.2-devel'
                             label 'nvidia-docker && volta'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
                         }


### PR DESCRIPTION
Docker Hub started enforcing rate limits and we started having issues on our Jenkins CI server
```
You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limits.
```