### PR TITLE
Boundary Indices

### DIFF
--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -142,7 +142,8 @@ class IndexSpace
     {
         bool result = true;
         for ( long i = 0; i < N; ++i )
-            result = result && (_min[i] <= index[i]) && (index[i] < _max[i]);
+            result =
+                result && ( _min[i] <= index[i] ) && ( index[i] < _max[i] );
         return result;
     }
 

--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -136,6 +136,16 @@ class IndexSpace
         return size;
     }
 
+    // Determine if a set of indices is within the range of the index space.
+    KOKKOS_INLINE_FUNCTION
+    bool inRange( const long index[N] ) const
+    {
+        bool result = true;
+        for ( long i = 0; i < N; ++i )
+            result = result && (_min[i] <= index[i]) && (index[i] < _max[i]);
+        return result;
+    }
+
   private:
     // Minimum index bounds.
     Kokkos::Array<long, Rank> _min;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -104,6 +104,29 @@ class LocalGrid
     sharedIndexSpace( DecompositionTag, EntityType, const int off_i,
                       const int off_j, const int halo_width = -1 ) const;
 
+    /*
+       Given the relative offsets of a boundary get the set of ghost entity
+       local indices are in that boundary region. Optionally provide a halo
+       width for the boundary space. This halo width must be less than or
+       equal to the halo width of the local grid. The default behavior is to
+       use the halo width of the local grid.
+    */
+    template <class EntityType>
+    IndexSpace<num_space_dim>
+    boundaryIndexSpace( EntityType,
+                        const std::array<int, num_space_dim>& off_ijk,
+                        const int halo_width = -1 ) const;
+
+    template <class EntityType, std::size_t NSD = num_space_dim>
+    std::enable_if_t<3 == NSD, IndexSpace<3>>
+    boundaryIndexSpace( EntityType, const int off_i, const int off_j,
+                        const int off_k, const int halo_width = -1 ) const;
+
+    template <class EntityType, std::size_t NSD = num_space_dim>
+    std::enable_if_t<2 == NSD, IndexSpace<2>>
+    boundaryIndexSpace( EntityType, const int off_i, const int off_j,
+                        const int halo_width = -1 ) const;
+
   private:
     // 3D and 2D entity types
     IndexSpace<num_space_dim> indexSpaceImpl( Own, Cell, Local ) const;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -56,11 +56,13 @@ class LocalGrid
     // halo).
     int totalNumCell( const int d ) const;
 
-    // Given the relative offsets of a neighbor rank relative to this local
-    // grid's indices get the of the neighbor. If the neighbor rank is out of
-    // bounds return -1. Note that in the case of periodic boundaries out of
-    // bounds indices are allowed as the indices will be wrapped around the
-    // periodic boundary.
+    /*
+       Given the relative offsets of a neighbor rank relative to this local
+       grid's indices get the of the neighbor. If the neighbor rank is out of
+       bounds return -1. Note that in the case of periodic boundaries out of
+       bounds indices are allowed as the indices will be wrapped around the
+       periodic boundary.
+    */
     int neighborRank( const std::array<int, num_space_dim>& off_ijk ) const;
 
     template <std::size_t NSD = num_space_dim>
@@ -71,8 +73,11 @@ class LocalGrid
     std::enable_if_t<2 == NSD, int> neighborRank( const int off_i,
                                                   const int off_j ) const;
 
-    // Get the index space for a given combination of decomposition, entity,
-    // and index types.
+    /*
+      Given a decomposition type, entity type, and index type, get the
+      contiguous set of indices that span the space of those entities in the
+      local domain
+    */
     template <class DecompositionTag, class EntityType, class IndexType>
     IndexSpace<num_space_dim> indexSpace( DecompositionTag, EntityType,
                                           IndexType ) const;
@@ -105,27 +110,34 @@ class LocalGrid
                       const int off_j, const int halo_width = -1 ) const;
 
     /*
-       Given the relative offsets of a boundary get the set of ghost entity
-       local indices are in that boundary region. Optionally provide a halo
-       width for the boundary space. This halo width must be less than or
-       equal to the halo width of the local grid. The default behavior is to
-       use the halo width of the local grid.
+       Given the relative offsets of a boundary relative to this local
+       grid's indices get the set of local entity indices associated with that
+       boundary in the given decomposition. Optionally provide a halo width
+       for the shared space. This halo width must be less than or equal to the
+       halo width of the local grid. The default behavior is to use the halo
+       width of the local grid. For example, if the Own decomposition is used,
+       the interior entities that would be affected by a boundary operation
+       are provided whereas if the Ghost decomposition is used the halo
+       entities on the boundary are provided.
     */
