### PR TITLE
Create Boundary Halo

### DIFF
--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -61,6 +61,12 @@ class GlobalGrid
     // Get whether a given dimension is periodic.
     bool isPeriodic( const int dim ) const;
 
+    // Determine if this block is on a low boundary in the given dimension.
+    bool onLowBoundary( const int dim ) const;
+
+    // Determine if this block is on a high boundary in the given dimension.
+    bool onHighBoundary( const int dim ) const;
+
     // Get the number of blocks in each dimension in the global mesh.
     int dimNumBlock( const int dim ) const;
 
@@ -119,6 +125,8 @@ class GlobalGrid
     std::array<int, num_space_dim> _cart_rank;
     std::array<int, num_space_dim> _owned_num_cell;
     std::array<int, num_space_dim> _global_cell_offset;
+    std::array<bool, num_space_dim> _boundary_lo;
+    std::array<bool, num_space_dim> _boundary_hi;
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -79,6 +79,13 @@ GlobalGrid<MeshType>::GlobalGrid(
         if ( dim_remainder[d] > _cart_rank[d] )
             ++_owned_num_cell[d];
     }
+
+    // Determine if a block is on the low or high boundaries.
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        _boundary_lo[d] = ( 0 == _cart_rank[d] );
+        _boundary_hi[d] = ( _ranks_per_dim[d] - 1 == _cart_rank[d] );
+    }
 }
 
 //---------------------------------------------------------------------------//
@@ -111,6 +118,22 @@ template <class MeshType>
 bool GlobalGrid<MeshType>::isPeriodic( const int dim ) const
 {
     return _periodic[dim];
+}
+
+//---------------------------------------------------------------------------//
+// Determine if this block is on a low boundary in the given dimension.
+template <class MeshType>
+bool GlobalGrid<MeshType>::onLowBoundary( const int dim ) const
+{
+    return _boundary_lo[dim];
+}
+
+//---------------------------------------------------------------------------//
+// Determine if this block is on a high boundary in the given dimension.
+template <class MeshType>
+bool GlobalGrid<MeshType>::onHighBoundary( const int dim ) const
+{
+    return _boundary_hi[dim];
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_IndexConversion.hpp
+++ b/cajita/src/Cajita_IndexConversion.hpp
@@ -96,9 +96,8 @@ struct L2G
         // Determine if a block is on the low or high boundaries.
         for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
-            auto block = global_grid.dimBlockId( d );
-            boundary_lo[d] = ( 0 == block );
-            boundary_hi[d] = ( global_grid.dimNumBlock( d ) - 1 == block );
+            boundary_lo[d] = global_grid.onLowBoundary( d );
+            boundary_hi[d] = global_grid.onHighBoundary( d );
         }
     }
 

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -52,6 +52,10 @@ class LocalGrid
     // Get the number of cells in the halo.
     int haloCellWidth() const;
 
+    // Get the total number of local cells in a given dimension (owned +
+    // halo).
+    int totalNumCell( const int d ) const;
+
     // Given the relative offsets of a neighbor rank relative to this local
     // grid's indices get the of the neighbor. If the neighbor rank is out of
     // bounds return -1. Note that in the case of periodic boundaries out of

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -86,23 +86,37 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
 
         // Compute the ghosted low corner
         for ( std::size_t d = 0; d < num_space_dim; ++d )
-            _ghost_low_corner[d] =
-                ( global_grid.isPeriodic( d ) ||
-                  global_grid.dimBlockId( d ) > 0 )
-                    ? lowCorner( Own(), d ) -
-                          local_grid.haloCellWidth() * _cell_size[d]
-                    : lowCorner( Own(), d );
+            _ghost_low_corner[d] = lowCorner( Own(), d ) -
+                                   local_grid.haloCellWidth() * _cell_size[d];
 
         // Compute the ghosted high corner
         for ( std::size_t d = 0; d < num_space_dim; ++d )
