### PR TITLE
LinkedCellList allocation

### DIFF
--- a/core/performance_test/benchmark/Cabana_LinkedCellPerformance.cpp
+++ b/core/performance_test/benchmark/Cabana_LinkedCellPerformance.cpp
@@ -105,7 +105,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix )
             {
                 // Build the linked cell list.
                 create_timer.start( p );
-                linked_cell_list.build( x, 0, x.size() );
+                linked_cell_list.build( x );
                 create_timer.stop( p );
 
                 // Sort the particles.

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -35,6 +35,7 @@ class LinkedCellList
     using memory_space = typename device_type::memory_space;
     using execution_space = typename device_type::execution_space;
     using size_type = typename memory_space::size_type;
+    using CountView = Kokkos::View<int*, device_type>;
     using OffsetView = Kokkos::View<size_type*, device_type>;
 
     /*!
@@ -66,7 +67,9 @@ class LinkedCellList
                  grid_max[1], grid_max[2], grid_delta[0], grid_delta[1],
                  grid_delta[2] )
     {
-        build( positions, 0, positions.size() );
+        std::size_t np = positions.size();
+        allocate( totalBins(), np );
+        build( positions, 0, np );
     }
 
     /*!
@@ -98,6 +101,7 @@ class LinkedCellList
                  grid_max[1], grid_max[2], grid_delta[0], grid_delta[1],
                  grid_delta[2] )
     {
+        allocate( totalBins(), end - begin );
         build( positions, begin, end );
     }
 
@@ -204,34 +208,45 @@ class LinkedCellList
     */
     BinningData<DeviceType> binningData() const { return _bin_data; }
 
-  public:
-    // This function should be private but we need to expose it as public to
-    // launch CUDA kernels with class data.
+    /*!
+      \brief Build the linked cell list with a subset of particles.
+
+      \tparam SliceType Slice type for positions.
+
+      \param positions Slice of positions.
+
+      \param begin The beginning index of the slice range to sort.
+
+      \param end The end index of the slice range to sort.
+    */
     template <class SliceType>
     void build( SliceType positions, const std::size_t begin,
                 const std::size_t end )
     {
-        // Allocate the binning data. Note that the permutation vector spans
+        // Resize the binning data. Note that the permutation vector spans
         // only the length of begin-end;
         std::size_t ncell = totalBins();
-        Kokkos::View<int*, memory_space> counts(
-            Kokkos::view_alloc( Kokkos::WithoutInitializing, "counts" ),
-            ncell );
-        OffsetView offsets(
-            Kokkos::view_alloc( Kokkos::WithoutInitializing, "offsets" ),
-            ncell );
-        OffsetView permute(
-            Kokkos::view_alloc( Kokkos::WithoutInitializing, "permute" ),
-            end - begin );
+        if ( _counts.extent( 0 ) != ncell )
+        {
+            Kokkos::resize( _counts, ncell );
+            Kokkos::resize( _offsets, ncell );
+        }
+        std::size_t nparticles = end - begin;
+        if ( _permutes.extent( 0 ) != nparticles )
+        {
+            Kokkos::resize( _permutes, nparticles );
+        }
 
-        // Get a local copy of the grid because it is class data and a lambda
-        // function will not capture it otherwise via CUDA.
+        // Get local copies of class data for lambda function capture.
         auto grid = _grid;
+        auto counts = _counts;
+        auto offsets = _offsets;
+        auto permutes = _permutes;
 
         // Count.
         Kokkos::RangePolicy<execution_space> particle_range( begin, end );
-        Kokkos::deep_copy( counts, 0 );
-        auto counts_sv = Kokkos::Experimental::create_scatter_view( counts );
+        Kokkos::deep_copy( _counts, 0 );
+        auto counts_sv = Kokkos::Experimental::create_scatter_view( _counts );
         auto cell_count = KOKKOS_LAMBDA( const std::size_t p )
         {
             int i, j, k;
@@ -243,7 +258,7 @@ class LinkedCellList
         Kokkos::parallel_for( "Cabana::LinkedCellList::build::cell_count",
                               particle_range, cell_count );
         Kokkos::fence();
-        Kokkos::Experimental::contribute( counts, counts_sv );
+        Kokkos::Experimental::contribute( _counts, counts_sv );
 
         // Compute offsets.
         Kokkos::RangePolicy<execution_space> cell_range( 0, ncell );
@@ -259,7 +274,7 @@ class LinkedCellList
         Kokkos::fence();
 
         // Reset counts.
-        Kokkos::deep_copy( counts, 0 );
+        Kokkos::deep_copy( _counts, 0 );
 
         // Compute the permutation vector.
         auto create_permute = KOKKOS_LAMBDA( const std::size_t p )
@@ -269,7 +284,7 @@ class LinkedCellList
                               positions( p, 2 ), i, j, k );
             auto cell_id = grid.cardinalCellIndex( i, j, k );
             int c = Kokkos::atomic_fetch_add( &counts( cell_id ), 1 );
-            permute( offsets( cell_id ) + c ) = p;
+            permutes( offsets( cell_id ) + c ) = p;
         };
         Kokkos::parallel_for( "Cabana::LinkedCellList::build::create_permute",
                               particle_range, create_permute );
@@ -277,12 +292,42 @@ class LinkedCellList
 
         // Create the binning data.
         _bin_data =
-            BinningData<DeviceType>( begin, end, counts, offsets, permute );
+            BinningData<DeviceType>( begin, end, _counts, _offsets, _permutes );
+    }
+
+    /*!
+      \brief Build the linked cell list with all particles.
+
+      \tparam SliceType Slice type for positions.
+
+      \param positions Slice of positions.
+    */
+    template <class SliceType>
+    void build( SliceType positions )
+    {
+        build( positions, 0, positions.size() );
     }
 
   private:
     BinningData<DeviceType> _bin_data;
     Impl::CartesianGrid<double> _grid;