-    template <class EntityType>
+    template <class DecompositionTag, class EntityType>
     IndexSpace<num_space_dim>
-    boundaryIndexSpace( EntityType,
+    boundaryIndexSpace( DecompositionTag, EntityType,
                         const std::array<int, num_space_dim>& off_ijk,
                         const int halo_width = -1 ) const;
 
-    template <class EntityType, std::size_t NSD = num_space_dim>
+    template <class DecompositionTag, class EntityType,
+              std::size_t NSD = num_space_dim>
     std::enable_if_t<3 == NSD, IndexSpace<3>>
-    boundaryIndexSpace( EntityType, const int off_i, const int off_j,
-                        const int off_k, const int halo_width = -1 ) const;
-
-    template <class EntityType, std::size_t NSD = num_space_dim>
-    std::enable_if_t<2 == NSD, IndexSpace<2>>
-    boundaryIndexSpace( EntityType, const int off_i, const int off_j,
+    boundaryIndexSpace( DecompositionTag, EntityType, const int off_i,
+                        const int off_j, const int off_k,
                         const int halo_width = -1 ) const;
+
+    template <class DecompositionTag, class EntityType,
+              std::size_t NSD = num_space_dim>
+    std::enable_if_t<2 == NSD, IndexSpace<2>>
+    boundaryIndexSpace( DecompositionTag, EntityType, const int off_i,
+                        const int off_j, const int halo_width = -1 ) const;
 
   private:
     // 3D and 2D entity types

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -97,11 +97,12 @@ auto LocalGrid<MeshType>::indexSpace( DecompositionTag t1, EntityType t2,
 }
 
 //---------------------------------------------------------------------------//
-// Given a relative set of indices of a neighbor get the set of local entity
-// indices shared with that neighbor in the given decomposition. Optionally
-// provide a halo width for the shared space. This halo width must be less
-// than or equal to the halo width of the local grid. The default behavior is
-// to use the halo width of the local grid.
+// Given the relative offsets of a neighbor rank relative to this local
+// grid's indices get the set of local entity indices shared with that
+// neighbor in the given decomposition. Optionally provide a halo width
+// for the shared space. This halo width must be less than or equal to the
+// halo width of the local grid. The default behavior is to use the halo
+// width of the local grid.
 template <class MeshType>
 template <class DecompositionTag, class EntityType>
 auto LocalGrid<MeshType>::sharedIndexSpace(
@@ -156,6 +157,69 @@ LocalGrid<MeshType>::sharedIndexSpace( DecompositionTag t1, EntityType t2,
 {
     std::array<int, 2> off_ijk = { off_i, off_j };
     return sharedIndexSpace( t1, t2, off_ijk, halo_width );
+}
+
+//---------------------------------------------------------------------------//
+// Given the relative offsets of a boundary get the set of ghost entity
+// local indices are in that boundary region. Optionally provide a halo
+// width for the behavior space. This halo width must be less than or
+// equal to the halo width of the local grid. The default behavior is to
+// use the halo width of the local grid.
+template <class MeshType>
+template <class EntityType>
+auto LocalGrid<MeshType>::boundaryIndexSpace(
+    EntityType entity, const std::array<int, num_space_dim>& off_ijk,
+    const int halo_width ) const -> IndexSpace<num_space_dim>
+{
+    // If we got the default halo width of -1 this means we want to use the
+    // default of the entire halo.
+    int hw = ( -1 == halo_width ) ? _halo_cell_width : halo_width;
+
+    // Check that the offsets are valid.
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        if ( off_ijk[d] < -1 || 1 < off_ijk[d] )
+            throw std::logic_error( "Boundary indices out of bounds" );
+
+    // Check that the requested halo width is valid.
+    if ( hw > _halo_cell_width )
+        throw std::logic_error(
+            "Requested halo width larger than local grid halo" );
+
+    // Check to see if this is not a communication neighbor. If it is, return
+    // a shared space of size 0 because there is no boundary.
+    if ( neighborRank( off_ijk ) >= 0 )
+    {
+        std::array<long, num_space_dim> zero_size;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            zero_size[d] = 0;
+        return IndexSpace<num_space_dim>( zero_size, zero_size );
+    }
+
+    // The boundary index space is just the ghost shared index space for the
+    // given offsets.
+    return sharedIndexSpaceImpl( Ghost{}, entity, off_ijk, hw );
+}
+
+template <class MeshType>
+template <class EntityType, std::size_t NSD>
+std::enable_if_t<3 == NSD, IndexSpace<3>>
+LocalGrid<MeshType>::boundaryIndexSpace( EntityType entity, const int off_i,
+                                         const int off_j, const int off_k,
+                                         const int halo_width ) const
+{
+    std::array<int, 3> off_ijk = { off_i, off_j, off_k };
+    return boundaryIndexSpace( entity, off_ijk, halo_width );
+}
+
+template <class MeshType>
+template <class EntityType, std::size_t NSD>
+std::enable_if_t<2 == NSD, IndexSpace<2>>
+LocalGrid<MeshType>::boundaryIndexSpace( EntityType entity, const int off_i,
+                                         const int off_j,
+                                         const int halo_width ) const
+{
+    std::array<int, 2> off_ijk = { off_i, off_j };
+    return boundaryIndexSpace( entity, off_ijk, halo_width );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -552,6 +552,39 @@ void defaultConstructorTest()
 }
 
 //---------------------------------------------------------------------------//
+void inRangeTest()
+{
+    IndexSpace<3> space( { 9, 2, 1 }, { 12, 16, 4 } );
+
+    long i0[3] = { 9, 2, 1 };
+    EXPECT_TRUE( space.inRange( i0 ) );
+
+    long i1[3] = { 10, 9, 3 };
+    EXPECT_TRUE( space.inRange( i1 ) );
+
+    long i2[3] = { 3, 9, 3 };
+    EXPECT_FALSE( space.inRange( i2 ) );
+
+    long i3[3] = { 10, 19, 3 };
+    EXPECT_FALSE( space.inRange( i3 ) );
+
+    long i4[3] = { 10, 9, 13 };
+    EXPECT_FALSE( space.inRange( i4 ) );
+
+    long i5[3] = { 3, 19, 3 };
+    EXPECT_FALSE( space.inRange( i5 ) );
+
+    long i6[3] = { 10, 19, 13 };
+    EXPECT_FALSE( space.inRange( i6 ) );
+
+    long i7[3] = { 3, 19, 13 };
+    EXPECT_FALSE( space.inRange( i7 ) );
+
+    long i8[3] = { 12, 16, 4 };
+    EXPECT_FALSE( space.inRange( i8 ) );
+}
+
+//---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, index_space_test )

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -327,13 +327,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_cell_space =
-        local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
-    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1, 0 );
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
-    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1, -1 );
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Own{}, Cell(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Own{}, Cell(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Own{}, Cell(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
     //////////////////
@@ -594,13 +608,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_node_space =
-        local_grid->boundaryIndexSpace( Node(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
-    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 1, -1, 0 );
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
-    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 0, 1, -1 );
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Own{}, Node(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Own{}, Node(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Own{}, Node(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
     //////////////////
@@ -842,15 +870,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     //////////////////
@@ -998,15 +1038,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 
     boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 
     boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 
     //////////////////
@@ -1154,15 +1206,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_face_k_space =
-        local_grid->boundaryIndexSpace( Face<Dim::K>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::K>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_face_k_space.size() );
 
     boundary_face_k_space =
-        local_grid->boundaryIndexSpace( Face<Dim::K>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::K>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_face_k_space.size() );
 
     boundary_face_k_space =
-        local_grid->boundaryIndexSpace( Face<Dim::K>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::K>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
+
+    boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::K>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
+
+    boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::K>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
+
+    boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::K>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_face_k_space.size() );
 
     //////////////////
@@ -1404,15 +1468,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_edge_i_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::I>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::I>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_edge_i_space.size() );
 
     boundary_edge_i_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::I>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::I>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_edge_i_space.size() );
 
     boundary_edge_i_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::I>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::I>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
+    boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::I>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
+    boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::I>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
+    boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::I>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_edge_i_space.size() );
 
     //////////////////
@@ -1560,15 +1636,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_edge_j_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::J>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::J>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_edge_j_space.size() );
 
     boundary_edge_j_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::J>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::J>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_edge_j_space.size() );
 
     boundary_edge_j_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::J>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::J>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
+    boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::J>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
+    boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::J>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
+    boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::J>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_edge_j_space.size() );
 
     //////////////////
@@ -1716,15 +1804,27 @@ void periodicTest3d()
 
     // Check that the boundary spaces are empty.
     auto boundary_edge_k_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::K>(), -1, 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::K>(), -1, 0, 1 );
     EXPECT_EQ( 0, boundary_edge_k_space.size() );
 
     boundary_edge_k_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::K>(), 1, -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::K>(), 1, -1, 0 );
     EXPECT_EQ( 0, boundary_edge_k_space.size() );
 
     boundary_edge_k_space =