-            _ghost_high_corner[d] =
-                ( global_grid.isPeriodic( d ) ||
-                  global_grid.dimBlockId( d ) <
-                      global_grid.dimNumBlock( d ) - 1 )
-                    ? highCorner( Own(), d ) +
-                          local_grid.haloCellWidth() * _cell_size[d]
-                    : highCorner( Own(), d );
+            _ghost_high_corner[d] = highCorner( Own(), d ) +
+                                    local_grid.haloCellWidth() * _cell_size[d];
+
+        // Periodicity
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            _periodic[d] = global_grid.isPeriodic( d );
+
+        // Determine if a block is on the low or high boundaries.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            _boundary_lo[d] = global_grid.onLowBoundary( d );
+            _boundary_hi[d] = global_grid.onHighBoundary( d );
+        }
     }
+
+    // Determine if the mesh is periodic in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool isPeriodic( const int dim ) const { return _periodic[dim]; }
+
+    // Determine if this block is on a low boundary in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool onLowBoundary( const int dim ) const { return _boundary_lo[dim]; }
+
+    // Determine if this block is on a high boundary in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool onHighBoundary( const int dim ) const { return _boundary_hi[dim]; }
 
     // Get the physical coordinate of the low corner of the local grid in a
     // given dimension in the given decomposition.
@@ -224,6 +238,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     Kokkos::Array<Scalar, num_space_dim> _own_high_corner;
     Kokkos::Array<Scalar, num_space_dim> _ghost_low_corner;
     Kokkos::Array<Scalar, num_space_dim> _ghost_high_corner;
+    Kokkos::Array<bool, num_space_dim> _periodic;
+    Kokkos::Array<bool, num_space_dim> _boundary_lo;
+    Kokkos::Array<bool, num_space_dim> _boundary_hi;
 };
 
 //---------------------------------------------------------------------------//
@@ -267,12 +284,16 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
         // Compute the ghosted low corner
         for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
-            if ( global_grid.dimBlockId( d ) > 0 )
+            // Interior domain case.
+            if ( !global_grid.onLowBoundary( d ) )
             {
                 _ghost_low_corner[d] = global_mesh.nonUniformEdge(
                     d )[global_grid.globalOffset( d ) -
                         local_grid.haloCellWidth()];
             }
+
+            // Periodic boundary. Use cells on other side of boundary to
+            // generate geometry.
             else if ( global_grid.isPeriodic( d ) )
             {
                 int nedge = global_mesh.nonUniformEdge( d ).size();
@@ -282,23 +303,32 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
                       global_mesh.nonUniformEdge(
                           d )[nedge - local_grid.haloCellWidth() - 1] );
             }
+
+            // In the non-periodic boundary case we extrapolate halo cells to
+            // have the same width as the boundary cell.
             else
             {
-                _ghost_low_corner[d] = global_mesh.nonUniformEdge( d ).front();
+                Scalar dx = global_mesh.nonUniformEdge( d )[1] -
+                            global_mesh.nonUniformEdge( d )[0];
+                _ghost_low_corner[d] = global_mesh.nonUniformEdge( d ).front() -
+                                       dx * local_grid.haloCellWidth();
             }
         }
 
         // Compute the ghosted high corner
         for ( std::size_t d = 0; d < num_space_dim; ++d )
         {
-            if ( global_grid.dimBlockId( d ) <
-                 global_grid.dimNumBlock( d ) - 1 )
+            // Interior domain case.
+            if ( !global_grid.onHighBoundary( d ) )
             {
                 _ghost_high_corner[d] = global_mesh.nonUniformEdge(
                     d )[global_grid.globalOffset( d ) +
                         global_grid.ownedNumCell( d ) +
                         local_grid.haloCellWidth()];
             }
+
+            // Periodic boundary. Use cells on other side of boundary to
+            // generate geometry.
             else if ( global_grid.isPeriodic( d ) )
             {
                 _ghost_high_corner[d] =
@@ -307,9 +337,16 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
                           d )[local_grid.haloCellWidth()] -
                       global_mesh.nonUniformEdge( d ).front() );
             }
