### PR TITLE
Remove parallel flag

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -44,7 +44,6 @@ jobs:
             kokkos_ver: 'master'
             arborx: ['NoArborX']
             coverage: 'OFF'
-            cxx_flags: ' -parallel'
           - distro: 'fedora:intel'
             cxx: 'icpc'
             openmp: 'OFF'
@@ -52,7 +51,6 @@ jobs:
             kokkos_ver: 'master'
             arborx: ['NoArborX']
             coverage: 'OFF'
-            cxx_flags: ' -parallel'
           - distro: 'fedora:latest'
             cxx: 'g++'
             openmp: 'ON'
@@ -175,7 +173,7 @@ jobs:
             -DMPIEXEC_MAX_NUMPROCS=2 -DMPIEXEC_PREFLAGS="--oversubscribe" \
             -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx" \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
-            -DCMAKE_CXX_FLAGS="-Wall -pedantic ${{ matrix.cxx_flags }}" \
+            -DCMAKE_CXX_FLAGS="-Wall -pedantic" \
             -DCabana_ENABLE_TESTING=ON \
             -DCabana_ENABLE_EXAMPLES=ON \
             -DCabana_ENABLE_PERFORMANCE_TESTING=ON \

--- a/core/performance_test/CMakeLists.txt
+++ b/core/performance_test/CMakeLists.txt
@@ -9,5 +9,8 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
-add_subdirectory(peakflops)
+if(Kokkos_ENABLE_OPENMP)
+  add_subdirectory(peakflops)
+endif()
+
 add_subdirectory(benchmark)


### PR DESCRIPTION
Reverts a flag added when from switching to GHA. The `-parallel` flag (added for serial peakflops tests) seems to have caused occasional failures with team vector parallelism in the neighbor tests