### PR TITLE
Variable dimension local mesh

### DIFF
--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -101,7 +101,8 @@ set(MPI_TESTS
   GlobalGrid
   LocalGrid
   IndexConversion
-  LocalMesh
+  LocalMesh3d
+  LocalMesh2d
   Array
   Halo
   SplineEvaluation
@@ -116,9 +117,9 @@ if(Cabana_ENABLE_HYPRE)
 endif()
 
 if(Cabana_ENABLE_HEFFTE)
-    list(APPEND MPI_TESTS
-      FastFourierTransform
-      )
+  list(APPEND MPI_TESTS
+    FastFourierTransform
+    )
 endif()
 
 Cajita_add_tests(NAMES ${SERIAL_TESTS})

--- a/cajita/unit_test/tstLocalMesh2d.hpp
+++ b/cajita/unit_test/tstLocalMesh2d.hpp
@@ -1,0 +1,563 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_LocalGrid.hpp>
+#include <Cajita_LocalMesh.hpp>
+#include <Cajita_Partitioner.hpp>
+#include <Cajita_Types.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+using namespace Cajita;
+
+namespace Test
+{
+
+//---------------------------------------------------------------------------//
+template <class LocalMeshType, class LocalGridType>
+void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
+                             const LocalGridType& local_grid,
+                             const std::array<double, 2>& low_corner,
+                             const double cell_size, const int halo_width )
+{
+    // Get the global grid.
+    const auto& global_grid = local_grid.globalGrid();
+
+    // Check the low and high corners.
+    Kokkos::View<double[2], TEST_DEVICE> own_lc( "own_lc" );
+    Kokkos::View<double[2], TEST_DEVICE> own_hc( "own_hc" );
+    Kokkos::View<double[2], TEST_DEVICE> own_ext( "own_extent" );
+    Kokkos::View<double[2], TEST_DEVICE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[2], TEST_DEVICE> ghost_hc( "ghost_hc" );
+    Kokkos::View<double[2], TEST_DEVICE> ghost_ext( "ghost_extent" );
+
+    Kokkos::parallel_for(
+        "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 2 ),
+        KOKKOS_LAMBDA( const int d ) {
+            own_lc( d ) = local_mesh.lowCorner( Own(), d );
+            own_hc( d ) = local_mesh.highCorner( Own(), d );
+            own_ext( d ) = local_mesh.extent( Own(), d );
+            ghost_lc( d ) = local_mesh.lowCorner( Ghost(), d );
+            ghost_hc( d ) = local_mesh.highCorner( Ghost(), d );
+            ghost_ext( d ) = local_mesh.extent( Ghost(), d );
+        } );
+
+    auto own_lc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), own_lc );
+    auto own_hc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), own_hc );
+    auto own_ext_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), own_ext );
+    auto ghost_lc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ghost_lc );
+    auto ghost_hc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ghost_hc );
+    auto ghost_ext_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ghost_ext );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_FLOAT_EQ( own_lc_m( d ),
+                         low_corner[d] +
+                             cell_size * global_grid.globalOffset( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_FLOAT_EQ( own_hc_m( d ),
+                         low_corner[d] +
+                             cell_size * ( global_grid.globalOffset( d ) +
+                                           global_grid.ownedNumCell( d ) ) );
+
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_FLOAT_EQ( own_ext_m( d ),
+                         cell_size * global_grid.ownedNumCell( d ) );
+
+    for ( int d = 0; d < 2; ++d )
+    {
+        int ghost_lc_offset =
+            ( global_grid.isPeriodic( d ) || global_grid.dimBlockId( d ) > 0 )
+                ? halo_width
+                : 0;
+        EXPECT_FLOAT_EQ( ghost_lc_m( d ),
+                         low_corner[d] +
+                             cell_size * ( global_grid.globalOffset( d ) -
+                                           ghost_lc_offset ) );
+
+        int ghost_hc_offset =
+            ( global_grid.isPeriodic( d ) ||
+              global_grid.dimBlockId( d ) < global_grid.dimNumBlock( d ) - 1 )
+                ? local_grid.haloCellWidth()
+                : 0;
+        EXPECT_FLOAT_EQ( ghost_hc_m( d ),
+                         low_corner[d] +
+                             cell_size * ( global_grid.globalOffset( d ) +
+                                           ghost_hc_offset +
+                                           global_grid.ownedNumCell( d ) ) );
+
+        EXPECT_FLOAT_EQ( ghost_ext_m( d ),
+                         cell_size * ( global_grid.ownedNumCell( d ) +
+                                       ghost_hc_offset + ghost_lc_offset ) );
+    }
+
+    // Check the cell locations and measures.
+    auto cell_space = local_grid.indexSpace( Ghost(), Cell(), Local() );
+    {
+        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
+        Kokkos::parallel_for(
+            "get_cell_coord",
+            createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j ) {
+                double loc[2];
+                int idx[2] = { i, j };
+                local_mesh.coordinates( Cell(), idx, loc );
+                loc_x( i, j ) = loc[Dim::I];
+                loc_y( i, j ) = loc[Dim::J];
+                measure( i, j ) = local_mesh.measure( Cell(), idx );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        for ( int i = 0; i < cell_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < cell_space.extent( Dim::J ); ++j )
+            {
+                EXPECT_FLOAT_EQ( loc_x_m( i, j ), ghost_lc_m( Dim::I ) +
+                                                      cell_size * ( i + 0.5 ) );
+                EXPECT_FLOAT_EQ( loc_y_m( i, j ), ghost_lc_m( Dim::J ) +
+                                                      cell_size * ( j + 0.5 ) );
+                EXPECT_FLOAT_EQ( measure_m( i, j ), cell_size * cell_size );
+            }
+    }
+
+    // Check the node locations and measures.
+    auto node_space = local_grid.indexSpace( Ghost(), Node(), Local() );
+    {
+        auto measure = createView<double, TEST_DEVICE>( "measure", node_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", node_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", node_space );
+        Kokkos::parallel_for(
+            "get_node_coord",
+            createExecutionPolicy( node_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j ) {
+                double loc[2];
+                int idx[2] = { i, j };
+                local_mesh.coordinates( Node(), idx, loc );
+                loc_x( i, j ) = loc[Dim::I];
+                loc_y( i, j ) = loc[Dim::J];
+                measure( i, j ) = local_mesh.measure( Node(), idx );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        for ( int i = 0; i < node_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < node_space.extent( Dim::J ); ++j )
+            {
+                EXPECT_FLOAT_EQ( loc_x_m( i, j ),
+                                 ghost_lc_m( Dim::I ) + cell_size * i );
+                EXPECT_FLOAT_EQ( loc_y_m( i, j ),
+                                 ghost_lc_m( Dim::J ) + cell_size * j );
+                EXPECT_FLOAT_EQ( measure_m( i, j ), 0.0 );
+            }
+    }
+
+    // Check the I-face locations and measures
+    auto face_i_space =
+        local_grid.indexSpace( Ghost(), Face<Dim::I>(), Local() );
+    {
+        auto measure =
+            createView<double, TEST_DEVICE>( "measure", face_i_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_i_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_i_space );
+        Kokkos::parallel_for(
+            "get_face_i_coord",
+            createExecutionPolicy( face_i_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j ) {
+                double loc[2];
+                int idx[2] = { i, j };
+                local_mesh.coordinates( Face<Dim::I>(), idx, loc );
+                loc_x( i, j ) = loc[Dim::I];
+                loc_y( i, j ) = loc[Dim::J];
+                measure( i, j ) = local_mesh.measure( Face<Dim::I>(), idx );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        for ( int i = 0; i < face_i_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < face_i_space.extent( Dim::J ); ++j )
+            {
+                EXPECT_FLOAT_EQ( loc_x_m( i, j ),
+                                 ghost_lc_m( Dim::I ) + cell_size * i );
+                EXPECT_FLOAT_EQ( loc_y_m( i, j ), ghost_lc_m( Dim::J ) +
+                                                      cell_size * ( j + 0.5 ) );
+                EXPECT_FLOAT_EQ( measure_m( i, j ), cell_size );
+            }
+    }
+
+    // Check the J-face locations and measures.
+    auto face_j_space =
+        local_grid.indexSpace( Ghost(), Face<Dim::J>(), Local() );
+    {
+        auto measure =
+            createView<double, TEST_DEVICE>( "measure", face_j_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_j_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_j_space );
+        Kokkos::parallel_for(
+            "get_face_j_coord",
+            createExecutionPolicy( face_j_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j ) {
+                double loc[2];
+                int idx[2] = { i, j };
+                local_mesh.coordinates( Face<Dim::J>(), idx, loc );
+                loc_x( i, j ) = loc[Dim::I];
+                loc_y( i, j ) = loc[Dim::J];
+                measure( i, j ) = local_mesh.measure( Face<Dim::J>(), idx );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        for ( int i = 0; i < face_j_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < face_j_space.extent( Dim::J ); ++j )
+            {
+                EXPECT_FLOAT_EQ( loc_x_m( i, j ), ghost_lc_m( Dim::I ) +
+                                                      cell_size * ( i + 0.5 ) );
+                EXPECT_FLOAT_EQ( loc_y_m( i, j ),
+                                 ghost_lc_m( Dim::J ) + cell_size * j );
+                EXPECT_FLOAT_EQ( measure_m( i, j ), cell_size );
+            }
+    }
+}
+
+//---------------------------------------------------------------------------//
+void uniformTest2d( const std::array<int, 2>& ranks_per_dim,
+                    const std::array<bool, 2>& is_dim_periodic )
+{
+    // Create the global mesh.
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    std::array<double, 2> high_corner = { -0.3, 9.5 };
+    double cell_size = 0.05;
+    auto global_mesh =
+        createUniformGlobalMesh( low_corner, high_corner, cell_size );
+
+    // Create the global grid.
+    ManualBlockPartitioner<2> partitioner( ranks_per_dim );
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Create a local grid
+    int halo_width = 1;
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+
+    // Create the local mesh.
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+
+    // Test the local mesh.
+    uniformLocalMeshTest2d( local_mesh, *local_grid, low_corner, cell_size,
+                            halo_width );
+}
+
+//---------------------------------------------------------------------------//
+void nonUniformTest2d( const std::array<int, 2>& ranks_per_dim,
+                       const std::array<bool, 2>& is_dim_periodic )
+{
+    // Create the global mesh.
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    double cell_size = 0.05;
+    std::array<int, 2> num_cell = { 18, 188 };
+    std::array<std::vector<double>, 2> edges;
+    for ( int d = 0; d < 2; ++d )
+        for ( int n = 0; n < num_cell[d] + 1; ++n )
+            edges[d].push_back( low_corner[d] + n * cell_size );
+    auto global_mesh =
+        createNonUniformGlobalMesh( edges[Dim::I], edges[Dim::J] );
+
+    // Create the global grid.
+    ManualBlockPartitioner<2> partitioner( ranks_per_dim );
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Create a local grid.
+    int halo_width = 1;
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+
+    // Create the local mesh.
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+
+    // Test the local mesh.
+    uniformLocalMeshTest2d( local_mesh, *local_grid, low_corner, cell_size,
+                            halo_width );
+}
+
+//---------------------------------------------------------------------------//
+void irregularTest2d( const std::array<int, 2>& ranks_per_dim )
+{
+    // Create the global mesh using functions to build the edges. Use a cyclic
+    // pattern for the cell sizes so we can easily compute cell sizes from
+    // periodic wrap-around.
+    std::array<double, 2> low_corner = { 3.1, 4.1 };
+    int ncell = 20;
+    double ref_cell_size = 8.0 * std::atan( 1.0 ) / ncell;
+    std::array<int, 2> num_cell = { ncell, ncell };
+
+    auto i_func = [=]( const int i ) {
+        return 0.5 * std::cos( i * ref_cell_size ) + low_corner[Dim::I];
+    };
+    auto j_func = [=]( const int j ) {
+        return 2.0 * std::cos( j * ref_cell_size ) + low_corner[Dim::J];
+    };
+
+    std::array<std::vector<double>, 2> edges;
+    for ( int n = 0; n < num_cell[Dim::I] + 1; ++n )
+        edges[Dim::I].push_back( i_func( n ) );
+    for ( int n = 0; n < num_cell[Dim::J] + 1; ++n )
+        edges[Dim::J].push_back( j_func( n ) );
+
+    auto global_mesh =
+        createNonUniformGlobalMesh( edges[Dim::I], edges[Dim::J] );
+
+    // Create the global grid.
+    std::array<bool, 2> periodic = { true, true };
+    ManualBlockPartitioner<2> partitioner( ranks_per_dim );
+    auto global_grid =
+        createGlobalGrid( MPI_COMM_WORLD, global_mesh, periodic, partitioner );
+
+    // Create a local grid.
+    int halo_width = 1;
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+
+    // Create the local mesh.
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+
+    // Get index spaces
+    auto ghost_cell_local_space =
+        local_grid->indexSpace( Ghost(), Cell(), Local() );
+    auto own_cell_global_space =
+        local_grid->indexSpace( Own(), Cell(), Global() );
+    auto own_cell_local_space =
+        local_grid->indexSpace( Own(), Cell(), Local() );
+
+    // Check the low and high corners.
+    Kokkos::View<double[2], TEST_DEVICE> own_lc( "own_lc" );
+    Kokkos::View<double[2], TEST_DEVICE> own_hc( "own_hc" );
+    Kokkos::View<double[2], TEST_DEVICE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[2], TEST_DEVICE> ghost_hc( "ghost_hc" );
+
+    Kokkos::parallel_for(
+        "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 2 ),
+        KOKKOS_LAMBDA( const int d ) {
+            own_lc( d ) = local_mesh.lowCorner( Own(), d );
+            own_hc( d ) = local_mesh.highCorner( Own(), d );
+            ghost_lc( d ) = local_mesh.lowCorner( Ghost(), d );
+            ghost_hc( d ) = local_mesh.highCorner( Ghost(), d );
+        } );
+
+    auto own_lc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), own_lc );
+    auto own_hc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), own_hc );
+    auto ghost_lc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ghost_lc );
+    auto ghost_hc_m =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ghost_hc );
+
+    EXPECT_FLOAT_EQ( own_lc_m( Dim::I ),
+                     i_func( own_cell_global_space.min( Dim::I ) ) );
+    EXPECT_FLOAT_EQ( own_lc_m( Dim::J ),
+                     j_func( own_cell_global_space.min( Dim::J ) ) );
+
+    EXPECT_FLOAT_EQ( own_hc_m( Dim::I ),
+                     i_func( own_cell_global_space.max( Dim::I ) ) );
+    EXPECT_FLOAT_EQ( own_hc_m( Dim::J ),
+                     j_func( own_cell_global_space.max( Dim::J ) ) );
+
+    EXPECT_FLOAT_EQ( ghost_lc_m( Dim::I ),
+                     i_func( own_cell_global_space.min( Dim::I ) -
+                             own_cell_local_space.min( Dim::I ) ) );
+    EXPECT_FLOAT_EQ( ghost_lc_m( Dim::J ),
+                     j_func( own_cell_global_space.min( Dim::J ) -
+                             own_cell_local_space.min( Dim::J ) ) );
+
+    EXPECT_FLOAT_EQ( ghost_hc_m( Dim::I ),
+                     i_func( own_cell_global_space.max( Dim::I ) +
+                             own_cell_local_space.min( Dim::I ) ) );
+    EXPECT_FLOAT_EQ( ghost_hc_m( Dim::J ),
+                     j_func( own_cell_global_space.max( Dim::J ) +
+                             own_cell_local_space.min( Dim::J ) ) );
+
+    // Check the cell locations and measures.
+    auto cell_measure = createView<double, TEST_DEVICE>(
+        "cell_measures", ghost_cell_local_space );
+    auto cell_location_x = createView<double, TEST_DEVICE>(
+        "cell_locations_x", ghost_cell_local_space );
+    auto cell_location_y = createView<double, TEST_DEVICE>(
+        "cell_locations_y", ghost_cell_local_space );
+    Kokkos::parallel_for(
+        "get_cell_data",
+        createExecutionPolicy( own_cell_local_space, TEST_EXECSPACE() ),
+        KOKKOS_LAMBDA( const int i, const int j ) {
+            int idx[2] = { i, j };
+            double loc[2];
+            local_mesh.coordinates( Cell(), idx, loc );
+            cell_location_x( i, j ) = loc[Dim::I];
+            cell_location_y( i, j ) = loc[Dim::J];
+            cell_measure( i, j ) = local_mesh.measure( Cell(), idx );
+        } );
+    auto cell_measure_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), cell_measure );
+    auto cell_location_x_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), cell_location_x );
+    auto cell_location_y_h = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), cell_location_y );
+    for ( int i = own_cell_global_space.min( Dim::I );
+          i < own_cell_global_space.max( Dim::I ); ++i )
+        for ( int j = own_cell_global_space.min( Dim::J );
+              j < own_cell_global_space.max( Dim::J ); ++j )
+        {
+            double measure = ( i_func( i + 1 ) - i_func( i ) ) *
+                             ( j_func( j + 1 ) - j_func( j ) );
+            double compute_m =
+                cell_measure_h( i - own_cell_global_space.min( Dim::I ) +
+                                    own_cell_local_space.min( Dim::I ),
+                                j - own_cell_global_space.min( Dim::J ) +
+                                    own_cell_local_space.min( Dim::J ) );
+            EXPECT_FLOAT_EQ( measure, compute_m );
+
+            double x_loc = ( i_func( i + 1 ) + i_func( i ) ) / 2.0;
+            double compute_x =
+                cell_location_x_h( i - own_cell_global_space.min( Dim::I ) +
+                                       own_cell_local_space.min( Dim::I ),
+                                   j - own_cell_global_space.min( Dim::J ) +
+                                       own_cell_local_space.min( Dim::J ) );
+            EXPECT_FLOAT_EQ( x_loc, compute_x );
+
+            double y_loc = ( j_func( j + 1 ) + j_func( j ) ) / 2.0;
+            double compute_y =
+                cell_location_y_h( i - own_cell_global_space.min( Dim::I ) +
+                                       own_cell_local_space.min( Dim::I ),
+                                   j - own_cell_global_space.min( Dim::J ) +
+                                       own_cell_local_space.min( Dim::J ) );
+            EXPECT_FLOAT_EQ( y_loc, compute_y );
+        }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( mesh, periodic_uniform_test )
+{
+    std::array<bool, 2> is_dim_periodic = { true, true };
+
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    // Test with different block configurations to make sure all the
+    // dimensions get partitioned even at small numbers of ranks.
+    uniformTest2d( ranks_per_dim, is_dim_periodic );
+    std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+    uniformTest2d( ranks_per_dim, is_dim_periodic );
+}
+
+//---------------------------------------------------------------------------//
+TEST( mesh, periodic_non_uniform_test )
+{
+    std::array<bool, 2> is_dim_periodic = { true, true };
+
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    // Test with different block configurations to make sure all the
+    // dimensions get partitioned even at small numbers of ranks.
+    nonUniformTest2d( ranks_per_dim, is_dim_periodic );
+    std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+    nonUniformTest2d( ranks_per_dim, is_dim_periodic );
+}
+
+//---------------------------------------------------------------------------//
+TEST( mesh, non_periodic_uniform_test )
+{
+    std::array<bool, 2> is_dim_periodic = { false, false };
+
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    // Test with different block configurations to make sure all the
+    // dimensions get partitioned even at small numbers of ranks.
+    uniformTest2d( ranks_per_dim, is_dim_periodic );
+    std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+    uniformTest2d( ranks_per_dim, is_dim_periodic );
+}
+
+//---------------------------------------------------------------------------//
+TEST( mesh, non_periodic_non_uniform_test )
+{
+    std::array<bool, 2> is_dim_periodic = { false, false };
+
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    // Test with different block configurations to make sure all the
+    // dimensions get partitioned even at small numbers of ranks.
+    nonUniformTest2d( ranks_per_dim, is_dim_periodic );
+    std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+    nonUniformTest2d( ranks_per_dim, is_dim_periodic );
+}
+
+//---------------------------------------------------------------------------//
+TEST( mesh, irregular_non_uniform_test )
+{
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    // Test with different block configurations to make sure all the
+    // dimensions get partitioned even at small numbers of ranks.
+    irregularTest2d( ranks_per_dim );
+    std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+    irregularTest2d( ranks_per_dim );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/cajita/unit_test/tstLocalMesh3d.hpp
+++ b/cajita/unit_test/tstLocalMesh3d.hpp
@@ -33,10 +33,10 @@ namespace Test
 
 //---------------------------------------------------------------------------//
 template <class LocalMeshType, class LocalGridType>
-void uniformLocalMeshTest( const LocalMeshType& local_mesh,
-                           const LocalGridType& local_grid,
-                           const std::array<double, 3>& low_corner,
-                           const double cell_size, const int halo_width )
+void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
+                             const LocalGridType& local_grid,
+                             const std::array<double, 3>& low_corner,
+                             const double cell_size, const int halo_width )
 {
     // Get the global grid.
     const auto& global_grid = local_grid.globalGrid();
@@ -473,8 +473,8 @@ void uniformLocalMeshTest( const LocalMeshType& local_mesh,
 }
 
 //---------------------------------------------------------------------------//
-void uniformTest( const std::array<int, 3>& ranks_per_dim,
-                  const std::array<bool, 3>& is_dim_periodic )
+void uniformTest3d( const std::array<int, 3>& ranks_per_dim,
+                    const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
     std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
@@ -496,13 +496,13 @@ void uniformTest( const std::array<int, 3>& ranks_per_dim,
     auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
 
     // Test the local mesh.
-    uniformLocalMeshTest( local_mesh, *local_grid, low_corner, cell_size,
-                          halo_width );
+    uniformLocalMeshTest3d( local_mesh, *local_grid, low_corner, cell_size,
+                            halo_width );
 }
 
 //---------------------------------------------------------------------------//
-void nonUniformTest( const std::array<int, 3>& ranks_per_dim,
-                     const std::array<bool, 3>& is_dim_periodic )
+void nonUniformTest3d( const std::array<int, 3>& ranks_per_dim,
+                       const std::array<bool, 3>& is_dim_periodic )
 {
     // Create the global mesh.
     std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
@@ -528,12 +528,12 @@ void nonUniformTest( const std::array<int, 3>& ranks_per_dim,
     auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
 
     // Test the local mesh.
-    uniformLocalMeshTest( local_mesh, *local_grid, low_corner, cell_size,
-                          halo_width );
+    uniformLocalMeshTest3d( local_mesh, *local_grid, low_corner, cell_size,
+                            halo_width );
 }
 
 //---------------------------------------------------------------------------//
-void irregularTest( const std::array<int, 3>& ranks_per_dim )
+void irregularTest3d( const std::array<int, 3>& ranks_per_dim )
 {
     // Create the global mesh using functions to build the edges. Use a cyclic
     // pattern for the cell sizes so we can easily compute cell sizes from
@@ -738,15 +738,15 @@ TEST( mesh, periodic_uniform_test )
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
 }
 
 //---------------------------------------------------------------------------//
@@ -762,15 +762,15 @@ TEST( mesh, periodic_non_uniform_test )
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
 }
 
 //---------------------------------------------------------------------------//
@@ -786,15 +786,15 @@ TEST( mesh, non_periodic_uniform_test )
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    uniformTest( ranks_per_dim, is_dim_periodic );
+    uniformTest3d( ranks_per_dim, is_dim_periodic );
 }
 
 //---------------------------------------------------------------------------//
@@ -810,15 +810,15 @@ TEST( mesh, non_periodic_non_uniform_test )
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    nonUniformTest( ranks_per_dim, is_dim_periodic );
+    nonUniformTest3d( ranks_per_dim, is_dim_periodic );
 }
 
 //---------------------------------------------------------------------------//
@@ -832,15 +832,15 @@ TEST( mesh, irregular_non_uniform_test )
 
     // Test with different block configurations to make sure all the
     // dimensions get partitioned even at small numbers of ranks.
-    irregularTest( ranks_per_dim );
+    irregularTest3d( ranks_per_dim );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    irregularTest( ranks_per_dim );
+    irregularTest3d( ranks_per_dim );
     std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-    irregularTest( ranks_per_dim );
+    irregularTest3d( ranks_per_dim );
     std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-    irregularTest( ranks_per_dim );
+    irregularTest3d( ranks_per_dim );
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-    irregularTest( ranks_per_dim );
+    irregularTest3d( ranks_per_dim );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Adding variable dimensions (in particular 3d and 2d) to `Cajita::LocalMesh`. The interface implementation is backwards compatible. Again note, as in the other PRs in #340 that 3D meshes have cells, faces, edges, and nodes which 2D meshes have cells, faces, and nodes in only the `i`, and `j` dimensions.

I added a separate test for 2D which may seem like it largely duplicates the 3D test but in fact the interface functions used to get at data are largely dimension-dependent and therefore the majority of a combined 2d/3d test would have had much of the code in dimension-based if/else or enable_if statements.

Part of #340. Depends on #344 