-        local_grid->boundaryIndexSpace( Edge<Dim::K>(), 0, 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Edge<Dim::K>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
+
+    boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::K>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
+
+    boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::K>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
+
+    boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Own{}, Edge<Dim::K>(), 0, 1, -1 );
     EXPECT_EQ( 0, boundary_edge_k_space.size() );
 }
 
@@ -1935,7 +2035,7 @@ void notPeriodicTest3d()
     if ( -1 == local_grid->neighborRank( -1, 0, 1 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ), 0 );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ),
@@ -1946,12 +2046,27 @@ void notPeriodicTest3d()
                    owned_cell_space.max( Dim::K ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ),
                    owned_cell_space.max( Dim::K ) + halo_width );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.min( Dim::I ) + halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.max( Dim::K ) - halo_width );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
     }
 
     if ( -1 == local_grid->neighborRank( 1, -1, 0 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), 1, -1, 0 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1, 0 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.max( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -1962,12 +2077,27 @@ void notPeriodicTest3d()
                    owned_cell_space.min( Dim::K ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ),
                    owned_cell_space.max( Dim::K ) );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 1, -1, 0 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) - halo_width );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.min( Dim::J ) + halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
     }
 
     if ( -1 == local_grid->neighborRank( 0, 1, -1 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), 0, 1, -1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1, -1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.min( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -1978,6 +2108,21 @@ void notPeriodicTest3d()
                    owned_cell_space.max( Dim::J ) + halo_width );
         EXPECT_EQ( boundary_cell_space.min( Dim::K ), 0 );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ), halo_width );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 0, 1, -1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) - halo_width );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.min( Dim::K ) + halo_width );
     }
 
     // Check the boundary spaces again but this time with a