+
+            // In the non-periodic boundary case we extrapolate halo cells to
+            // have the same width as the boundary cell.
             else
             {
-                _ghost_high_corner[d] = global_mesh.nonUniformEdge( d ).back();
+                int nedge = global_mesh.nonUniformEdge( d ).size();
+                Scalar dx = global_mesh.nonUniformEdge( d )[nedge - 1] -
+                            global_mesh.nonUniformEdge( d )[nedge - 2];
+                _ghost_high_corner[d] = global_mesh.nonUniformEdge( d ).back() +
+                                        dx * local_grid.haloCellWidth();
             }
         }
 
@@ -325,6 +362,7 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
             // Allocate edges on the device for this dimension.
             const auto& global_edge = global_mesh.nonUniformEdge( d );
             int nedge = ghosted_nodes_local.extent( d );
+            int nedge_global = global_edge.size();
             _local_edges[d] = Kokkos::View<Scalar*, Device>(
                 Kokkos::ViewAllocateWithoutInitializing( "local_edges" ),
                 nedge );
@@ -336,42 +374,113 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
             // Compute the owned edges.
             for ( int n = owned_nodes_local.min( d );
                   n < owned_nodes_local.max( d ); ++n )
+            {
                 edge_mirror( n ) = global_edge[owned_nodes_global.min( d ) + n -
                                                owned_nodes_local.min( d )];
+            }
 
             // Compute the lower boundary edges.
-            if ( global_grid.dimBlockId( d ) > 0 )
+            if ( !global_grid.onLowBoundary( d ) )
+            {
+                // Interior block gets edges from neighbors.
                 for ( int n = 0; n < owned_nodes_local.min( d ); ++n )
+                {
                     edge_mirror( n ) =
                         global_edge[owned_nodes_global.min( d ) + n -
                                     owned_nodes_local.min( d )];
+                }
+            }
             else if ( global_grid.isPeriodic( d ) )
+            {
+                // Periodic boundary block gets edges from neighbor on
+                // opposite side of boundary.
                 for ( int n = 0; n < owned_nodes_local.min( d ); ++n )
+                {
                     edge_mirror( n ) =
                         global_edge.front() - global_edge.back() +
                         global_edge[global_edge.size() - 1 -
                                     local_grid.haloCellWidth() + n];
+                }
+            }
+            else
+            {
+                // Non-periodic boundary block extrapolates edges using
+                // boundary cell width.
+                for ( int n = 0; n < owned_nodes_local.min( d ); ++n )
+                {
+                    Scalar dx = global_edge[1] - global_edge[0];
+                    edge_mirror( n ) = global_edge.front() -
+                                       ( owned_nodes_local.min( d ) - n ) * dx;
+                }
+            }
 
             // Compute the upper boundary edges.
-            if ( global_grid.dimBlockId( d ) <
-                 global_grid.dimNumBlock( d ) - 1 )
+            if ( !global_grid.onHighBoundary( d ) )
+            {
+                // Interior block gets edges from neighbors.
                 for ( int n = owned_nodes_local.max( d );
                       n < ghosted_nodes_local.max( d ); ++n )
+                {
                     edge_mirror( n ) =
                         global_edge[owned_nodes_global.min( d ) + n -
                                     owned_nodes_local.min( d )];
+                }
+            }
             else if ( global_grid.isPeriodic( d ) )
+            {
+                // Periodic boundary block gets edges from neighbor on
+                // opposite side of boundary.
                 for ( int n = 0; n < ghosted_nodes_local.max( d ) -
                                          owned_nodes_local.max( d );
                       ++n )
+                {
                     edge_mirror( owned_nodes_local.max( d ) + n ) =
                         global_edge.back() + global_edge[n] -
                         global_edge.front();
+                }
+            }
+            else
+            {
+                // Non-periodic boundary block extrapolates edges using
+                // boundary cell width.
+                for ( int n = owned_nodes_local.max( d );
+                      n < ghosted_nodes_local.max( d ); ++n )
+                {
+                    Scalar dx = global_edge[nedge_global - 1] -
+                                global_edge[nedge_global - 2];
+                    edge_mirror( n ) =
+                        global_edge.back() +
+                        ( n - owned_nodes_local.max( d ) + 1 ) * dx;
+                }
+            }
 
             // Copy edges to the device.
             Kokkos::deep_copy( _local_edges[d], edge_mirror );
         }