+
+    CountView _counts;
+    OffsetView _offsets;
+    OffsetView _permutes;
+
+    void allocate( const int ncell, const int nparticles )
+    {
+        _counts = CountView(
+            Kokkos::view_alloc( Kokkos::WithoutInitializing, "counts" ),
+            ncell );
+        _offsets = OffsetView(
+            Kokkos::view_alloc( Kokkos::WithoutInitializing, "offsets" ),
+            ncell );
+        _permutes = OffsetView(
+            Kokkos::view_alloc( Kokkos::WithoutInitializing, "permutes" ),
+            nparticles );
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -17,20 +17,20 @@
 
 namespace Test
 {
-//---------------------------------------------------------------------------//
-void testLinkedList()
+struct LCLTestData
 {
-    // Make an AoSoA with positions and ijk cell ids.
     enum MyFields
     {
         Position = 0,
         CellId = 1
     };
-    using DataTypes = Cabana::MemberTypes<double[3], int[3]>;
-    using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE>;
-    using size_type = typename AoSoA_t::memory_space::size_type;
-    int num_p = 1000;
-    AoSoA_t aosoa( "aosoa", num_p );
+    using data_types = Cabana::MemberTypes<double[3], int[3]>;
+    using aosoa_type = Cabana::AoSoA<data_types, TEST_MEMSPACE>;
+    using size_type = typename aosoa_type::memory_space::size_type;
+    std::size_t num_p = 1000;
+    std::size_t begin = 250;
+    std::size_t end = 750;
+    aosoa_type aosoa;
 
     // Set the problem so each particle lives in the center of a cell on a
     // regular grid of cell size 1 and total size 10x10x10. We are making them
@@ -40,463 +40,269 @@ void testLinkedList()
     double dx = 1.0;
     double x_min = 0.0;
     double x_max = x_min + nx * dx;
-    auto pos = Cabana::slice<Position>( aosoa, "position" );
-    auto cell_id = Cabana::slice<CellId>( aosoa, "cell_id" );
-    Kokkos::parallel_for(
-        "initialize", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-        KOKKOS_LAMBDA( const int k ) {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int i = 0; i < nx; ++i )
-                {
-                    std::size_t particle_id = i + j * nx + k * nx * nx;
-
-                    cell_id( particle_id, 0 ) = i;
-                    cell_id( particle_id, 1 ) = j;
-                    cell_id( particle_id, 2 ) = k;
-
-                    pos( particle_id, 0 ) = x_min + ( i + 0.5 ) * dx;
-                    pos( particle_id, 1 ) = x_min + ( j + 0.5 ) * dx;
-                    pos( particle_id, 2 ) = x_min + ( k + 0.5 ) * dx;
-                }
-            }
-        } );
 
     // Create a grid.
     double grid_delta[3] = { dx, dx, dx };
     double grid_min[3] = { x_min, x_min, x_min };
     double grid_max[3] = { x_max, x_max, x_max };
 
-    // Bin and permute the particles in the grid. First do this by only
-    // operating on a subset of the particles.
+    using IDViewType = Kokkos::View<int* [3], TEST_MEMSPACE>;
+    using PosViewType = Kokkos::View<double* [3], TEST_MEMSPACE>;
+    using BinViewType = Kokkos::View<size_type***, TEST_MEMSPACE>;
+
+    using layout = typename TEST_EXECSPACE::array_layout;
+    Kokkos::View<int* [3], layout, Kokkos::HostSpace> ids_mirror;
+    Kokkos::View<double* [3], layout, Kokkos::HostSpace> pos_mirror;
+    Kokkos::View<size_type***, layout, Kokkos::HostSpace> bin_size_mirror;
+    Kokkos::View<size_type***, layout, Kokkos::HostSpace> bin_offset_mirror;
+
+    LCLTestData()
     {
-        std::size_t begin = 250;
-        std::size_t end = 750;
-        Cabana::LinkedCellList<typename AoSoA_t::memory_space> cell_list(
-            pos, begin, end, grid_delta, grid_min, grid_max );
-        Cabana::permute( cell_list, aosoa );
+        aosoa = aosoa_type( "aosoa", num_p );
 
-        // Checking the binning.
-        EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
-        EXPECT_EQ( cell_list.numBin( 0 ), nx );
-        EXPECT_EQ( cell_list.numBin( 1 ), nx );
-        EXPECT_EQ( cell_list.numBin( 2 ), nx );
+        createParticles();
+    }
 
-        // Copy data to the host for testing.
-        Kokkos::View<int* [3], TEST_MEMSPACE> ids( "cell_ids", num_p );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                            nx );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                              nx, nx );
+    void createParticles()
+    {
+        // Create local variables for lambda capture
+        auto nx_ = nx;
+        auto x_min_ = x_min;
+        auto dx_ = dx;
+
+        // Fill the AoSoA with positions and ijk cell ids.
+        auto pos = Cabana::slice<Position>( aosoa, "position" );
+        auto cell_id = Cabana::slice<CellId>( aosoa, "cell_id" );
         Kokkos::parallel_for(
-            "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-            KOKKOS_LAMBDA( const int i ) {
-                for ( int j = 0; j < nx; ++j )
-                    for ( int k = 0; k < nx; ++k )
+            "initialize", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx_ ),
+            KOKKOS_LAMBDA( const int k ) {
+                for ( int j = 0; j < nx_; ++j )
+                {
+                    for ( int i = 0; i < nx_; ++i )
                     {
-                        std::size_t original_id = i + j * nx + k * nx * nx;
-                        ids( original_id, 0 ) = cell_id( original_id, 0 );
-                        ids( original_id, 1 ) = cell_id( original_id, 1 );
-                        ids( original_id, 2 ) = cell_id( original_id, 2 );
-                        bin_size( i, j, k ) = cell_list.binSize( i, j, k );
-                        bin_offset( i, j, k ) = cell_list.binOffset( i, j, k );
-                    }
-            } );
-        Kokkos::fence();
-        auto ids_mirror =
-            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ids );
-        auto bin_size_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_size );
-        auto bin_offset_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_offset );
+                        std::size_t particle_id = i + j * nx_ + k * nx_ * nx_;
 
