### PR TITLE
Variable Dimension GlobalMesh

### DIFF
--- a/cajita/src/Cajita_GlobalMesh.hpp
+++ b/cajita/src/Cajita_GlobalMesh.hpp
@@ -234,34 +234,25 @@ createSparseGlobalMesh(
 // meshes have a list of node locations for each spatial dimension which
 // describe a rectilinear mesh that has arbitrary cell sizes - each cell can
 // possibly be different.
-template <class Scalar, int NumSpaceDim>
-class GlobalMesh<NonUniformMesh<Scalar, NumSpaceDim>>
+//
+// 3D specialization
+template <class Scalar>
+class GlobalMesh<NonUniformMesh<Scalar, 3>>
 {
   public:
     // Mesh type.
-    using mesh_type = NonUniformMesh<Scalar, NumSpaceDim>;
+    using mesh_type = NonUniformMesh<Scalar, 3>;
 
     // Scalar type.
     using scalar_type = Scalar;
 
     // Spatial dimension.
-    static constexpr std::size_t num_space_dim = NumSpaceDim;
-
-    // 2D constructor.
-    template <int NSD = NumSpaceDim>
-    GlobalMesh( const std::vector<Scalar>& i_edges,
-                const std::vector<Scalar>& j_edges,
-                std::enable_if_t<2 == NSD, int> = 0 )
-        : _edges( { i_edges, j_edges } )
-    {
-    }
+    static constexpr std::size_t num_space_dim = 3;
 
     // 3D constructor.
-    template <int NSD = NumSpaceDim>
     GlobalMesh( const std::vector<Scalar>& i_edges,
                 const std::vector<Scalar>& j_edges,
-                const std::vector<Scalar>& k_edges,
-                std::enable_if_t<3 == NSD, int> = 0 )
+                const std::vector<Scalar>& k_edges )
         : _edges( { i_edges, j_edges, k_edges } )
     {
     }
@@ -301,17 +292,8 @@ class GlobalMesh<NonUniformMesh<Scalar, NumSpaceDim>>
     }
 
   private:
-    std::array<std::vector<Scalar>, NumSpaceDim> _edges;
+    std::array<std::vector<Scalar>, 3> _edges;
 };
-
-template <class Scalar>
-std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar, 2>>>
-createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
-                            const std::vector<Scalar>& j_edges )
-{
-    return std::make_shared<GlobalMesh<NonUniformMesh<Scalar, 2>>>( i_edges,
-                                                                    j_edges );
-}
 
 template <class Scalar>
 std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar, 3>>>
