### PR TITLE
Sparsemap

### DIFF
--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -516,7 +516,7 @@ class SparseMap
 
 //---------------------------------------------------------------------------//
 // Creation function for SparseMap from GlobalMesh<SparseMesh>
-template <class Scalar, typename MemorySpace,
+template <typename MemorySpace, class Scalar,
           unsigned long long CellPerTileDim = 4,
           HashTypes Hash = HashTypes::Naive, typename Key = uint64_t,
           typename Value = uint64_t>

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -1,10 +1,12 @@
 #ifndef CAJITA_SPARSE_INDEXSPACE_HPP
 #define CAJITA_SPARSE_INDEXSPACE_HPP
 
+#include <Cajita_GlobalMesh.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_UnorderedMap.hpp>
 
 #include <array>
+#include <memory>
 #include <string>
 
 //---------------------------------------------------------------------------//
@@ -427,8 +429,8 @@ class SparseMap
 
     /*!
       \brief (Device) Insert a tile (to hash table); Note that the tile ijk
-      should be global 
-      \param tile_i tile id in dim-x 
+      should be global
+      \param tile_i tile id in dim-x
       \param tile_j tile id in
       dim-y \param tile_k tile id in dim-z
     */
@@ -510,6 +512,23 @@ class SparseMap
     Kokkos::Array<int, rank> _min;
     Kokkos::Array<int, rank> _max;
 };
+
+//---------------------------------------------------------------------------//
+// Creation function for SparseMap from GlobalMesh<SparseMesh>
+template <class Scalar, typename MemorySpace,
+          unsigned long long CellPerTileDim = 4,
+          HashTypes Hash = HashTypes::Naive, typename Key = uint64_t,
+          typename Value = uint64_t>
+SparseMap<MemorySpace, CellPerTileDim, Hash, Key, Value> createSparseMap(
+    const std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>& global_mesh,
+    int pre_alloc_size )
+{
+    return SparseMap<MemorySpace, CellPerTileDim, Hash, Key, Value>(
+        { global_mesh->globalNumCell( Dim::I ),
+          global_mesh->globalNumCell( Dim::J ),
+          global_mesh->globalNumCell( Dim::K ) },
+        pre_alloc_size );
+}
 
 //---------------------------------------------------------------------------//
 /*!

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -432,8 +432,8 @@ class SparseMap
       \brief (Device) Insert a tile (to hash table); Note that the tile ijk
       should be global
       \param tile_i tile id in dim-x
-      \param tile_j tile id in
-      dim-y \param tile_k tile id in dim-z
+      \param tile_j tile id in dim-y
+      \param tile_k tile id in dim-z
     */
     KOKKOS_INLINE_FUNCTION
     void insertTile( int tile_i, int tile_j, int tile_k ) const

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -399,14 +399,15 @@ class SparseMap
     /*!
       \brief (Host) Constructor
       \param size The size of the block (MPI rank) (Unit: cell)
-      \param capacity Expected capacity of the allocator to store the tiles
-      when tile nums exceed the capacity
+      \param pre_alloc_size Expected capacity of the allocator to store the
+      tiles when tile nums exceed the capacity
     */
-    SparseMap( const std::array<int, rank> size, const unsigned int capacity )
+    SparseMap( const std::array<int, rank> size,
+               const unsigned int pre_alloc_size )
         : _block_id_space( size[0] >> cell_bits_per_tile_dim,
                            size[1] >> cell_bits_per_tile_dim,
                            size[2] >> cell_bits_per_tile_dim,
-                           1 << bitCount( capacity ) )
+                           1 << bitCount( pre_alloc_size ) )
     {
         std::fill( _min.data(), _min.data() + rank, 0 );
         std::copy( size.begin(), size.end(), _max.data() );
@@ -573,11 +574,11 @@ class BlockMap
       \param size_x The size of the block (MPI rank) in dim-x (Unit: tile)
       \param size_y The size of the block (MPI rank) in dim-y (Unit: tile)
       \param size_z The size of the block (MPI rank) in dim-z (Unit: tile)
-      \param capacity Expected capacity of the allocator to store the tiles
-      when tile nums exceed the capcity
+      \param pre_alloc_size Expected capacity of the allocator to store the
+      tiles when tile nums exceed the capcity
     */
     BlockMap( const int size_x, const int size_y, const int size_z,
-              const value_type capacity )
+              const value_type pre_alloc_size )
         : _tile_table_info( "hash_table_info" )
         , _tile_table( size_x * size_y * size_z )
         , _op_ijk2key( size_x, size_y, size_z )