-        // The order should be reversed with the i index moving the slowest
-        // for those that are actually in the binning range. Do this pass
-        // first. We do this by looping through in the sorted order and check
-        // those that had original indices in the sorting range.
-        std::size_t particle_id = 0;
-        for ( int i = 0; i < nx; ++i )
-        {
+                        cell_id( particle_id, 0 ) = i;
+                        cell_id( particle_id, 1 ) = j;
+                        cell_id( particle_id, 2 ) = k;
+
+                        pos( particle_id, 0 ) = x_min_ + ( i + 0.5 ) * dx_;
+                        pos( particle_id, 1 ) = x_min_ + ( j + 0.5 ) * dx_;
+                        pos( particle_id, 2 ) = x_min_ + ( k + 0.5 ) * dx_;
+                    }
+                }
+            } );
+    }
+};
+
+void copyListToHost( LCLTestData& test_data,
+                     const Cabana::LinkedCellList<TEST_MEMSPACE> cell_list )
+{
+    // Copy data to the host for testing.
+    auto np = test_data.num_p;
+    auto nx = test_data.nx;
+    auto pos_slice = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
+    auto id_slice = Cabana::slice<LCLTestData::CellId>( test_data.aosoa );
+
+    LCLTestData::IDViewType ids( "cell_ids", np );
+    LCLTestData::PosViewType pos( "cell_ids", np );
+    LCLTestData::BinViewType bin_size( "bin_size", nx, nx, nx );
+    LCLTestData::BinViewType bin_offset( "bin_offset", nx, nx, nx );
+    Kokkos::parallel_for(
+        "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
+        KOKKOS_LAMBDA( const int i ) {
             for ( int j = 0; j < nx; ++j )
-            {
                 for ( int k = 0; k < nx; ++k )
                 {
                     std::size_t original_id = i + j * nx + k * nx * nx;
-                    if ( begin <= original_id && original_id < end )
+                    ids( original_id, 0 ) = id_slice( original_id, 0 );
+                    ids( original_id, 1 ) = id_slice( original_id, 1 );
+                    ids( original_id, 2 ) = id_slice( original_id, 2 );
+                    pos( original_id, 0 ) = pos_slice( original_id, 0 );
+                    pos( original_id, 1 ) = pos_slice( original_id, 1 );
+                    pos( original_id, 2 ) = pos_slice( original_id, 2 );
+                    bin_size( i, j, k ) = cell_list.binSize( i, j, k );
+                    bin_offset( i, j, k ) = cell_list.binOffset( i, j, k );
+                }
+        } );
+    Kokkos::fence();
+    test_data.ids_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ids );
+    test_data.pos_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pos );
+    test_data.bin_size_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), bin_size );
+    test_data.bin_offset_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), bin_offset );
+}
+
+void checkBins( const LCLTestData test_data,
+                const Cabana::LinkedCellList<TEST_MEMSPACE> cell_list )
+{
+    auto nx = test_data.nx;
+
+    // Checking the binning.
+    EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
+    EXPECT_EQ( cell_list.numBin( 0 ), nx );
+    EXPECT_EQ( cell_list.numBin( 1 ), nx );
+    EXPECT_EQ( cell_list.numBin( 2 ), nx );
+}
+
+void checkLinkedCell( const LCLTestData test_data,
+                      const std::size_t check_begin,
+                      const std::size_t check_end, const bool sorted_ids )
+{
+    auto nx = test_data.nx;
+    auto ids_mirror = test_data.ids_mirror;
+    auto bin_size_mirror = test_data.bin_size_mirror;
+    auto bin_offset_mirror = test_data.bin_offset_mirror;
+
+    // The order should be reversed with the i index moving the slowest
+    // for those that are actually in the binning range. Do this pass
+    // first. We do this by looping through in the sorted order and
+    // check those that had original indices in the sorting range.
+    std::size_t particle_id = 0;
+    for ( int i = 0; i < nx; ++i )
+    {
+        for ( int j = 0; j < nx; ++j )
+        {
+            for ( int k = 0; k < nx; ++k )
+            {
+                std::size_t original_id = i + j * nx + k * nx * nx;
+                if ( check_begin <= original_id && original_id < check_end )
+                {
+                    // Get what should be the local id of the particle
+                    // in the newly sorted decomposition. We are looping
+                    // through this in k-fastest order (the indexing of
+                    // the grid cells) and therefore should get the
+                    // particles in their sorted order.
+                    int sort_id = check_begin + particle_id;
+
+                    // Back calculate what we think the ijk indices of
+                    // the particle are based on k-fastest ordering.
+                    int grid_id = i * nx * nx + j * nx + k;
+                    int grid_i = grid_id / ( nx * nx );
+                    int grid_j = ( grid_id / nx ) % nx;
+                    int grid_k = grid_id % nx;
+
+                    // Check the indices of the particle, if sorted.
+                    if ( sorted_ids )
                     {
-                        // Get what should be the local id of the particle in
-                        // the newly sorted decomposition. We are looping
-                        // through this in k-fastest order (the indexing of
-                        // the grid cells) and therefore should get the
-                        // particles in their sorted order.
-                        int sort_id = begin + particle_id;
-
-                        // Back calculate what we think the ijk indices of
-                        // the particle are based on k-fastest ordering.
-                        int grid_id = i * nx * nx + j * nx + k;
-                        int grid_i = grid_id / ( nx * nx );
-                        int grid_j = ( grid_id / nx ) % nx;
-                        int grid_k = grid_id % nx;
-
-                        // Check the indices of the particle
                         EXPECT_EQ( ids_mirror( sort_id, 0 ), grid_i );
                         EXPECT_EQ( ids_mirror( sort_id, 1 ), grid_j );
                         EXPECT_EQ( ids_mirror( sort_id, 2 ), grid_k );
-
-                        // Check that we binned the particle and got the right
-                        // offset.
-                        EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
-                        EXPECT_EQ( bin_offset_mirror( i, j, k ),
-                                   size_type( particle_id ) );
-
-                        // Increment the particle id.
-                        ++particle_id;
                     }
-                }
-            }
-        }
+                    // Check that we binned the particle and got the
+                    // right offset.
+                    EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
+                    EXPECT_EQ( bin_offset_mirror( i, j, k ),
+                               LCLTestData::size_type( particle_id ) );
 
-        // For those that are outside the binned range IDs should be
-        // unchanged and the bins should empty.
-        particle_id = 0;
-        for ( int k = 0; k < nx; ++k )
-        {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int i = 0; i < nx; ++i, ++particle_id )
-                {
-                    if ( begin > particle_id || particle_id >= end )
-                    {
-                        EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
-                        EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
-                        EXPECT_EQ( ids_mirror( particle_id, 2 ), k );
-                        EXPECT_EQ( bin_size_mirror( i, j, k ), 0 );
-                    }
+                    // Increment the particle id.
+                    ++particle_id;
                 }
             }
         }
     }
 