@@ -321,6 +303,80 @@ createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
 {
     return std::make_shared<GlobalMesh<NonUniformMesh<Scalar, 3>>>(
         i_edges, j_edges, k_edges );
+}
+
+//---------------------------------------------------------------------------//
+// Global mesh partial specialization for non-uniform mesh. Non-uniform
+// meshes have a list of node locations for each spatial dimension which
+// describe a rectilinear mesh that has arbitrary cell sizes - each cell can
+// possibly be different.
+//
+// 2D specialization
+template <class Scalar>
+class GlobalMesh<NonUniformMesh<Scalar, 2>>
+{
+  public:
+    // Mesh type.
+    using mesh_type = NonUniformMesh<Scalar, 2>;
+
+    // Scalar type.
+    using scalar_type = Scalar;
+
+    // Spatial dimension.
+    static constexpr std::size_t num_space_dim = 2;
+
+    // 2D constructor.
+    GlobalMesh( const std::vector<Scalar>& i_edges,
+                const std::vector<Scalar>& j_edges )
+        : _edges( { i_edges, j_edges } )
+    {
+    }
+
+    // GLOBAL MESH INTERFACE
+
+    // Get the global low corner of the mesh.
+    Scalar lowCorner( const std::size_t dim ) const
+    {
+        return _edges[dim].front();
+    }
+
+    // Get the global high corner of the mesh.
+    Scalar highCorner( const std::size_t dim ) const
+    {
+        return _edges[dim].back();
+    }
+
+    // Get the extent of a given dimension.
+    Scalar extent( const std::size_t dim ) const
+    {
+        return highCorner( dim ) - lowCorner( dim );
+    }
+
+    // Get the global numer of cells in a given dimension.
+    int globalNumCell( const std::size_t dim ) const
+    {
+        return _edges[dim].size() - 1;
+    }
+
+    // NON-UNIFORM MESH SPECIFIC
+
+    // Get the edge array in a given dimension.
+    const std::vector<Scalar>& nonUniformEdge( const std::size_t dim ) const
+    {
+        return _edges[dim];
+    }
+
+  private:
+    std::array<std::vector<Scalar>, 2> _edges;
+};
+
+template <class Scalar>
+std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar, 2>>>
+createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
+                            const std::vector<Scalar>& j_edges )
+{
+    return std::make_shared<GlobalMesh<NonUniformMesh<Scalar, 2>>>( i_edges,
+                                                                    j_edges );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalMesh.hpp
+++ b/cajita/src/Cajita_GlobalMesh.hpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 namespace Cajita
@@ -42,19 +43,23 @@ class GlobalMesh
     // Scalar type.
     using scalar_type = typename mesh_type::scalar_type;
 
+    // Spatial dimension.
+    static constexpr std::size_t num_space_dim = mesh_type::num_space_dim;
+
     // Cell size constructor - special case where all cell dimensions are the
     // same.
-    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
-                const std::array<scalar_type, 3>& global_high_corner,
-                const scalar_type cell_size )
+    GlobalMesh(
+        const std::array<scalar_type, num_space_dim>& global_low_corner,
+        const std::array<scalar_type, num_space_dim>& global_high_corner,
+        const scalar_type cell_size )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
-        , _cell_size( { cell_size, cell_size, cell_size } )
     {
         // Check that the domain is evenly divisible by the cell size in each
         // dimension within round-off error.
-        for ( int d = 0; d < 3; ++d )
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
+            _cell_size[d] = cell_size;
             scalar_type ext = globalNumCell( d ) * _cell_size[d];
             if ( std::abs( ext - extent( d ) ) >
                  scalar_type( 100.0 ) *
@@ -65,16 +70,17 @@ class GlobalMesh
     }
 
     // Cell size constructor - each cell dimension can be different.
-    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
-                const std::array<scalar_type, 3>& global_high_corner,
-                const std::array<scalar_type, 3>& cell_size )
+    GlobalMesh(
+        const std::array<scalar_type, num_space_dim>& global_low_corner,
+        const std::array<scalar_type, num_space_dim>& global_high_corner,
+        const std::array<scalar_type, num_space_dim>& cell_size )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
         , _cell_size( cell_size )
     {
         // Check that the domain is evenly divisible by the cell size in each
         // dimension within round-off error.
-        for ( int d = 0; d < 3; ++d )
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
             scalar_type ext = globalNumCell( d ) * _cell_size[d];
             if ( std::abs( ext - extent( d ) ) >
@@ -86,21 +92,22 @@ class GlobalMesh
     }
 
     // Number of global cells constructor.
-    GlobalMesh( const std::array<scalar_type, 3>& global_low_corner,
-                const std::array<scalar_type, 3>& global_high_corner,
-                const std::array<int, 3>& global_num_cell )
+    GlobalMesh(
+        const std::array<scalar_type, num_space_dim>& global_low_corner,
+        const std::array<scalar_type, num_space_dim>& global_high_corner,
+        const std::array<int, num_space_dim>& global_num_cell )
         : _global_low_corner( global_low_corner )
         , _global_high_corner( global_high_corner )
     {
         // Compute the cell size in each dimension.
-        for ( int d = 0; d < 3; ++d )
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
             _cell_size[d] = ( _global_high_corner[d] - _global_low_corner[d] ) /
                             global_num_cell[d];
 
         // Check that the domain is evenly divisible by the cell size in each
         // dimension within round-off error and that we got the expected
         // number of cells.
-        for ( int d = 0; d < 3; ++d )
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
             scalar_type ext = globalNumCell( d ) * _cell_size[d];
             if ( std::abs( ext - extent( d ) ) >
@@ -116,25 +123,25 @@ class GlobalMesh
     // GLOBAL MESH INTERFACE
 
     // Get the global low corner of the mesh.
-    scalar_type lowCorner( const int dim ) const
+    scalar_type lowCorner( const std::size_t dim ) const
     {
         return _global_low_corner[dim];
     }
 
     // Get the global high corner of the mesh.
-    scalar_type highCorner( const int dim ) const
+    scalar_type highCorner( const std::size_t dim ) const
     {
         return _global_high_corner[dim];
     }
 
     // Get the extent of a given dimension.
-    scalar_type extent( const int dim ) const
+    scalar_type extent( const std::size_t dim ) const
     {
         return highCorner( dim ) - lowCorner( dim );
     }
 
     // Get the global numer of cells in a given dimension.
-    int globalNumCell( const int dim ) const
+    int globalNumCell( const std::size_t dim ) const
     {
         return std::rint( extent( dim ) / _cell_size[dim] );
     }
@@ -142,95 +149,119 @@ class GlobalMesh
     // UNIFORM MESH SPECIFIC
 
     // Get the uniform cell size in a given dimension.
-    scalar_type cellSize( const int dim ) const { return _cell_size[dim]; }
+    scalar_type cellSize( const std::size_t dim ) const
+    {
+        return _cell_size[dim];
+    }
 
   private:
-    std::array<scalar_type, 3> _global_low_corner;
-    std::array<scalar_type, 3> _global_high_corner;
-    std::array<scalar_type, 3> _cell_size;
+    std::array<scalar_type, num_space_dim> _global_low_corner;
+    std::array<scalar_type, num_space_dim> _global_high_corner;
+    std::array<scalar_type, num_space_dim> _cell_size;
 };
 
 // Creation function for Uniform Mesh.
-template <class Scalar>
-std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                         const std::array<Scalar, 3>& global_high_corner,
-                         const Scalar cell_size )
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>
+createUniformGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const Scalar cell_size )
 {
-    return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
+    return std::make_shared<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>(
         global_low_corner, global_high_corner, cell_size );
 }
 