@@ -587,7 +588,7 @@ class BlockMap
         auto tile_table_info_mirror =
             Kokkos::create_mirror_view( Kokkos::HostSpace(), _tile_table_info );
         tile_table_info_mirror( 0 ) = 0;
-        tile_table_info_mirror( 1 ) = capacity;
+        tile_table_info_mirror( 1 ) = pre_alloc_size;
         Kokkos::deep_copy( _tile_table_info, tile_table_info_mirror );
 
         // size related init

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -257,8 +257,7 @@ void testSparseMapFullInsert()
 
     // Create Sparse Map
     // SparseMap<TEST_EXECSPACE> sis( size, pre_alloc_size );
-    auto sis =
-        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
+    auto sis = createSparseMap<TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -358,8 +357,7 @@ void testSparseMapSparseInsert()
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
     // Create Sparse Map
-    auto sis =
-        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
+    auto sis = createSparseMap<TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -481,8 +479,7 @@ void testSparseMapReinsert()
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
     // Create Sparse Map
-    auto sis =
-        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
+    auto sis = createSparseMap<TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     constexpr int insert_cell_num = 50;
     Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -115,7 +115,7 @@ void testTileSpace()
     // size 4x4x4
     constexpr int size_bit = SizeBit;
     constexpr int size = Size;
-    using TIS = TileIndexSpace<size_bit, size, size * size>;
+    using TIS = TileMap<size_bit, size, size * size>;
     Kokkos::View<int[size][size][size], TEST_DEVICE> offset_res( "offset" );
     Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
     Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
@@ -167,9 +167,8 @@ void testBlockSpace()
     using value_type = uint32_t;
     constexpr int size = 64;
     int capacity = size * size;
-    BlockIndexSpace<TEST_MEMSPACE, cell_bits_per_tile_dim,
-                    cell_num_per_tile_dim, cell_num_per_tile, HashType,
-                    key_type, value_type>
+    BlockMap<TEST_MEMSPACE, cell_bits_per_tile_dim, cell_num_per_tile_dim,
+             cell_num_per_tile, HashType, key_type, value_type>
         bis( size, size, size, capacity );
 
     Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
@@ -237,7 +236,7 @@ void testBlockSpace()
             }
 }
 
-void testSparseIndexSpaceFullInsert()
+void testSparseMapFullInsert()
 {
     constexpr int dim_n = 3;
     constexpr int size_tile_per_dim = 16;
@@ -245,7 +244,7 @@ void testSparseIndexSpaceFullInsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+    SparseMap<TEST_EXECSPACE> sis( size, capacity );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -325,7 +324,7 @@ void testSparseIndexSpaceFullInsert()
     EXPECT_EQ( new_s, total_tile_num );
 }
 
-void testSparseIndexSpaceSparseInsert()
+void testSparseMapSparseInsert()
 {
     constexpr int dim_n = 3;
     constexpr int size_tile_per_dim = 16;
@@ -334,7 +333,7 @@ void testSparseIndexSpaceSparseInsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+    SparseMap<TEST_EXECSPACE> sis( size, capacity );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -436,7 +435,7 @@ void testSparseIndexSpaceSparseInsert()
     EXPECT_EQ( new_s, valid_cell_num );
 }
 
-void testSparseIndexSpaceReinsert()
+void testSparseMapReinsert()
 {
     constexpr int dim_n = 3;
     constexpr int size_tile_per_dim = 16;
@@ -445,7 +444,7 @@ void testSparseIndexSpaceReinsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseIndexSpace<TEST_EXECSPACE> sis( size, capacity );
+    SparseMap<TEST_EXECSPACE> sis( size, capacity );
 
     constexpr int insert_cell_num = 50;
     Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );
@@ -599,9 +598,9 @@ TEST( sparse_grid, sparse_index_space_test )
     testTileSpace<3, 8>(); // tile size 8x8x8
     testBlockSpace<HashTypes::Naive>();
     testBlockSpace<HashTypes::Morton>();