-    // Now bin and permute all of the particles.
+    // For those that are outside the binned range IDs should be
+    // unchanged and the bins should empty.
+    particle_id = 0;
+    for ( int k = 0; k < nx; ++k )
     {
-        Cabana::LinkedCellList<typename AoSoA_t::memory_space> cell_list(
-            Cabana::slice<Position>( aosoa ), grid_delta, grid_min, grid_max );
-        Cabana::permute( cell_list, aosoa );
-
-        // Copy data to the host for testing.
-        Kokkos::View<int* [3], TEST_MEMSPACE> ids( "cell_ids", num_p );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                            nx );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                              nx, nx );
-        Kokkos::parallel_for(
-            "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-            KOKKOS_LAMBDA( const int i ) {
-                for ( int j = 0; j < nx; ++j )
-                    for ( int k = 0; k < nx; ++k )
-                    {
-                        std::size_t original_id = i + j * nx + k * nx * nx;
-                        ids( original_id, 0 ) = cell_id( original_id, 0 );
-                        ids( original_id, 1 ) = cell_id( original_id, 1 );
-                        ids( original_id, 2 ) = cell_id( original_id, 2 );
-                        bin_size( i, j, k ) = cell_list.binSize( i, j, k );
-                        bin_offset( i, j, k ) = cell_list.binOffset( i, j, k );
-                    }
-            } );
-        Kokkos::fence();
-        auto ids_mirror =
-            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ids );
-        auto bin_size_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_size );
-        auto bin_offset_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_offset );
-
-        // Checking the binning. The order should be reversed with the i index
-        // moving the slowest.
-        EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
-        EXPECT_EQ( cell_list.numBin( 0 ), nx );
-        EXPECT_EQ( cell_list.numBin( 1 ), nx );
-        EXPECT_EQ( cell_list.numBin( 2 ), nx );
-        std::size_t particle_id = 0;
-        for ( int i = 0; i < nx; ++i )
+        for ( int j = 0; j < nx; ++j )
         {
-            for ( int j = 0; j < nx; ++j )
+            for ( int i = 0; i < nx; ++i, ++particle_id )
             {
-                for ( int k = 0; k < nx; ++k, ++particle_id )
+                if ( check_begin > particle_id || particle_id >= check_end )
                 {
                     EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
                     EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
                     EXPECT_EQ( ids_mirror( particle_id, 2 ), k );
-                    EXPECT_EQ( cell_list.cardinalBinIndex( i, j, k ),
-                               particle_id );
-                    EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
-                    EXPECT_EQ( bin_offset_mirror( i, j, k ),
-                               size_type( particle_id ) );
+                    EXPECT_EQ( bin_size_mirror( i, j, k ), 0 );
+                }
+                else if ( not sorted_ids )
+                {
+                    // If sorted by position slice, IDs in range should
+                    // still not be sorted.
+                    EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
+                    EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
+                    EXPECT_EQ( ids_mirror( particle_id, 2 ), k );
                 }
             }
         }