-template <class Scalar>
-std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                         const std::array<Scalar, 3>& global_high_corner,
-                         const std::array<Scalar, 3>& cell_size )
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>
+createUniformGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const std::array<Scalar, NumSpaceDim>& cell_size )
 {
-    return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
+    return std::make_shared<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>(
         global_low_corner, global_high_corner, cell_size );
 }
 
-template <class Scalar>
-std::shared_ptr<GlobalMesh<UniformMesh<Scalar>>>
-createUniformGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                         const std::array<Scalar, 3>& global_high_corner,
-                         const std::array<int, 3>& global_num_cell )
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>
+createUniformGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const std::array<int, NumSpaceDim>& global_num_cell )
 {
-    return std::make_shared<GlobalMesh<UniformMesh<Scalar>>>(
-        global_low_corner, global_high_corner, global_num_cell );
-}
-
-// Creation functions for Sparse Mesh.
-template <class Scalar>
-std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                        const std::array<Scalar, 3>& global_high_corner,
-                        const Scalar cell_size )
-{
-    return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
-        global_low_corner, global_high_corner, cell_size );
-}
-
-template <class Scalar>
-std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                        const std::array<Scalar, 3>& global_high_corner,
-                        const std::array<Scalar, 3>& cell_size )
-{
-    return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
-        global_low_corner, global_high_corner, cell_size );
-}
-
-template <class Scalar>
-std::shared_ptr<GlobalMesh<SparseMesh<Scalar>>>
-createSparseGlobalMesh( const std::array<Scalar, 3>& global_low_corner,
-                        const std::array<Scalar, 3>& global_high_corner,
-                        const std::array<int, 3>& global_num_cell )
-{
-    return std::make_shared<GlobalMesh<SparseMesh<Scalar>>>(
+    return std::make_shared<GlobalMesh<UniformMesh<Scalar, NumSpaceDim>>>(
         global_low_corner, global_high_corner, global_num_cell );
 }
 
 //---------------------------------------------------------------------------//
-// Global mesh partial specialization for non-uniform mesh. Non-uniform meshes
-// have a list of node locations for each spatial dimension which describe a
-// rectilinear mesh that has arbitrary cell sizes - each cell can possibly be
-// different.
-template <class Scalar>
-class GlobalMesh<NonUniformMesh<Scalar>>
+// Creation functions for Sparse Mesh.
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>
+createSparseGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const Scalar cell_size )
+{
+    return std::make_shared<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>(
+        global_low_corner, global_high_corner, cell_size );
+}
+
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>
+createSparseGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const std::array<Scalar, NumSpaceDim>& cell_size )
+{
+    return std::make_shared<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>(
+        global_low_corner, global_high_corner, cell_size );
+}
+
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>
+createSparseGlobalMesh(
+    const std::array<Scalar, NumSpaceDim>& global_low_corner,
+    const std::array<Scalar, NumSpaceDim>& global_high_corner,
+    const std::array<int, NumSpaceDim>& global_num_cell )
+{
+    return std::make_shared<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>(
+        global_low_corner, global_high_corner, global_num_cell );
+}
+
+//---------------------------------------------------------------------------//
+// Global mesh partial specialization for non-uniform mesh. Non-uniform
+// meshes have a list of node locations for each spatial dimension which
+// describe a rectilinear mesh that has arbitrary cell sizes - each cell can
+// possibly be different.
+template <class Scalar, int NumSpaceDim>
+class GlobalMesh<NonUniformMesh<Scalar, NumSpaceDim>>
 {
   public:
     // Mesh type.
-    using mesh_type = NonUniformMesh<Scalar>;
+    using mesh_type = NonUniformMesh<Scalar, NumSpaceDim>;
 
     // Scalar type.
     using scalar_type = Scalar;
 
-    // Constructor.
+    // Spatial dimension.
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
+
+    // 2D constructor.
+    template <int NSD = NumSpaceDim>
     GlobalMesh( const std::vector<Scalar>& i_edges,
                 const std::vector<Scalar>& j_edges,
-                const std::vector<Scalar>& k_edges )
+                std::enable_if_t<2 == NSD, int> = 0 )
+        : _edges( { i_edges, j_edges } )
+    {
+    }
+
+    // 3D constructor.
+    template <int NSD = NumSpaceDim>
+    GlobalMesh( const std::vector<Scalar>& i_edges,
+                const std::vector<Scalar>& j_edges,
+                const std::vector<Scalar>& k_edges,
+                std::enable_if_t<3 == NSD, int> = 0 )
         : _edges( { i_edges, j_edges, k_edges } )
     {
     }