@@ -1985,7 +2130,7 @@ void notPeriodicTest3d()
     if ( -1 == local_grid->neighborRank( -1, 0, 1 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0, 1, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ), halo_width - 1 );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ),
@@ -1996,12 +2141,27 @@ void notPeriodicTest3d()
                    owned_cell_space.max( Dim::K ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ),
                    owned_cell_space.max( Dim::K ) + 1 );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), -1, 0, 1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.min( Dim::I ) + 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.max( Dim::K ) - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
     }
 
     if ( -1 == local_grid->neighborRank( 1, -1, 0 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), 1, -1, 0, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1, 0, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.max( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -2012,12 +2172,27 @@ void notPeriodicTest3d()
                    owned_cell_space.min( Dim::K ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ),
                    owned_cell_space.max( Dim::K ) );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 1, -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.min( Dim::J ) + 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
     }
 
     if ( -1 == local_grid->neighborRank( 0, 1, -1 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), 0, 1, -1, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1, -1, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.min( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -2028,6 +2203,21 @@ void notPeriodicTest3d()
                    owned_cell_space.max( Dim::J ) + 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::K ), halo_width - 1 );
         EXPECT_EQ( boundary_cell_space.max( Dim::K ), halo_width );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 0, 1, -1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.min( Dim::K ) + 1 );
     }
 
     // Free the serial communicator we made
@@ -2272,13 +2462,27 @@ void periodicTest2d()
                owned_cell_space.max( Dim::J ) + 1 );
 
     // Check that the boundary spaces are empty.
-    auto boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), -1, 0 );
+    auto boundary_cell_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
-    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1 );
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
-    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1 );
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Own{}, Cell(), -1, 0 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space =
+        local_grid->boundaryIndexSpace( Own{}, Cell(), 1, -1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space = local_grid->boundaryIndexSpace( Own{}, Cell(), 0, 1 );
     EXPECT_EQ( 0, boundary_cell_space.size() );
 
     //////////////////
@@ -2478,13 +2682,27 @@ void periodicTest2d()
                owned_node_space.max( Dim::J ) + 2 );
 
     // Check that the boundary spaces are empty.