-    testSparseIndexSpaceFullInsert();
-    testSparseIndexSpaceSparseInsert();
-    testSparseIndexSpaceReinsert();
+    testSparseMapFullInsert();
+    testSparseMapSparseInsert();
+    testSparseMapReinsert();
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -166,10 +166,10 @@ void testBlockSpace()
     using key_type = uint64_t;
     using value_type = uint32_t;
     constexpr int size = 64;
-    int capacity = size * size;
+    int pre_alloc_size = size * size;
     BlockMap<TEST_MEMSPACE, cell_bits_per_tile_dim, cell_num_per_tile_dim,
              cell_num_per_tile, HashType, key_type, value_type>
-        bis( size, size, size, capacity );
+        bis( size, size, size, pre_alloc_size );
 
     Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
     Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
@@ -243,7 +243,7 @@ void testSparseMapFullInsert()
     constexpr int size_per_dim = size_tile_per_dim * 4;
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
-    int capacity = size_per_dim * size_per_dim;
+    int pre_alloc_size = size_per_dim * size_per_dim;
     // Create the global mesh
     double cell_size = 0.1;
     std::array<int, 3> global_num_cell = size;
@@ -256,8 +256,9 @@ void testSparseMapFullInsert()
         global_low_corner, global_high_corner, global_num_cell );
 
     // Create Sparse Map
-    // SparseMap<TEST_EXECSPACE> sis( size, capacity );
-    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
+    // SparseMap<TEST_EXECSPACE> sis( size, pre_alloc_size );
+    auto sis =
+        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -345,7 +346,7 @@ void testSparseMapSparseInsert()
     constexpr int total_size = size_per_dim * size_per_dim * size_per_dim;
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
-    int capacity = size_per_dim * size_per_dim;
+    int pre_alloc_size = size_per_dim * size_per_dim;
     // Create the global mesh
     double cell_size = 0.1;
     std::array<int, 3> global_num_cell = size;
@@ -357,7 +358,8 @@ void testSparseMapSparseInsert()
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
     // Create Sparse Map
-    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
+    auto sis =
+        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -467,7 +469,7 @@ void testSparseMapReinsert()
     constexpr int total_size = size_per_dim * size_per_dim * size_per_dim;
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
-    int capacity = size_per_dim * size_per_dim;
+    int pre_alloc_size = size_per_dim * size_per_dim;
     // Create the global mesh
     double cell_size = 0.1;
     std::array<int, 3> global_num_cell = size;
@@ -479,7 +481,8 @@ void testSparseMapReinsert()
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
     // Create Sparse Map
-    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
+    auto sis =
+        createSparseMap<double, TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     constexpr int insert_cell_num = 50;
     Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -244,7 +244,20 @@ void testSparseMapFullInsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseMap<TEST_EXECSPACE> sis( size, capacity );
+    // Create the global mesh
+    double cell_size = 0.1;
+    std::array<int, 3> global_num_cell = size;
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Create Sparse Map
+    // SparseMap<TEST_EXECSPACE> sis( size, capacity );
+    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -333,7 +346,18 @@ void testSparseMapSparseInsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseMap<TEST_EXECSPACE> sis( size, capacity );
+    // Create the global mesh
+    double cell_size = 0.1;
+    std::array<int, 3> global_num_cell = size;
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+    // Create Sparse Map
+    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
 
     auto cbd = sis.cell_bits_per_tile_dim;
     EXPECT_EQ( cbd, 2 );
@@ -444,7 +468,18 @@ void testSparseMapReinsert()
 
     std::array<int, dim_n> size( { size_per_dim, size_per_dim, size_per_dim } );
     int capacity = size_per_dim * size_per_dim;
-    SparseMap<TEST_EXECSPACE> sis( size, capacity );
+    // Create the global mesh
+    double cell_size = 0.1;
+    std::array<int, 3> global_num_cell = size;
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+    // Create Sparse Map
+    auto sis = createSparseMap<double, TEST_EXECSPACE>( global_mesh, capacity );
 
     constexpr int insert_cell_num = 50;
     Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );


### PR DESCRIPTION
First TODO for #323. 

1. Rename SparseIndexSpace -> SparseMap (Also the TileIndexSpace and similarly named classes). 
2. Add to comment: the inputting global ijk cell ids are global. 
3. Add a createSparseMap() function which takes a GlobalMesh<SparseMesh> and returns a SparseMap. Corresponding tests are also changed.
4. Change the name to distinguish between hash table capacity with the pre-allocation-size info.