+    }
+}
+//---------------------------------------------------------------------------//
+void testLinkedList()
+{
+    LCLTestData test_data;
+    auto grid_delta = test_data.grid_delta;
+    auto grid_min = test_data.grid_min;
+    auto grid_max = test_data.grid_max;
+    auto pos = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
+
+    // Bin and permute the particles in the grid. First do this by only
+    // operating on a subset of the particles.
+    {
+        auto begin = test_data.begin;
+        auto end = test_data.end;
+        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list(
+            pos, begin, end, grid_delta, grid_min, grid_max );
+        Cabana::permute( cell_list, test_data.aosoa );
+
+        copyListToHost( test_data, cell_list );
+
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, begin, end, true );
+    }
+
+    // Now bin and permute all of the particles.
+    {
+        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list( pos, grid_delta,
+                                                         grid_min, grid_max );
+        Cabana::permute( cell_list, test_data.aosoa );
+
+        copyListToHost( test_data, cell_list );
+
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, 0, test_data.num_p, true );
     }
 }
 
 //---------------------------------------------------------------------------//
 void testLinkedListSlice()
 {
-    // Make an AoSoA with positions and ijk cell ids.
-    enum MyFields
-    {
-        Position = 0,
-        CellId = 1
-    };
-    using DataTypes = Cabana::MemberTypes<double[3], int[3]>;
-    using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE>;
-    using size_type = typename AoSoA_t::memory_space::size_type;
-    int num_p = 1000;
-    AoSoA_t aosoa( "aosoa", num_p );
-
-    // Set the problem so each particle lives in the center of a cell on a
-    // regular grid of cell size 1 and total size 10x10x10. We are making them
-    // in the reverse order we expect the sort to happen. The sort binary
-    // operator should order by i first and k last.
-    int nx = 10;
-    double dx = 1.0;
-    double x_min = 0.0;
-    double x_max = x_min + nx * dx;
-    auto pos = Cabana::slice<Position>( aosoa );
-    auto cell_id = Cabana::slice<CellId>( aosoa );
-    Kokkos::parallel_for(
-        "initialize", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-        KOKKOS_LAMBDA( const int k ) {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int i = 0; i < nx; ++i )
-                {
-                    std::size_t particle_id = i + j * nx + k * nx * nx;
-
-                    cell_id( particle_id, 0 ) = i;
-                    cell_id( particle_id, 1 ) = j;
-                    cell_id( particle_id, 2 ) = k;
-
-                    pos( particle_id, 0 ) = x_min + ( i + 0.5 ) * dx;
-                    pos( particle_id, 1 ) = x_min + ( j + 0.5 ) * dx;
-                    pos( particle_id, 2 ) = x_min + ( k + 0.5 ) * dx;
-                }
-            }
-        } );
-
-    // Create a grid.
-    double grid_delta[3] = { dx, dx, dx };
-    double grid_min[3] = { x_min, x_min, x_min };
-    double grid_max[3] = { x_max, x_max, x_max };
+    LCLTestData test_data;
+    auto grid_delta = test_data.grid_delta;
+    auto grid_min = test_data.grid_min;
+    auto grid_max = test_data.grid_max;
+    auto pos = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
 
     // Bin the particles in the grid and permute only the position slice.
     // First do this by only operating on a subset of the particles.
     {
-        std::size_t begin = 250;
-        std::size_t end = 750;
-        Cabana::LinkedCellList<typename AoSoA_t::memory_space> cell_list(
+        auto begin = test_data.begin;
+        auto end = test_data.end;
+        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list(
             pos, begin, end, grid_delta, grid_min, grid_max );
         Cabana::permute( cell_list, pos );
 
-        // Checking the binning.
-        EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
-        EXPECT_EQ( cell_list.numBin( 0 ), nx );
-        EXPECT_EQ( cell_list.numBin( 1 ), nx );
-        EXPECT_EQ( cell_list.numBin( 2 ), nx );
+        copyListToHost( test_data, cell_list );
 
-        // Copy data to the host for testing.
-        Kokkos::View<int* [3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
-        Kokkos::View<double* [3], TEST_MEMSPACE> pos_view( "positions", num_p );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                            nx );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                              nx, nx );
-        Kokkos::parallel_for(
-            "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-            KOKKOS_LAMBDA( const int i ) {
-                for ( int j = 0; j < nx; ++j )
-                    for ( int k = 0; k < nx; ++k )
-                    {
-                        std::size_t original_id = i + j * nx + k * nx * nx;
-                        ids_view( original_id, 0 ) = cell_id( original_id, 0 );
-                        ids_view( original_id, 1 ) = cell_id( original_id, 1 );
-                        ids_view( original_id, 2 ) = cell_id( original_id, 2 );
-                        pos_view( original_id, 0 ) = pos( original_id, 0 );
-                        pos_view( original_id, 1 ) = pos( original_id, 1 );
-                        pos_view( original_id, 2 ) = pos( original_id, 2 );
-                        bin_size( i, j, k ) = cell_list.binSize( i, j, k );
-                        bin_offset( i, j, k ) = cell_list.binOffset( i, j, k );
-                    }
-            } );
-        Kokkos::fence();
-        auto ids_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), ids_view );
-        auto pos_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), pos_view );
-        auto bin_size_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_size );
-        auto bin_offset_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_offset );
-
-        // The order should be reversed with the i index moving the slowest
-        // for those that are actually in the binning range. Do this pass
-        // first. We do this by looping through in the sorted order and check
-        // those that had original indices in the sorting range.
-        std::size_t particle_id = 0;
-        for ( int i = 0; i < nx; ++i )
-        {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int k = 0; k < nx; ++k )
-                {
-                    std::size_t original_id = i + j * nx + k * nx * nx;
-                    if ( begin <= original_id && original_id < end )
-                    {
-                        int sort_id = begin + particle_id;
-
-                        // Back calculate what we think the ijk indices of
-                        // the particle are based on k-fastest ordering.
-                        int grid_id = i * nx * nx + j * nx + k;
-                        int grid_i = grid_id / ( nx * nx );
-                        int grid_j = ( grid_id / nx ) % nx;
-                        int grid_k = grid_id % nx;
-                        float pos_i = x_min + ( grid_i + 0.5 ) * dx;
-                        float pos_j = x_min + ( grid_j + 0.5 ) * dx;
-                        float pos_k = x_min + ( grid_k + 0.5 ) * dx;
-
-                        // Get the position of the particle in
-                        // the newly sorted decomposition. We are looping
-                        // through this in k-fastest order (the indexing of
-                        // the grid cells) and therefore should get the
-                        // particles in their sorted order.
-                        EXPECT_EQ( pos_mirror( sort_id, 0 ), pos_i );
-                        EXPECT_EQ( pos_mirror( sort_id, 1 ), pos_j );
-                        EXPECT_EQ( pos_mirror( sort_id, 2 ), pos_k );
-
-                        // Check that we binned the particle and got the right
-                        // offset.
-                        EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
-                        EXPECT_EQ( bin_offset_mirror( i, j, k ),
-                                   size_type( particle_id ) );
-
-                        // Increment the particle id.
-                        ++particle_id;
-                    }
-                }
-            }
-        }
-        // For positions that are outside the binned range pos should be
-        // unchanged and the bins should empty.
-        particle_id = 0;
-        for ( int k = 0; k < nx; ++k )
-        {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int i = 0; i < nx; ++i, ++particle_id )
-                {
-                    if ( begin > particle_id || particle_id >= end )
-                    {
-                        float pos_i = x_min + ( i + 0.5 ) * dx;
-                        float pos_j = x_min + ( j + 0.5 ) * dx;
-                        float pos_k = x_min + ( k + 0.5 ) * dx;
-
-                        // Check the positions of the particle
-                        EXPECT_EQ( pos_mirror( particle_id, 0 ), pos_i );
-                        EXPECT_EQ( pos_mirror( particle_id, 1 ), pos_j );
-                        EXPECT_EQ( pos_mirror( particle_id, 2 ), pos_k );
-                        EXPECT_EQ( bin_size_mirror( i, j, k ), 0 );
-                    }
-
-                    // All IDs should be unsorted regardless of range
-                    EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
-                    EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
-                    EXPECT_EQ( ids_mirror( particle_id, 2 ), k );
-                }
-            }
-        }
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, begin, end, false );
     }
     // Now bin and permute all of the particles.
     {
-        Cabana::LinkedCellList<typename AoSoA_t::memory_space> cell_list(
-            pos, grid_delta, grid_min, grid_max );
+        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list( pos, grid_delta,
+                                                         grid_min, grid_max );
         Cabana::permute( cell_list, pos );
 
-        // Checking the binning. The order should be reversed with the i index
-        // moving the slowest.
-        EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
-        EXPECT_EQ( cell_list.numBin( 0 ), nx );
-        EXPECT_EQ( cell_list.numBin( 1 ), nx );
-        EXPECT_EQ( cell_list.numBin( 2 ), nx );
+        copyListToHost( test_data, cell_list );
 
-        // Copy data to the host for testing.
-        Kokkos::View<int* [3], TEST_MEMSPACE> ids_view( "cell_ids", num_p );
-        Kokkos::View<double* [3], TEST_MEMSPACE> pos_view( "positions", num_p );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_size( "bin_size", nx, nx,
-                                                            nx );
-        Kokkos::View<size_type***, TEST_MEMSPACE> bin_offset( "bin_offset", nx,
-                                                              nx, nx );
-        Kokkos::parallel_for(
-            "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
-            KOKKOS_LAMBDA( const int i ) {
-                for ( int j = 0; j < nx; ++j )
-                    for ( int k = 0; k < nx; ++k )
-                    {
-                        std::size_t original_id = i + j * nx + k * nx * nx;
-                        ids_view( original_id, 0 ) = cell_id( original_id, 0 );
-                        ids_view( original_id, 1 ) = cell_id( original_id, 1 );
-                        ids_view( original_id, 2 ) = cell_id( original_id, 2 );
-                        pos_view( original_id, 0 ) = pos( original_id, 0 );
-                        pos_view( original_id, 1 ) = pos( original_id, 1 );
-                        pos_view( original_id, 2 ) = pos( original_id, 2 );
-                        bin_size( i, j, k ) = cell_list.binSize( i, j, k );
-                        bin_offset( i, j, k ) = cell_list.binOffset( i, j, k );
-                    }
-            } );
-        Kokkos::fence();
-        auto ids_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), ids_view );
-        auto pos_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), pos_view );
-        auto bin_size_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_size );
-        auto bin_offset_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), bin_offset );
-
-        std::size_t particle_id = 0;
-        for ( int i = 0; i < nx; ++i )
-        {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int k = 0; k < nx; ++k, ++particle_id )
-                {
-                    float pos_i = x_min + ( i + 0.5 ) * dx;
-                    float pos_j = x_min + ( j + 0.5 ) * dx;
-                    float pos_k = x_min + ( k + 0.5 ) * dx;
-
-                    EXPECT_EQ( pos_mirror( particle_id, 0 ), pos_i );
-                    EXPECT_EQ( pos_mirror( particle_id, 1 ), pos_j );
-                    EXPECT_EQ( pos_mirror( particle_id, 2 ), pos_k );
-                    EXPECT_EQ( cell_list.cardinalBinIndex( i, j, k ),
-                               particle_id );
-                    EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
-                    EXPECT_EQ( bin_offset_mirror( i, j, k ),
-                               size_type( particle_id ) );
-                }
-            }
-        }
-        particle_id = 0;
-        for ( int k = 0; k < nx; ++k )
-        {
-            for ( int j = 0; j < nx; ++j )
-            {
-                for ( int i = 0; i < nx; ++i, ++particle_id )
-                {
-                    // All IDs should be unsorted
-                    EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
-                    EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
-                    EXPECT_EQ( ids_mirror( particle_id, 2 ), k );
-                }
-            }
-        }
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, 0, test_data.num_p, false );
     }
 }
 

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -148,6 +148,9 @@ void checkBins( const LCLTestData test_data,
     EXPECT_EQ( cell_list.numBin( 2 ), nx );
 }
 
+// Check LinkedCell data, where either a subset (begin->end) or all data is
+// sorted and where the IDs are sorted or not based on whether the entire AoSoA
+// or only the position slice was permuted.
 void checkLinkedCell( const LCLTestData test_data,
                       const std::size_t check_begin,
                       const std::size_t check_end, const bool sorted_ids )
@@ -297,6 +300,15 @@ void testLinkedListSlice()
     {
         Cabana::LinkedCellList<TEST_MEMSPACE> cell_list( pos, grid_delta,
                                                          grid_min, grid_max );
+        Cabana::permute( cell_list, pos );
+
+        copyListToHost( test_data, cell_list );
+
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, 0, test_data.num_p, false );
+
+        // Rebuild and make sure nothing changed.
+        cell_list.build( pos );
         Cabana::permute( cell_list, pos );
 
         copyListToHost( test_data, cell_list );


### PR DESCRIPTION
Only allocate on create of the LinkedCellList, with the normal use case being create once, then rebuild (resizing if needed). Part of #335 

Also rearranges the unit test to reduce copied code. 

Will need to be rebased once #372 is merged. Using that performance test, I posted some results below