@@ -238,40 +269,57 @@ class GlobalMesh<NonUniformMesh<Scalar>>
     // GLOBAL MESH INTERFACE
 
     // Get the global low corner of the mesh.
-    Scalar lowCorner( const int dim ) const { return _edges[dim].front(); }
+    Scalar lowCorner( const std::size_t dim ) const
+    {
+        return _edges[dim].front();
+    }
 
     // Get the global high corner of the mesh.
-    Scalar highCorner( const int dim ) const { return _edges[dim].back(); }
+    Scalar highCorner( const std::size_t dim ) const
+    {
+        return _edges[dim].back();
+    }
 
     // Get the extent of a given dimension.
-    Scalar extent( const int dim ) const
+    Scalar extent( const std::size_t dim ) const
     {
         return highCorner( dim ) - lowCorner( dim );
     }
 
     // Get the global numer of cells in a given dimension.
-    int globalNumCell( const int dim ) const { return _edges[dim].size() - 1; }
+    int globalNumCell( const std::size_t dim ) const
+    {
+        return _edges[dim].size() - 1;
+    }
 
     // NON-UNIFORM MESH SPECIFIC
 
     // Get the edge array in a given dimension.
-    const std::vector<Scalar>& nonUniformEdge( const int dim ) const
+    const std::vector<Scalar>& nonUniformEdge( const std::size_t dim ) const
     {
         return _edges[dim];
     }
 
   private:
-    std::array<std::vector<Scalar>, 3> _edges;
+    std::array<std::vector<Scalar>, NumSpaceDim> _edges;
 };
 
-// Creation function.
 template <class Scalar>
