### PR TITLE
Fix interpolation test 

### DIFF
--- a/cajita/unit_test/tstInterpolation2d.hpp
+++ b/cajita/unit_test/tstInterpolation2d.hpp
@@ -73,6 +73,9 @@ void interpolationTest()
             points( pid, Dim::J ) = x[Dim::J];
         } );
 
+    // Node space.
+    auto node_space = local_grid->indexSpace( Own(), Node(), Local() );
+
     // Create a scalar field on the grid.
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
     auto scalar_grid_field =
@@ -120,8 +123,8 @@ void interpolationTest()
     p2g( scalar_p2g, points, num_point, Spline<1>(), *scalar_halo,
          *scalar_grid_field );
     Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
             EXPECT_FLOAT_EQ( scalar_grid_host( i, j, 0 ), -1.75 );
 
@@ -131,8 +134,8 @@ void interpolationTest()
     p2g( vector_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
             for ( int d = 0; d < 2; ++d )
                 EXPECT_FLOAT_EQ( vector_grid_host( i, j, d ), -1.75 );
@@ -143,8 +146,8 @@ void interpolationTest()
     p2g( scalar_grad_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
             for ( int d = 0; d < 2; ++d )
                 EXPECT_FLOAT_EQ( vector_grid_host( i, j, d ) + 1.0, 1.0 );
@@ -155,8 +158,8 @@ void interpolationTest()
     p2g( vector_div_p2g, points, num_point, Spline<1>(), *scalar_halo,
          *scalar_grid_field );
     Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
             EXPECT_FLOAT_EQ( scalar_grid_host( i, j, 0 ) + 1.0, 1.0 );
 
@@ -166,8 +169,8 @@ void interpolationTest()
     p2g( tensor_div_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
             for ( int d = 0; d < 2; ++d )
                 EXPECT_FLOAT_EQ( vector_grid_host( i, j, d ) + 1.0, 1.0 );

--- a/cajita/unit_test/tstInterpolation3d.hpp
+++ b/cajita/unit_test/tstInterpolation3d.hpp
@@ -76,6 +76,9 @@ void interpolationTest()
             points( pid, Dim::K ) = x[Dim::K];
         } );
 
+    // Node space.
+    auto node_space = local_grid->indexSpace( Own(), Node(), Local() );
+
     // Create a scalar field on the grid.
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
     auto scalar_grid_field =
@@ -123,11 +126,11 @@ void interpolationTest()
     p2g( scalar_p2g, points, num_point, Spline<1>(), *scalar_halo,
          *scalar_grid_field );
     Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
-            for ( int k = cell_space.min( Dim::K );
-                  k < cell_space.max( Dim::K ); ++k )
+            for ( int k = node_space.min( Dim::K );
+                  k < node_space.max( Dim::K ); ++k )
                 EXPECT_FLOAT_EQ( scalar_grid_host( i, j, k, 0 ), -1.75 );
 
     // Interpolate a vector point value to the grid.
@@ -136,11 +139,11 @@ void interpolationTest()
     p2g( vector_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
-            for ( int k = cell_space.min( Dim::K );
-                  k < cell_space.max( Dim::K ); ++k )
+            for ( int k = node_space.min( Dim::K );
+                  k < node_space.max( Dim::K ); ++k )
                 for ( int d = 0; d < 3; ++d )
                     EXPECT_FLOAT_EQ( vector_grid_host( i, j, k, d ), -1.75 );
 
@@ -150,11 +153,11 @@ void interpolationTest()
     p2g( scalar_grad_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
-            for ( int k = cell_space.min( Dim::K );
-                  k < cell_space.max( Dim::K ); ++k )
+            for ( int k = node_space.min( Dim::K );
+                  k < node_space.max( Dim::K ); ++k )
                 for ( int d = 0; d < 3; ++d )
                     EXPECT_FLOAT_EQ( vector_grid_host( i, j, k, d ) + 1.0,
                                      1.0 );
@@ -165,11 +168,11 @@ void interpolationTest()
     p2g( vector_div_p2g, points, num_point, Spline<1>(), *scalar_halo,
          *scalar_grid_field );
     Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
-            for ( int k = cell_space.min( Dim::K );
-                  k < cell_space.max( Dim::K ); ++k )
+            for ( int k = node_space.min( Dim::K );
+                  k < node_space.max( Dim::K ); ++k )
                 EXPECT_FLOAT_EQ( scalar_grid_host( i, j, k, 0 ) + 1.0, 1.0 );
 
     // Interpolate a tensor point divergence value to the grid.
@@ -178,11 +181,11 @@ void interpolationTest()
     p2g( tensor_div_p2g, points, num_point, Spline<1>(), *vector_halo,
          *vector_grid_field );
     Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
-    for ( int i = cell_space.min( Dim::I ); i < cell_space.max( Dim::I ); ++i )
-        for ( int j = cell_space.min( Dim::J ); j < cell_space.max( Dim::J );
+    for ( int i = node_space.min( Dim::I ); i < node_space.max( Dim::I ); ++i )
+        for ( int j = node_space.min( Dim::J ); j < node_space.max( Dim::J );
               ++j )
-            for ( int k = cell_space.min( Dim::K );
-                  k < cell_space.max( Dim::K ); ++k )
+            for ( int k = node_space.min( Dim::K );
+                  k < node_space.max( Dim::K ); ++k )
                 for ( int d = 0; d < 3; ++d )
                     EXPECT_FLOAT_EQ( vector_grid_host( i, j, k, d ) + 1.0,
                                      1.0 );


### PR DESCRIPTION
The Cajita interpolation test had a bug where the wrong index space was used to loop over the test results. 

In addition, I was getting random failures for non-threaded backends on the test when `ScatterView` was used with the `Serial` backend. I believe that this was the result of threaded duplication still occurring so I updated to unit test harness to explicitly set `--kokkos-threads=1` when backends that are not threaded are used. That fixed my local test results. Curious if that will also fix the failures in #325 