-    auto boundary_node_space = local_grid->boundaryIndexSpace( Node(), -1, 0 );
+    auto boundary_node_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), -1, 0 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
-    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 1, -1 );
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), 1, -1 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
-    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 0, 1 );
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Ghost{}, Node(), 0, 1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Own{}, Node(), -1, 0 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space =
+        local_grid->boundaryIndexSpace( Own{}, Node(), 1, -1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space = local_grid->boundaryIndexSpace( Own{}, Node(), 0, 1 );
     EXPECT_EQ( 0, boundary_node_space.size() );
 
     //////////////////
@@ -2669,15 +2887,27 @@ void periodicTest2d()
 
     // Check that the boundary spaces are empty.
     auto boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), -1, 0 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), 1, -1 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     boundary_face_i_space =
-        local_grid->boundaryIndexSpace( Face<Dim::I>(), 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::I>(), 0, 1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), -1, 0 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), 1, -1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::I>(), 0, 1 );
     EXPECT_EQ( 0, boundary_face_i_space.size() );
 
     //////////////////
@@ -2792,15 +3022,27 @@ void periodicTest2d()
 
     // Check that the boundary spaces are empty.
     auto boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), -1, 0 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), -1, 0 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 
     boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), 1, -1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), 1, -1 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 
     boundary_face_j_space =
-        local_grid->boundaryIndexSpace( Face<Dim::J>(), 0, 1 );
+        local_grid->boundaryIndexSpace( Ghost{}, Face<Dim::J>(), 0, 1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), -1, 0 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), 1, -1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Own{}, Face<Dim::J>(), 0, 1 );
     EXPECT_EQ( 0, boundary_face_j_space.size() );
 }
 
@@ -2965,9 +3207,21 @@ void notPeriodicTest2d()
     IndexSpace<2> boundary_cell_space;
     if ( -1 == local_grid->neighborRank( -1, 0 ) )
     {
-        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), -1, 0 );
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ), 0 );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), -1, 0 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.min( Dim::I ) + halo_width );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ),
                    owned_cell_space.min( Dim::J ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ),
@@ -2976,18 +3230,30 @@ void notPeriodicTest2d()
 
     if ( -1 == local_grid->neighborRank( 1, -1 ) )
     {
-        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1 );
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.max( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
                    owned_cell_space.max( Dim::I ) + halo_width );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ), 0 );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
-    }
 
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 1, -1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) - halo_width );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.min( Dim::J ) + halo_width );
+    }
     if ( -1 == local_grid->neighborRank( 0, 1 ) )
     {
-        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1 );
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.min( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -2996,6 +3262,17 @@ void notPeriodicTest2d()
                    owned_cell_space.max( Dim::J ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ),
                    owned_cell_space.max( Dim::J ) + halo_width );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) - halo_width );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
     }
 
     // Check the boundary spaces again but this time with a
@@ -3003,9 +3280,20 @@ void notPeriodicTest2d()
     if ( -1 == local_grid->neighborRank( -1, 0 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), -1, 0, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ), halo_width - 1 );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.min( Dim::I ) + 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ),
                    owned_cell_space.min( Dim::J ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ),
@@ -3015,18 +3303,30 @@ void notPeriodicTest2d()
     if ( -1 == local_grid->neighborRank( 1, -1 ) )
     {
         boundary_cell_space =
-            local_grid->boundaryIndexSpace( Cell(), 1, -1, 1 );
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 1, -1, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.max( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
                    owned_cell_space.max( Dim::I ) + 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::J ), halo_width - 1 );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 1, -1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.min( Dim::J ) + 1 );
     }
 
     if ( -1 == local_grid->neighborRank( 0, 1 ) )
     {
-        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1, 1 );
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Ghost{}, Cell(), 0, 1, 1 );
         EXPECT_EQ( boundary_cell_space.min( Dim::I ),
                    owned_cell_space.min( Dim::I ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::I ),
@@ -3035,6 +3335,17 @@ void notPeriodicTest2d()
                    owned_cell_space.max( Dim::J ) );
         EXPECT_EQ( boundary_cell_space.max( Dim::J ),
                    owned_cell_space.max( Dim::J ) + 1 );