-std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar>>>
+std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar, 2>>>
+createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
+                            const std::vector<Scalar>& j_edges )
+{
+    return std::make_shared<GlobalMesh<NonUniformMesh<Scalar, 2>>>( i_edges,
+                                                                    j_edges );
+}
+
+template <class Scalar>
+std::shared_ptr<GlobalMesh<NonUniformMesh<Scalar, 3>>>
 createNonUniformGlobalMesh( const std::vector<Scalar>& i_edges,
                             const std::vector<Scalar>& j_edges,
                             const std::vector<Scalar>& k_edges )
 {
-    return std::make_shared<GlobalMesh<NonUniformMesh<Scalar>>>(
+    return std::make_shared<GlobalMesh<NonUniformMesh<Scalar, 3>>>(
         i_edges, j_edges, k_edges );
 }
 

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -26,15 +26,18 @@ class LocalMesh;
 
 //---------------------------------------------------------------------------//
 // Local mesh partial specialization for uniform mesh.
-template <class Scalar, class Device>
-class LocalMesh<Device, UniformMesh<Scalar>>
+template <class Scalar, class Device, std::size_t NumSpaceDim>
+class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
 {
   public:
     // Mesh type.
-    using mesh_type = UniformMesh<Scalar>;
+    using mesh_type = UniformMesh<Scalar, NumSpaceDim>;
 
     // Scalar type for geometric operations.
     using scalar_type = Scalar;
+
+    // Spatial dimension.
+    static constexpr int num_space_dim = NumSpaceDim;
 
     // Device type.
     using device_type = Device;
@@ -42,7 +45,7 @@ class LocalMesh<Device, UniformMesh<Scalar>>
     using execution_space = typename Device::execution_space;
 
     // Constructor.
-    LocalMesh( const LocalGrid<UniformMesh<Scalar>>& local_grid )
+    LocalMesh( const LocalGrid<UniformMesh<Scalar, NumSpaceDim>>& local_grid )
     {
         const auto& global_grid = local_grid.globalGrid();
         const auto& global_mesh = global_grid.globalMesh();
@@ -206,15 +209,18 @@ class LocalMesh<Device, UniformMesh<Scalar>>
 
 //---------------------------------------------------------------------------//
 // Global mesh partial specialization for non-uniform mesh.
-template <class Scalar, class Device>
-class LocalMesh<Device, NonUniformMesh<Scalar>>
+template <class Scalar, class Device, std::size_t NumSpaceDim>
+class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
 {
   public:
     // Mesh type.
-    using mesh_type = NonUniformMesh<Scalar>;
+    using mesh_type = NonUniformMesh<Scalar, NumSpaceDim>;
 
     // Scalar type for geometric operations.
     using scalar_type = Scalar;
+
+    // Spatial dimension.
+    static constexpr int num_space_dim = NumSpaceDim;
 
     // Device type.
     using device_type = Device;
@@ -222,7 +228,8 @@ class LocalMesh<Device, NonUniformMesh<Scalar>>
     using execution_space = typename Device::execution_space;
 
     // Constructor.
-    LocalMesh( const LocalGrid<NonUniformMesh<Scalar>>& local_grid )
+    LocalMesh(
+        const LocalGrid<NonUniformMesh<Scalar, NumSpaceDim>>& local_grid )
     {
         const auto& global_grid = local_grid.globalGrid();
         const auto& global_mesh = global_grid.globalMesh();

--- a/cajita/unit_test/tstGlobalMesh.hpp
+++ b/cajita/unit_test/tstGlobalMesh.hpp
@@ -24,7 +24,7 @@ namespace Test
 
 //---------------------------------------------------------------------------//
 // Test uniform mesh with cubic cells.
-void uniformTest1()
+void uniformTest3D1()
 {
     std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
     std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
@@ -53,7 +53,7 @@ void uniformTest1()
 
 //---------------------------------------------------------------------------//
 // Test uniform mesh with number of cells constructor.
-void uniformTest2()
+void uniformTest3D2()
 {
     std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
     std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
@@ -83,7 +83,7 @@ void uniformTest2()
 //---------------------------------------------------------------------------//
 // test uniform mesh with cells that can have a different size in each
 // dimension
-void uniformTest3()
+void uniformTest3D3()
 {
     std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
     std::array<double, 3> high_corner = { -0.3, 9.5, 1.3 };
@@ -111,8 +111,96 @@ void uniformTest3()
 }
 
 //---------------------------------------------------------------------------//
-// test a non uniform mesh
-void nonUniformTest()
+// Test uniform mesh with cubic cells.
+void uniformTest2D1()
+{
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    std::array<double, 2> high_corner = { -0.3, 9.5 };
+    double cell_size = 0.05;
+
+    auto global_mesh =
+        createUniformGlobalMesh( low_corner, high_corner, cell_size );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( low_corner[d], global_mesh->lowCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d], global_mesh->highCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
+                          global_mesh->extent( d ) );
+
+    std::array<int, 2> num_cell = { 18, 188 };
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize( d ), cell_size );
+}
+
+//---------------------------------------------------------------------------//
+// Test uniform mesh with number of cells constructor.
+void uniformTest2D2()
+{
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    std::array<double, 2> high_corner = { -0.3, 9.5 };
+    std::array<int, 2> num_cell = { 18, 188 };
+
+    auto global_mesh =
+        createUniformGlobalMesh( low_corner, high_corner, num_cell );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( low_corner[d], global_mesh->lowCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d], global_mesh->highCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
+                          global_mesh->extent( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
+
+    double cell_size = 0.05;
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize( d ), cell_size );
+}
+
+//---------------------------------------------------------------------------//
+// test uniform mesh with cells that can have a different size in each
+// dimension
+void uniformTest2D3()
+{
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    std::array<double, 2> high_corner = { -0.3, 9.5 };
+    std::array<double, 2> cell_size = { 0.05, 0.05 };
+
+    auto global_mesh =
+        createUniformGlobalMesh( low_corner, high_corner, cell_size );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( low_corner[d], global_mesh->lowCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d], global_mesh->highCorner( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
+                          global_mesh->extent( d ) );
+
+    std::array<int, 2> num_cell = { 18, 188 };
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_EQ( num_cell[d], global_mesh->globalNumCell( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize( d ), cell_size[d] );
+}
+
+//---------------------------------------------------------------------------//
+// test a non uniform 3d mesh
+void nonUniformTest3d()
 {
     std::vector<float> i_edge = { -0.3, 0.4, 1.1 };
     std::vector<float> j_edge = { 3.3, 8.1, 9.5, 12.2 };
@@ -156,16 +244,59 @@ void nonUniformTest()
 }
 
 //---------------------------------------------------------------------------//
-// RUN TESTS
-//---------------------------------------------------------------------------//
-TEST( mesh, uniform_test )
+// test a non uniform 2d mesh
+void nonUniformTest2d()
 {
-    uniformTest1();
-    uniformTest2();
-    uniformTest3();
+    std::vector<float> i_edge = { -0.3, 0.4, 1.1 };
+    std::vector<float> j_edge = { 3.3, 8.1, 9.5, 12.2 };
+
+    auto global_mesh = createNonUniformGlobalMesh( i_edge, j_edge );
+
+    EXPECT_FLOAT_EQ( i_edge.front(), global_mesh->lowCorner( Dim::I ) );
+    EXPECT_FLOAT_EQ( j_edge.front(), global_mesh->lowCorner( Dim::J ) );
+
+    EXPECT_FLOAT_EQ( i_edge.back(), global_mesh->highCorner( Dim::I ) );
+    EXPECT_FLOAT_EQ( j_edge.back(), global_mesh->highCorner( Dim::J ) );
+
+    EXPECT_FLOAT_EQ( i_edge.back() - i_edge.front(),
+                     global_mesh->extent( Dim::I ) );
+    EXPECT_FLOAT_EQ( j_edge.back() - j_edge.front(),
+                     global_mesh->extent( Dim::J ) );
+
+    EXPECT_EQ( 2, global_mesh->globalNumCell( Dim::I ) );
+    EXPECT_EQ( 3, global_mesh->globalNumCell( Dim::J ) );
+
+    const auto& mesh_i = global_mesh->nonUniformEdge( Dim::I );
+    int ni = mesh_i.size();
+    for ( int i = 0; i < ni; ++i )
+        EXPECT_FLOAT_EQ( i_edge[i], mesh_i[i] );
+
+    const auto& mesh_j = global_mesh->nonUniformEdge( Dim::J );
+    int nj = mesh_j.size();
+    for ( int j = 0; j < nj; ++j )
+        EXPECT_FLOAT_EQ( j_edge[j], mesh_j[j] );
 }
 
-TEST( mesh, non_uniform_test ) { nonUniformTest(); }
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( mesh, uniform_test_3d )
+{
+    uniformTest3D1();
+    uniformTest3D2();
+    uniformTest3D3();
+}
+
+TEST( mesh, uniform_test_2d )
+{
+    uniformTest2D1();
+    uniformTest2D2();
+    uniformTest2D3();
+}
+
+TEST( mesh, non_uniform_test_3d ) { nonUniformTest3d(); }
+
+TEST( mesh, non_uniform_test_2d ) { nonUniformTest2d(); }
 
 //---------------------------------------------------------------------------//
 


### PR DESCRIPTION
This PR is the first of several to support 2D (or even 1D) grids, data structures, and operations (e.g. interpolation and halo exchange) with Cajita. The general design pattern will be to add a `int NumSpaceDim` template parameter to the base mesh tag (e.g. UniformMesh, NonUniformMesh, SparseMesh) and have that silently propagate the dimension through all of the classes. That parameter can then be accessed to write 2D/3D or even 1D specializations as needed. A default template parameter value of `3` has been assigned to provide backwards compatibility with existing implementations.

This PR is part of #340 and depends on #341