### PR TITLE
Add HIP heFFTe, update FFT data types, and test with rocm 4.0

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -39,12 +39,12 @@ pipeline {
                         '''
                     }
                 }
-                stage('ROCM-3.5-HIPCC-DEBUG') {
+                stage('ROCM-4.0-HIPCC-DEBUG') {
                     agent {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-18.04:3.5'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-18.04:4.0-complete'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                             label 'rocm-docker && vega'
                         }
@@ -55,12 +55,14 @@ pipeline {
                             cmake \
                               -D CMAKE_BUILD_TYPE=Debug \
                               -D CMAKE_CXX_COMPILER=hipcc \
+                              -D CMAKE_CXX_STANDARD=14 \
                               -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -DNDEBUG" \
                               -D MPIEXEC_MAX_NUMPROCS=1 \
                               -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
-                              -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR" \
+                              -D CMAKE_PREFIX_PATH="$KOKKOS_DIR;$ARBORX_DIR;$HEFFTE_DIR" \
                               -D Cabana_REQUIRE_MPI=ON \
                               -D Cabana_REQUIRE_ARBORX=ON \
+                              -D Cabana_REQUIRE_HEFFTE=ON \
                               -D Cabana_REQUIRE_HIP=ON \
                               -D Cabana_ENABLE_TESTING=ON \
                               -D Cabana_ENABLE_EXAMPLES=ON \

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
       popd && popd;
     fi
   - if [[ ${HEFFTE} ]]; then
-       git clone --depth=1 --branch v1.0.1 https://bitbucket.org/icl/heffte.git &&
+       git clone --depth=1 --branch v2.0.0 https://bitbucket.org/icl/heffte.git &&
        pushd heffte && mkdir build && pushd build &&
        cmake -DCMAKE_INSTALL_PREFIX="$HOME/heffte"
           -DCMAKE_CXX_STANDARD="11"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if(HYPRE_FOUND)
 endif()
 
 # find heffte
-Cabana_add_dependency( PACKAGE Heffte VERSION 1.0.1 )
+Cabana_add_dependency( PACKAGE Heffte VERSION 2.0.0 )
 
 #------------------------------------------------------------------------------#
 # Tests and Documentation

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -73,56 +73,6 @@ struct FFTBackendDefault
 };
 } // namespace Impl
 
-// Static type checker.
-template <typename>
-struct is_cuda_complex_impl : public std::false_type
-{
-};
-#ifdef KOKKOS_ENABLE_CUDA
-template <>
-struct is_cuda_complex_impl<cufftComplex> : public std::true_type
-{
-};
-template <>
-struct is_cuda_complex_impl<cufftDoubleComplex> : public std::true_type
-{
-};
-#endif
-template <class T>
-struct is_cuda_complex
-    : public is_cuda_complex_impl<typename std::remove_cv<T>::type>::type
-{
-};
-
-template <typename>
-struct is_std_complex_impl : public std::false_type
-{
-};
-template <class Scalar>
-struct is_std_complex_impl<std::complex<Scalar>> : public std::true_type
-{
-};
-template <class T>
-struct is_std_complex
-    : public is_std_complex_impl<typename std::remove_cv<T>::type>::type
-{
-};
-
-template <typename T, typename U, typename SFINAE = void>
-struct is_matching_complex : public std::false_type
-{
-};
-template <class T, class U>
-struct is_matching_complex<
-    T, U,
-    typename std::enable_if<
-        std::is_same<T, U>::value ||
-        std::is_same<typename Kokkos::complex<T>, U>::value ||
-        std::is_same<T, typename Kokkos::complex<U>>::value>::type>
-    : public std::true_type
-{
-};
-
 template <class ArrayEntity, class ArrayMesh, class ArrayDevice,
           class ArrayScalar, class Entity, class Mesh, class Device,
           class Scalar, typename SFINAE = void>
@@ -134,8 +84,6 @@ struct is_matching_array : public std::false_type
                    "Array mesh type mush match FFT mesh type." );
     static_assert( std::is_same<ArrayDevice, Device>::value,
                    "Array device type must match FFT device type." );
-    static_assert( is_matching_complex<ArrayScalar, Scalar>::value,
-                   "Array value type must match complex FFT value type." );
 };
 template <class ArrayEntity, class ArrayMesh, class ArrayDevice,
           class ArrayScalar, class Entity, class Mesh, class Device,
@@ -143,11 +91,9 @@ template <class ArrayEntity, class ArrayMesh, class ArrayDevice,
 struct is_matching_array<
     ArrayEntity, ArrayMesh, ArrayDevice, ArrayScalar, Entity, Mesh, Device,
     Scalar,
-    typename std::enable_if<
-        std::is_same<ArrayEntity, Entity>::value &&
-        std::is_same<ArrayMesh, Mesh>::value &&
-        std::is_same<ArrayDevice, Device>::value &&
-        is_matching_complex<ArrayScalar, Scalar>::value>::type>
+    typename std::enable_if<std::is_same<ArrayEntity, Entity>::value &&
+                            std::is_same<ArrayMesh, Mesh>::value &&
+                            std::is_same<ArrayDevice, Device>::value>::type>
     : public std::true_type
 {
 };
@@ -252,7 +198,7 @@ class FastFourierTransform
     */
     inline void checkArrayDofs( const int dof )
     {
-        if ( 1 != dof )
+        if ( 2 != dof )
             throw std::logic_error(
                 "Only 1 complex value per entity allowed in FFT" );
     }
@@ -301,57 +247,45 @@ class FastFourierTransform
 //---------------------------------------------------------------------------//
 // heFFTe
 //---------------------------------------------------------------------------//
-
 namespace Impl
 {
-template <class ExecutionSpace, class Scalar, class BackendType>
+template <class ExecutionSpace, class BackendType>
 struct HeffteBackendTraits
 {
 };
 #ifdef Heffte_ENABLE_FFTW
-template <class ExecutionSpace, class Scalar>
-struct HeffteBackendTraits<ExecutionSpace, Scalar, FFTBackendFFTW>
+template <class ExecutionSpace>
+struct HeffteBackendTraits<ExecutionSpace, FFTBackendFFTW>
 {
     using backend_type = heffte::backend::fftw;
-    using complex_type = std::complex<Scalar>;
 };
-template <class ExecutionSpace, class Scalar>
-struct HeffteBackendTraits<ExecutionSpace, Scalar, Impl::FFTBackendDefault>
+template <class ExecutionSpace>
+struct HeffteBackendTraits<ExecutionSpace, Impl::FFTBackendDefault>
 {
     using backend_type = heffte::backend::fftw;
-    using complex_type = std::complex<Scalar>;
 };
 #endif
 #ifdef Heffte_ENABLE_MKL
-template <class ExecutionSpace, class Scalar>
-struct HeffteBackendTraits<ExecutionSpace, Scalar, FFTBackendMKL>
+template <class ExecutionSpace>
+struct HeffteBackendTraits<ExecutionSpace, FFTBackendMKL>
 {
     using backend_type = heffte::backend::mkl;
-    using complex_type = std::complex<Scalar>;
 };
 #endif
 #ifdef Heffte_ENABLE_CUDA
 #ifdef KOKKOS_ENABLE_CUDA
 template <>
-struct HeffteBackendTraits<Kokkos::Cuda, double, Impl::FFTBackendDefault>
+struct HeffteBackendTraits<Kokkos::Cuda, Impl::FFTBackendDefault>
 {
     using backend_type = heffte::backend::cufft;
-    using complex_type = cufftDoubleComplex;
-};
-template <>
-struct HeffteBackendTraits<Kokkos::Cuda, float, Impl::FFTBackendDefault>
-{
-    using backend_type = heffte::backend::cufft;
-    using complex_type = cufftComplex;
 };
 #endif
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-template <class Scalar>
-struct HeffteBackendTraits<Kokkos::Experimental::HIP, Scalar,
-                           Impl::FFTBackendDefault>
+template <>
+struct HeffteBackendTraits<Kokkos::Experimental::HIP, Impl::FFTBackendDefault>
 {
-    static_assert( false, "FFT with HIP not supported" ); // FIXME_HIP
+    using backend_type = heffte::backend::rocfft;
 };
 #endif
 
@@ -396,11 +330,8 @@ class HeffteFastFourierTransform
     using backend_type = BackendType;
     using exec_space = typename device_type::execution_space;
     using heffte_backend_type =
-        typename Impl::HeffteBackendTraits<exec_space, value_type,
+        typename Impl::HeffteBackendTraits<exec_space,
                                            backend_type>::backend_type;
-    using complex_type =
-        typename Impl::HeffteBackendTraits<exec_space, value_type,
-                                           backend_type>::complex_type;
 
     /*!
       \brief Constructor
@@ -437,8 +368,9 @@ class HeffteFastFourierTransform
             throw std::logic_error( "Expected FFT allocation size smaller "
                                     "than local grid size" );
 
-        _fft_work = Kokkos::View<complex_type*, DeviceType>(
-            Kokkos::ViewAllocateWithoutInitializing( "fft_work" ), fftsize );
+        _fft_work = Kokkos::View<Scalar*, DeviceType>(
+            Kokkos::ViewAllocateWithoutInitializing( "fft_work" ),
+            2 * fftsize );
     }
 
     /*!
@@ -464,68 +396,6 @@ class HeffteFastFourierTransform
     }
 
     /*!
-     \brief Copy data from Kokkos::complex to CUDA complex.
-     \param x_view_val Kokkos::complex value.
-     \param work_view_val CUDA complex value.
-    */
-    template <class ComplexType>
-    KOKKOS_INLINE_FUNCTION ComplexType copyFromKokkosComplex(
-        Kokkos::complex<value_type> x_view_val, ComplexType work_view_val,
-        typename std::enable_if<( is_cuda_complex<ComplexType>::value ),
-                                int>::type* = 0 )
-    {
-        work_view_val.x = x_view_val.real();
-        work_view_val.y = x_view_val.imag();
-        return work_view_val;
-    }
-    /*!
-     \brief Copy data from CUDA complex to Kokkos complex.
-     \param work_view_val CUDA complex value.
-     \param x_view_val Kokkos complex value.
-    */
-    template <class ComplexType>
-    KOKKOS_INLINE_FUNCTION Kokkos::complex<value_type> copyToKokkosComplex(
-        ComplexType work_view_val, Kokkos::complex<value_type> x_view_val,
-        typename std::enable_if<( is_cuda_complex<ComplexType>::value ),
-                                int>::type* = 0 )
-    {
-        x_view_val.real() = work_view_val.x;
-        x_view_val.imag() = work_view_val.y;
-        return x_view_val;
-    }
-
-    /*!
-     \brief Copy data from Kokkos::complex to std::complex.
-     \param x_view_val Kokkos::complex value.
-     \param work_view_val std::complex value.
-    */
-    template <class ComplexType>
-    inline ComplexType copyFromKokkosComplex(
-        Kokkos::complex<value_type> x_view_val, ComplexType work_view_val,
-        typename std::enable_if<( is_std_complex<ComplexType>::value ),
-                                int>::type* = 0 )
-    {
-        work_view_val.real( x_view_val.real() );
-        work_view_val.imag( x_view_val.imag() );
-        return work_view_val;
-    }
-    /*!
-     \brief Copy data from std::complex to Kokkos::complex.
-     \param work_view_val std::complex value.
-     \param x_view_val Kokkos::complex value.
-    */
-    template <class ComplexType>
-    inline Kokkos::complex<value_type> copyToKokkosComplex(
-        ComplexType work_view_val, Kokkos::complex<value_type> x_view_val,
-        typename std::enable_if<( is_std_complex<ComplexType>::value ),
-                                int>::type* = 0 )
-    {
-        x_view_val.real() = work_view_val.real();
-        x_view_val.imag() = work_view_val.imag();
-        return x_view_val;
-    }
-
-    /*!
      \brief Do the FFT.
      \param x The array on which to perform the transform.
      \param flag Flag for forward or reverse.
@@ -537,10 +407,9 @@ class HeffteFastFourierTransform
         // Create a subview of the work array to write the local data into.
         auto own_space =
             x.layout()->localGrid()->indexSpace( Own(), EntityType(), Local() );
-
-        auto work_view =
-            createView<complex_type, Kokkos::LayoutRight, DeviceType>(
-                own_space, _fft_work.data() );
+        auto work_view_space = appendDimension( own_space, 2 );
+        auto work_view = createView<Scalar, Kokkos::LayoutRight, DeviceType>(
+            work_view_space, _fft_work.data() );
 
         // TODO: pull this out to template function
         // Copy to the work array. The work array only contains owned data.
@@ -553,17 +422,23 @@ class HeffteFastFourierTransform
                 auto iw = i - own_space.min( Dim::I );
                 auto jw = j - own_space.min( Dim::J );
                 auto kw = k - own_space.min( Dim::K );
-                work_view( iw, jw, kw ) = copyFromKokkosComplex(
-                    x_view( i, j, k, 0 ), work_view( iw, jw, kw ) );
+                work_view( iw, jw, kw, 0 ) = x_view( i, j, k, 0 );
+                work_view( iw, jw, kw, 1 ) = x_view( i, j, k, 1 );
             } );
 
         if ( flag == 1 )
         {
-            _fft->forward( _fft_work.data(), _fft_work.data(), scale );
+            _fft->forward(
+                reinterpret_cast<std::complex<Scalar>*>( _fft_work.data() ),
+                reinterpret_cast<std::complex<Scalar>*>( _fft_work.data() ),
+                scale );
         }
         else if ( flag == -1 )
         {
-            _fft->backward( _fft_work.data(), _fft_work.data(), scale );
+            _fft->backward(
+                reinterpret_cast<std::complex<Scalar>*>( _fft_work.data() ),
+                reinterpret_cast<std::complex<Scalar>*>( _fft_work.data() ),
+                scale );
         }
         else
         {
@@ -580,14 +455,14 @@ class HeffteFastFourierTransform
                 auto iw = i - own_space.min( Dim::I );
                 auto jw = j - own_space.min( Dim::J );
                 auto kw = k - own_space.min( Dim::K );
-                x_view( i, j, k, 0 ) = copyToKokkosComplex(
-                    work_view( iw, jw, kw ), x_view( i, j, k, 0 ) );
+                x_view( i, j, k, 0 ) = work_view( iw, jw, kw, 0 );
+                x_view( i, j, k, 1 ) = work_view( iw, jw, kw, 1 );
             } );
     }
 
   private:
     std::shared_ptr<heffte::fft3d<heffte_backend_type>> _fft;
-    Kokkos::View<complex_type*, DeviceType> _fft_work;
+    Kokkos::View<Scalar*, DeviceType> _fft_work;
 };
 
 //---------------------------------------------------------------------------//
@@ -619,12 +494,11 @@ template <class Scalar, class DeviceType, class BackendType, class EntityType,
 auto createHeffteFastFourierTransform(
     const ArrayLayout<EntityType, MeshType>& layout )
 {
-    using value_type = Scalar;
     using device_type = DeviceType;
     using backend_type = BackendType;
     using exec_space = typename device_type::execution_space;
     using heffte_backend_type =
-        typename Impl::HeffteBackendTraits<exec_space, value_type,
+        typename Impl::HeffteBackendTraits<exec_space,
                                            backend_type>::backend_type;
 
     // use default heFFTe params for this backend

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -116,12 +116,9 @@ if(Cabana_ENABLE_HYPRE)
 endif()
 
 if(Cabana_ENABLE_HEFFTE)
-  # FIXME_HIP
-  if(NOT Kokkos_ENABLE_HIP)
     list(APPEND MPI_TESTS
       FastFourierTransform
       )
-  endif()
 endif()
 
 Cajita_add_tests(NAMES ${SERIAL_TESTS})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,7 +123,7 @@ RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
     rm -rf ${SCRATCH_DIR}
 
 # Install heffte
-ARG HEFFTE_VERSION=1.0.1
+ARG HEFFTE_VERSION=2.0.0
 ENV HEFFTE_DIR=/opt/heffte
 RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
     HEFFTE_ARCHIVE=heffte.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -1,4 +1,5 @@
-ARG BASE=rocm/dev-ubuntu-18.04:3.5
+# Use -complete to get both rocm and rocfft
+ARG BASE=rocm/dev-ubuntu-18.04:4.0-complete
 FROM $BASE
 
 ARG NPROCS=4
@@ -80,7 +81,7 @@ RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz
     tar -xf ${KOKKOS_ARCHIVE} -C kokkos --strip-components=1 && \
     cd kokkos && \
     mkdir -p build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${KOKKOS_DIR} -D CMAKE_CXX_COMPILER=hipcc ${KOKKOS_OPTIONS} .. && \
+    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=${KOKKOS_DIR} -D CMAKE_CXX_STANDARD=14 -D CMAKE_CXX_COMPILER=hipcc ${KOKKOS_OPTIONS} .. && \
     make -j${NPROCS} install && \
     rm -rf ${SCRATCH_DIR}
 
@@ -104,3 +105,52 @@ RUN ARBORX_VERSION=4834bff44c23c9510c6ed93366638dcdf85ab217 && \
     .. && \
     make -j${NPROCS} install && \
     cd ../.. && rm -r arborx
+
+# Install fftw (double and single)
+ARG FFTW_VERSION=3.3.8
+ENV FFTW_DIR=/opt/fftw
+RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
+    FFTW_ARCHIVE=fftw.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${FFTW_URL} --output-document=${FFTW_ARCHIVE} && \
+    mkdir -p fftw && \
+    tar -xf ${FFTW_ARCHIVE} -C fftw --strip-components=1 && \
+    cd fftw && \
+    mkdir -p build && cd build && \
+    cmake \
+      -D CMAKE_INSTALL_PREFIX=${FFTW_DIR} \
+      -D CMAKE_BUILD_TYPE=Debug \
+      -D ENABLE_FLOAT=ON \
+    .. && \
+    make -j${NPROCS} install && \
+    cmake \
+      -D CMAKE_INSTALL_PREFIX=${FFTW_DIR} \
+      -D CMAKE_BUILD_TYPE=Debug \
+      -D ENABLE_FLOAT=OFF \
+    .. && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
+
+# Install heffte
+ARG HEFFTE_VERSION=2.0.0
+ENV HEFFTE_DIR=/opt/heffte
+RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
+    HEFFTE_ARCHIVE=heffte.tar.gz && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${HEFFTE_URL} --output-document=${HEFFTE_ARCHIVE} && \
+    mkdir -p heffte && \
+    tar -xf ${HEFFTE_ARCHIVE} -C heffte --strip-components=1 && \
+    cd heffte && \
+    mkdir -p build && cd build && \
+    cmake \
+      -D CMAKE_INSTALL_PREFIX=${HEFFTE_DIR} \
+      -D CMAKE_PREFIX_PATH="${FFTW_DIR}" \
+      -D CMAKE_BUILD_TYPE=Debug \
+      -D CMAKE_CXX_COMPILER=hipcc \
+      -D CMAKE_CXX_STANDARD=14 \
+      -D CMAKE_CXX_FLAGS="--amdgpu-target=gfx906" \
+      -D Heffte_ENABLE_ROCM=ON \
+      -D Heffte_ENABLE_FFTW=ON \
+    .. && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}


### PR DESCRIPTION
Closes #319 

This PR does two things. First, to simplify the FFT interface, Kokkos Views with a pair of float/double is cast to `std::complex` when passed to heFFTe (rather than separate device complex types and `Kokkos::complex`). This also enabled adding FFTs with HIP, using the heFFTe rocm backend.

Testing with `rocm 4.0` was added (the `-complete` docker image comes with `rocff`)