+
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Own(), Cell(), 0, 1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
     }
 
     // Free the serial communicator we made

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -325,6 +325,17 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_cell_space.min( Dim::K ), halo_width - 1 );
     EXPECT_EQ( ghosted_shared_cell_space.max( Dim::K ), halo_width );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_cell_space =
+        local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
     //////////////////
     // NODE SPACES
     //////////////////
@@ -581,6 +592,17 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_node_space.max( Dim::K ),
                owned_node_space.min( Dim::K ) );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_node_space =
+        local_grid->boundaryIndexSpace( Node(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
     //////////////////
     // I-FACE SPACES
     //////////////////
@@ -818,6 +840,19 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_i_face_space.max( Dim::K ),
                owned_i_face_space.min( Dim::K ) );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
     //////////////////
     // J-FACE SPACES
     //////////////////
@@ -961,6 +996,19 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_j_face_space.min( Dim::K ), 0 );
     EXPECT_EQ( ghosted_shared_j_face_space.max( Dim::K ), halo_width );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
     //////////////////
     // K-FACE SPACES
     //////////////////
@@ -1103,6 +1151,19 @@ void periodicTest3d()
                owned_k_face_space.max( Dim::J ) + halo_width );
     EXPECT_EQ( ghosted_shared_k_face_space.min( Dim::K ), 0 );
     EXPECT_EQ( ghosted_shared_k_face_space.max( Dim::K ), halo_width );
+
+    // Check that the boundary spaces are empty.
+    auto boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Face<Dim::K>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
+
+    boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Face<Dim::K>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
+
+    boundary_face_k_space =
+        local_grid->boundaryIndexSpace( Face<Dim::K>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_face_k_space.size() );
 
     //////////////////
     // I-EDGE SPACES
@@ -1341,6 +1402,19 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_i_edge_space.max( Dim::K ),
                owned_i_edge_space.min( Dim::K ) );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::I>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
+    boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::I>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
+    boundary_edge_i_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::I>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_i_space.size() );
+
     //////////////////
     // J-EDGE SPACES
     //////////////////
@@ -1484,6 +1558,19 @@ void periodicTest3d()
     EXPECT_EQ( ghosted_shared_j_edge_space.min( Dim::K ), 0 );
     EXPECT_EQ( ghosted_shared_j_edge_space.max( Dim::K ), halo_width );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::J>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
+    boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::J>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
+    boundary_edge_j_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::J>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_j_space.size() );
+
     //////////////////
     // K-EDGE SPACES
     //////////////////
@@ -1626,6 +1713,19 @@ void periodicTest3d()
                owned_k_edge_space.max( Dim::J ) + halo_width + 1 );
     EXPECT_EQ( ghosted_shared_k_edge_space.min( Dim::K ), 0 );
     EXPECT_EQ( ghosted_shared_k_edge_space.max( Dim::K ), halo_width );
+
+    // Check that the boundary spaces are empty.
+    auto boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::K>(), -1, 0, 1 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
+
+    boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::K>(), 1, -1, 0 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
+
+    boundary_edge_k_space =
+        local_grid->boundaryIndexSpace( Edge<Dim::K>(), 0, 1, -1 );
+    EXPECT_EQ( 0, boundary_edge_k_space.size() );
 }
 
 //---------------------------------------------------------------------------//
@@ -1829,6 +1929,106 @@ void notPeriodicTest3d()
                     EXPECT_EQ( ghosted_shared_k_face_space.size(), 0 );
                 }
             }
+
+    // Check the boundary spaces.
+    IndexSpace<3> boundary_cell_space;
+    if ( -1 == local_grid->neighborRank( -1, 0, 1 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ), 0 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) + halo_width );
+    }
+
+    if ( -1 == local_grid->neighborRank( 1, -1, 0 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), 1, -1, 0 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) + halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ), 0 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
+    }
+
+    if ( -1 == local_grid->neighborRank( 0, 1, -1 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), 0, 1, -1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) + halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ), 0 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ), halo_width );
+    }
+
+    // Check the boundary spaces again but this time with a
+    // specified halo width.
+    if ( -1 == local_grid->neighborRank( -1, 0, 1 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ), halo_width - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) + 1 );
+    }
+
+    if ( -1 == local_grid->neighborRank( 1, -1, 0 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), 1, -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) + 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ), halo_width - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ),
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ),
+                   owned_cell_space.max( Dim::K ) );
+    }
+
+    if ( -1 == local_grid->neighborRank( 0, 1, -1 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), 0, 1, -1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) + 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::K ), halo_width - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::K ), halo_width );
+    }
 
     // Free the serial communicator we made
     MPI_Comm_free( &serial_comm );