+
+        // Periodicity
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            _periodic[d] = global_grid.isPeriodic( d );
+
+        // Determine if a block is on the low or high boundaries.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            _boundary_lo[d] = global_grid.onLowBoundary( d );
+            _boundary_hi[d] = global_grid.onHighBoundary( d );
+        }
     }
+
+    // Determine if the mesh is periodic in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool isPeriodic( const int dim ) const { return _periodic[dim]; }
+
+    // Determine if this block is on a low boundary in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool onLowBoundary( const int dim ) const { return _boundary_lo[dim]; }
+
+    // Determine if this block is on a high boundary in the given dimension.
+    KOKKOS_INLINE_FUNCTION
+    bool onHighBoundary( const int dim ) const { return _boundary_hi[dim]; }
 
     // Get the physical coordinate of the low corner of the local grid in a
     // given dimension in the given decomposition.
@@ -529,6 +638,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
     Kokkos::Array<Scalar, num_space_dim> _ghost_low_corner;
     Kokkos::Array<Scalar, num_space_dim> _ghost_high_corner;
     Kokkos::Array<Kokkos::View<Scalar*, Device>, num_space_dim> _local_edges;
+    Kokkos::Array<bool, num_space_dim> _periodic;
+    Kokkos::Array<bool, num_space_dim> _boundary_lo;
+    Kokkos::Array<bool, num_space_dim> _boundary_hi;
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -1674,7 +1674,8 @@ void notPeriodicTest3d()
     auto ghosted_cell_space =
         local_grid->indexSpace( Ghost(), Cell(), Local() );
     for ( int d = 0; d < 3; ++d )
-        EXPECT_EQ( ghosted_cell_space.extent( d ), global_num_cell[d] );
+        EXPECT_EQ( ghosted_cell_space.extent( d ),
+                   global_num_cell[d] + 2 * halo_width );
 
     // Get the owned number of nodes.
     auto owned_node_space = local_grid->indexSpace( Own(), Node(), Local() );
@@ -1685,7 +1686,8 @@ void notPeriodicTest3d()
     auto ghosted_node_space =
         local_grid->indexSpace( Ghost(), Node(), Local() );
     for ( int d = 0; d < 3; ++d )
-        EXPECT_EQ( ghosted_node_space.extent( d ), global_num_cell[d] + 1 );
+        EXPECT_EQ( ghosted_node_space.extent( d ),
+                   global_num_cell[d] + 1 + 2 * halo_width );
 
     // Get the owned number of I-faces.
     auto owned_i_face_space =
@@ -1705,9 +1707,10 @@ void notPeriodicTest3d()
     {
         if ( Dim::I == d )
             EXPECT_EQ( ghosted_i_face_space.extent( d ),
-                       global_num_cell[d] + 1 );
+                       global_num_cell[d] + 1 + 2 * halo_width );
         else
-            EXPECT_EQ( ghosted_i_face_space.extent( d ), global_num_cell[d] );
+            EXPECT_EQ( ghosted_i_face_space.extent( d ),
+                       global_num_cell[d] + 2 * halo_width );
     }
 
     // Get the owned number of J-faces.
@@ -1728,9 +1731,10 @@ void notPeriodicTest3d()
     {
         if ( Dim::J == d )
             EXPECT_EQ( ghosted_j_face_space.extent( d ),
-                       global_num_cell[d] + 1 );
+                       global_num_cell[d] + 1 + 2 * halo_width );
         else
-            EXPECT_EQ( ghosted_j_face_space.extent( d ), global_num_cell[d] );
+            EXPECT_EQ( ghosted_j_face_space.extent( d ),
+                       global_num_cell[d] + 2 * halo_width );
     }
 
     // Get the owned number of K-faces.
