### PR TITLE
Fixed cartesian grid off by one error

### DIFF
--- a/core/performance_test/peakflops/common.h
+++ b/core/performance_test/peakflops/common.h
@@ -1,5 +1,7 @@
 /*
-  Note that the performance output on skylake can be about twice as the expected flops/cycle. This is because the rdtsp() is off by about a factor of two on this cpu.
+  Note that the performance output on skylake can be about twice as the expected
+  flops/cycle. This is because the rdtsp() is off by about a factor of two on
+  this cpu.
   TODO: remove rdtsp() and use flops/sec for measuring performance.
  */
 #ifndef PEAKFLOPS_COMMON_H
@@ -7,10 +9,12 @@
 
 #include <gtest/gtest.h>
 
-static inline unsigned long long rdtscp() {
-  unsigned long long u;
-  asm volatile ("rdtscp;shlq $32,%%rdx;orq %%rdx,%%rax;movq %%rax,%0":"=q"(u)::"%rax", "%rdx", "%rcx");
-  return u;
+static inline unsigned long long rdtscp()
+{
+    unsigned long long u;
+    asm volatile( "rdtscp;shlq $32,%%rdx;orq %%rdx,%%rax;movq %%rax,%0"
+                  : "=q"( u )::"%rax", "%rdx", "%rcx" );
+    return u;
 }
 
 #endif // guard

--- a/core/src/impl/Cabana_CartesianGrid.hpp
+++ b/core/src/impl/Cabana_CartesianGrid.hpp
@@ -104,11 +104,11 @@ class CartesianGrid
         // Since we use a floor function a point on the outer boundary
         // will be found in the next cell, causing an out of bounds error
         ic = cellsBetween( xp, _min_x, _rdx );
-        ic = (ic == _nx) ? ic - 1 : ic;
+        ic = ( ic == _nx ) ? ic - 1 : ic;
         jc = cellsBetween( yp, _min_y, _rdy );
-        jc = (jc == _ny) ? jc - 1 : jc;
+        jc = ( jc == _ny ) ? jc - 1 : jc;
         kc = cellsBetween( zp, _min_z, _rdz );
-        kc = (kc == _nz) ? kc - 1 : kc;
+        kc = ( kc == _nz ) ? kc - 1 : kc;
     }
 
     // Given a position and a cell index get square of the minimum distance to

--- a/core/src/impl/Cabana_CartesianGrid.hpp
+++ b/core/src/impl/Cabana_CartesianGrid.hpp
@@ -101,9 +101,14 @@ class CartesianGrid
     void locatePoint( const Real xp, const Real yp, const Real zp, int& ic,
                       int& jc, int& kc ) const
     {
+        // Since we use a floor function a point on the outer boundary
+        // will be found in the next cell, causing an out of bounds error
         ic = cellsBetween( xp, _min_x, _rdx );
+        ic = (ic == _nx) ? ic - 1 : ic;
         jc = cellsBetween( yp, _min_y, _rdy );
+        jc = (jc == _ny) ? jc - 1 : jc;
         kc = cellsBetween( zp, _min_z, _rdz );
+        kc = (kc == _nz) ? kc - 1 : kc;
     }
 
     // Given a position and a cell index get square of the minimum distance to

--- a/core/unit_test/tstCartesianGrid.cpp
+++ b/core/unit_test/tstCartesianGrid.cpp
@@ -46,6 +46,14 @@ TEST( cabana_cartesian_grid, grid_test )
 
     double min_dist = grid.minDistanceToPoint( xp, yp, zp, ic, jc, kc );
     EXPECT_DOUBLE_EQ( min_dist, 0.0 );
+
+    xp = 2.5;
+    yp = 1.5;
+    zp = 1.9;
+    grid.locatePoint( xp, yp, zp, ic, jc, kc );
+    EXPECT_EQ( ic, 6 );
+    EXPECT_EQ( jc, 15 );
+    EXPECT_EQ( kc, 9 );
 }
 
 } // end namespace Test


### PR DESCRIPTION
A simple fix to the boundary error. The logic is a bit redundant in the sense that every particle is checked by it even though almost none will meet this condition. 

Fixes #333 