@@ -2071,6 +2271,16 @@ void periodicTest2d()
     EXPECT_EQ( ghosted_shared_cell_space.max( Dim::J ),
                owned_cell_space.max( Dim::J ) + 1 );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), -1, 0 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
+    boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1 );
+    EXPECT_EQ( 0, boundary_cell_space.size() );
+
     //////////////////
     // NODE SPACES
     //////////////////
@@ -2267,6 +2477,16 @@ void periodicTest2d()
     EXPECT_EQ( ghosted_shared_node_space.max( Dim::J ),
                owned_node_space.max( Dim::J ) + 2 );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_node_space = local_grid->boundaryIndexSpace( Node(), -1, 0 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 1, -1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
+    boundary_node_space = local_grid->boundaryIndexSpace( Node(), 0, 1 );
+    EXPECT_EQ( 0, boundary_node_space.size() );
+
     //////////////////
     // I-FACE SPACES
     //////////////////
@@ -2447,6 +2667,19 @@ void periodicTest2d()
     EXPECT_EQ( ghosted_shared_i_face_space.max( Dim::J ),
                owned_i_face_space.max( Dim::J ) + 1 );
 
+    // Check that the boundary spaces are empty.
+    auto boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), -1, 0 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), 1, -1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
+    boundary_face_i_space =
+        local_grid->boundaryIndexSpace( Face<Dim::I>(), 0, 1 );
+    EXPECT_EQ( 0, boundary_face_i_space.size() );
+
     //////////////////
     // J-FACE SPACES
     //////////////////
@@ -2556,6 +2789,19 @@ void periodicTest2d()
                owned_j_face_space.max( Dim::J ) );
     EXPECT_EQ( ghosted_shared_j_face_space.max( Dim::J ),
                owned_j_face_space.max( Dim::J ) + halo_width + 1 );
+
+    // Check that the boundary spaces are empty.
+    auto boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), -1, 0 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), 1, -1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
+
+    boundary_face_j_space =
+        local_grid->boundaryIndexSpace( Face<Dim::J>(), 0, 1 );
+    EXPECT_EQ( 0, boundary_face_j_space.size() );
 }
 
 //---------------------------------------------------------------------------//
@@ -2714,6 +2960,82 @@ void notPeriodicTest2d()
                 EXPECT_EQ( ghosted_shared_j_face_space.size(), 0 );
             }
         }
+
+    // Check the boundary spaces.
+    IndexSpace<2> boundary_cell_space;
+    if ( -1 == local_grid->neighborRank( -1, 0 ) )
+    {
+        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), -1, 0 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ), 0 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+    }
+
+    if ( -1 == local_grid->neighborRank( 1, -1 ) )
+    {
+        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 1, -1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) + halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ), 0 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
+    }
+
+    if ( -1 == local_grid->neighborRank( 0, 1 ) )
+    {
+        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) + halo_width );
+    }
+
+    // Check the boundary spaces again but this time with a
+    // specified halo width.
+    if ( -1 == local_grid->neighborRank( -1, 0 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), -1, 0, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ), halo_width - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ), halo_width );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+    }
+
+    if ( -1 == local_grid->neighborRank( 1, -1 ) )
+    {
+        boundary_cell_space =
+            local_grid->boundaryIndexSpace( Cell(), 1, -1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) + 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ), halo_width - 1 );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ), halo_width );
+    }
+
+    if ( -1 == local_grid->neighborRank( 0, 1 ) )
+    {
+        boundary_cell_space = local_grid->boundaryIndexSpace( Cell(), 0, 1, 1 );
+        EXPECT_EQ( boundary_cell_space.min( Dim::I ),
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::I ),
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( boundary_cell_space.min( Dim::J ),
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( boundary_cell_space.max( Dim::J ),
+                   owned_cell_space.max( Dim::J ) + 1 );
+    }
 
     // Free the serial communicator we made
     MPI_Comm_free( &serial_comm );


### PR DESCRIPTION
Follow on to #374.

1. Adds `boundaryIndexSpace()` to the `LocalGrid` to allow for operations over indices in the boundary halo region for non-periodic boundaries.
2. Adds `inRange()` to the `IndexSpace` to check whether or not an index is within the range of the space. The will make implementing boundary conditions easier in some cases.