@@ -1751,9 +1755,10 @@ void notPeriodicTest3d()
     {
         if ( Dim::K == d )
             EXPECT_EQ( ghosted_k_face_space.extent( d ),
-                       global_num_cell[d] + 1 );
+                       global_num_cell[d] + 1 + 2 * halo_width );
         else
-            EXPECT_EQ( ghosted_k_face_space.extent( d ), global_num_cell[d] );
+            EXPECT_EQ( ghosted_k_face_space.extent( d ),
+                       global_num_cell[d] + 2 * halo_width );
     }
 
     // Check neighbor ranks and shared spaces.
@@ -2598,7 +2603,8 @@ void notPeriodicTest2d()
     auto ghosted_cell_space =
         local_grid->indexSpace( Ghost(), Cell(), Local() );
     for ( int d = 0; d < 2; ++d )
-        EXPECT_EQ( ghosted_cell_space.extent( d ), global_num_cell[d] );
+        EXPECT_EQ( ghosted_cell_space.extent( d ),
+                   global_num_cell[d] + 2 * halo_width );
 
     // Get the owned number of nodes.
     auto owned_node_space = local_grid->indexSpace( Own(), Node(), Local() );
@@ -2609,7 +2615,8 @@ void notPeriodicTest2d()
     auto ghosted_node_space =
         local_grid->indexSpace( Ghost(), Node(), Local() );
     for ( int d = 0; d < 2; ++d )
-        EXPECT_EQ( ghosted_node_space.extent( d ), global_num_cell[d] + 1 );
+        EXPECT_EQ( ghosted_node_space.extent( d ),
+                   global_num_cell[d] + 1 + 2 * halo_width );
 
     // Get the owned number of I-faces.
     auto owned_i_face_space =
@@ -2629,9 +2636,10 @@ void notPeriodicTest2d()
     {
         if ( Dim::I == d )
             EXPECT_EQ( ghosted_i_face_space.extent( d ),
-                       global_num_cell[d] + 1 );
+                       global_num_cell[d] + 1 + 2 * halo_width );
         else
-            EXPECT_EQ( ghosted_i_face_space.extent( d ), global_num_cell[d] );
+            EXPECT_EQ( ghosted_i_face_space.extent( d ),
+                       global_num_cell[d] + 2 * halo_width );
     }
 
     // Get the owned number of J-faces.
@@ -2652,9 +2660,10 @@ void notPeriodicTest2d()
     {
         if ( Dim::J == d )
             EXPECT_EQ( ghosted_j_face_space.extent( d ),
-                       global_num_cell[d] + 1 );
+                       global_num_cell[d] + 1 + 2 * halo_width );
         else
-            EXPECT_EQ( ghosted_j_face_space.extent( d ), global_num_cell[d] );
+            EXPECT_EQ( ghosted_j_face_space.extent( d ),
+                       global_num_cell[d] + 2 * halo_width );
     }
     // Check neighbor ranks and shared spaces.
     for ( int i = -1; i < 2; ++i )

--- a/cajita/unit_test/tstLocalMesh2d.hpp
+++ b/cajita/unit_test/tstLocalMesh2d.hpp
@@ -90,29 +90,20 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
 
     for ( int d = 0; d < 2; ++d )
     {
-        int ghost_lc_offset =
-            ( global_grid.isPeriodic( d ) || global_grid.dimBlockId( d ) > 0 )
-                ? halo_width
-                : 0;
-        EXPECT_FLOAT_EQ( ghost_lc_m( d ),
-                         low_corner[d] +
-                             cell_size * ( global_grid.globalOffset( d ) -
-                                           ghost_lc_offset ) );
+        EXPECT_FLOAT_EQ(
+            ghost_lc_m( d ),
+            low_corner[d] +
+                cell_size * ( global_grid.globalOffset( d ) - halo_width ) );
 
-        int ghost_hc_offset =
-            ( global_grid.isPeriodic( d ) ||
-              global_grid.dimBlockId( d ) < global_grid.dimNumBlock( d ) - 1 )
-                ? local_grid.haloCellWidth()
-                : 0;
         EXPECT_FLOAT_EQ( ghost_hc_m( d ),
                          low_corner[d] +
                              cell_size * ( global_grid.globalOffset( d ) +
-                                           ghost_hc_offset +
-                                           global_grid.ownedNumCell( d ) ) );
+                                           global_grid.ownedNumCell( d ) +
+                                           halo_width ) );
 
