### PR TITLE
fixup: run CI coverage once

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -185,8 +185,8 @@ jobs:
           cmake --install build
       - name: Format Cabana
         if: ${{ matrix.distro == 'ubuntu:latest' }}
+        working-directory: build
         run: |
-             cd build
              make format
              git diff --exit-code
       - name: Upload Report to codecov.io

--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -190,5 +190,5 @@ jobs:
              make format
              git diff --exit-code
       - name: Upload Report to codecov.io
-        if: ${{ matrix.coverage }}
+        if: ${{ matrix.coverage == 'ON' }}
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
#366 still uploaded coverage for all runs, so we're still getting codecov fluctuations on every PR