-        EXPECT_FLOAT_EQ( ghost_ext_m( d ),
-                         cell_size * ( global_grid.ownedNumCell( d ) +
-                                       ghost_hc_offset + ghost_lc_offset ) );
+        EXPECT_FLOAT_EQ(
+            ghost_ext_m( d ),
+            cell_size * ( global_grid.ownedNumCell( d ) + 2 * halo_width ) );
     }
 
     // Check the cell locations and measures.

--- a/cajita/unit_test/tstLocalMesh3d.hpp
+++ b/cajita/unit_test/tstLocalMesh3d.hpp
@@ -90,29 +90,20 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
 
     for ( int d = 0; d < 3; ++d )
     {
-        int ghost_lc_offset =
-            ( global_grid.isPeriodic( d ) || global_grid.dimBlockId( d ) > 0 )
-                ? halo_width
-                : 0;
-        EXPECT_FLOAT_EQ( ghost_lc_m( d ),
-                         low_corner[d] +
-                             cell_size * ( global_grid.globalOffset( d ) -
-                                           ghost_lc_offset ) );
+        EXPECT_FLOAT_EQ(
+            ghost_lc_m( d ),
+            low_corner[d] +
+                cell_size * ( global_grid.globalOffset( d ) - halo_width ) );
 
-        int ghost_hc_offset =
-            ( global_grid.isPeriodic( d ) ||
-              global_grid.dimBlockId( d ) < global_grid.dimNumBlock( d ) - 1 )
-                ? local_grid.haloCellWidth()
-                : 0;
         EXPECT_FLOAT_EQ( ghost_hc_m( d ),
                          low_corner[d] +
                              cell_size * ( global_grid.globalOffset( d ) +
-                                           ghost_hc_offset +
-                                           global_grid.ownedNumCell( d ) ) );
+                                           global_grid.ownedNumCell( d ) +
+                                           halo_width ) );
 
-        EXPECT_FLOAT_EQ( ghost_ext_m( d ),
-                         cell_size * ( global_grid.ownedNumCell( d ) +
-                                       ghost_hc_offset + ghost_lc_offset ) );
+        EXPECT_FLOAT_EQ(
+            ghost_ext_m( d ),
+            cell_size * ( global_grid.ownedNumCell( d ) + 2 * halo_width ) );
     }
 
     // Check the cell locations and measures.


### PR DESCRIPTION
The pull requests adds indexing to the `LocalGrid` which creates a halo region on non-periodic boundaries. Previously, we cut off the grid on non-periodic boundaries such that the owned set of indices coincided with the ghosted set of indices. All of the physics applications we have been developing on top of this require a boundary halo region for boundary conditions on non-periodic boundaries so we are adding this. 

Notes:

- The new boundary halo region does not participate in communication because it does not have a neighboring block to communicate with.
- A follow-on PR will be made that will allow a user to specifically grab an `IndexSpace` for a given boundary halo. I didn't add this here because that will require a bit of code to implement
- New functions have been added to mesh classes to allow one to identify if a block is on a low/high boundary in a given logical dimension.
- Most of the updates in this PR are to the unit tests to account for the fact that the `Ghost` index spaces can now include a boundary halo that doesn't participate in communication. The tests previously assumed all ghost regions were part of communication.
- The shouldn't affect user code in that the concept of `Own` and `Ghost` hasn't changed - there are just some additional ghost regions now.
- The `LocalMesh` also had to be updated for creation of mesh data to include the new boundary region. For the `NonUniformMesh` case, the new boundary zones are created such that the cell sizes are equal to the cell size of the boundary cell. 