### PR TITLE
Fix Hypre tests for v2.20

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -257,7 +257,7 @@ jobs:
         uses: actions/checkout@v2.2.0
         with:
           repository: hypre-space/hypre
-          ref: v2.18.2
+          ref: v2.20.0
           path: hypre
       - name: Build hypre
         if: ${{ matrix.hypre == 'HYPRE' }}

--- a/cajita/src/Cajita_HypreStructuredSolver.hpp
+++ b/cajita/src/Cajita_HypreStructuredSolver.hpp
@@ -442,9 +442,12 @@ class HypreStructuredSolver
     {
         if ( error > 0 )
         {
+            char error_msg[256];
+            HYPRE_DescribeError( error, error_msg );
             std::stringstream out;
             out << "HYPRE structured solver error: ";
-            out << error;
+            out << error << " " << error_msg;
+            HYPRE_ClearError( error );
             throw std::runtime_error( out.str() );
         }
     }

--- a/cajita/unit_test/tstHypreStructuredSolver2d.hpp
+++ b/cajita/unit_test/tstHypreStructuredSolver2d.hpp
@@ -77,11 +77,11 @@ void poissonTest( const std::string& solver_type,
         "fill_matrix_entries",
         createExecutionPolicy( owned_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j ) {
-            entry_view( i, j, 0 ) = -4.0;
-            entry_view( i, j, 1 ) = 1.0;
-            entry_view( i, j, 2 ) = 1.0;
-            entry_view( i, j, 3 ) = 1.0;
-            entry_view( i, j, 4 ) = 1.0;
+            entry_view( i, j, 0 ) = 4.0;
+            entry_view( i, j, 1 ) = -1.0;
+            entry_view( i, j, 2 ) = -1.0;
+            entry_view( i, j, 3 ) = -1.0;
+            entry_view( i, j, 4 ) = -1.0;
         } );
 
     solver->setMatrixValues( *matrix_entries );
@@ -93,7 +93,7 @@ void poissonTest( const std::string& solver_type,
     solver->setMaxIter( 2000 );
 
     // Set the print level.
-    solver->setPrintLevel( 2 );
+    solver->setPrintLevel( 1 );
 
     // Create a preconditioner.
     if ( "none" != precond_type )
@@ -127,11 +127,11 @@ void poissonTest( const std::string& solver_type,
         KOKKOS_LAMBDA( const int i, const int j ) {
             int gi = i + global_space.min( Dim::I ) - owned_space.min( Dim::I );
             int gj = j + global_space.min( Dim::J ) - owned_space.min( Dim::J );
-            matrix_view( i, j, 0 ) = -4.0;
-            matrix_view( i, j, 1 ) = ( gi - 1 >= 0 ) ? 1.0 : 0.0;
-            matrix_view( i, j, 2 ) = ( gi + 1 < ncell_i ) ? 1.0 : 0.0;
-            matrix_view( i, j, 3 ) = ( gj - 1 >= 0 ) ? 1.0 : 0.0;
-            matrix_view( i, j, 4 ) = ( gj + 1 < ncell_j ) ? 1.0 : 0.0;
+            matrix_view( i, j, 0 ) = 4.0;
+            matrix_view( i, j, 1 ) = ( gi > 0 ) ? -1.0 : 0.0;
+            matrix_view( i, j, 2 ) = ( gi < ncell_i - 1 ) ? -1.0 : 0.0;
+            matrix_view( i, j, 3 ) = ( gj > 0 ) ? -1.0 : 0.0;
+            matrix_view( i, j, 4 ) = ( gj < ncell_j - 1 ) ? -1.0 : 0.0;
         } );
 
     std::vector<std::array<int, 2>> diag_stencil = { { 0, 0 } };
@@ -142,7 +142,7 @@ void poissonTest( const std::string& solver_type,
         "fill_preconditioner_entries",
         createExecutionPolicy( owned_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j ) {
-            preconditioner_view( i, j, 0 ) = -1.0 / 4.0;
+            preconditioner_view( i, j, 0 ) = 1.0 / 4.0;
         } );
 
     ref_solver->setTolerance( 1.0e-11 );

--- a/cajita/unit_test/tstHypreStructuredSolver3d.hpp
+++ b/cajita/unit_test/tstHypreStructuredSolver3d.hpp
@@ -78,13 +78,13 @@ void poissonTest( const std::string& solver_type,
         "fill_matrix_entries",
         createExecutionPolicy( owned_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
-            entry_view( i, j, k, 0 ) = -6.0;
-            entry_view( i, j, k, 1 ) = 1.0;
-            entry_view( i, j, k, 2 ) = 1.0;
-            entry_view( i, j, k, 3 ) = 1.0;
-            entry_view( i, j, k, 4 ) = 1.0;
-            entry_view( i, j, k, 5 ) = 1.0;
-            entry_view( i, j, k, 6 ) = 1.0;
+            entry_view( i, j, k, 0 ) = 6.0;
+            entry_view( i, j, k, 1 ) = -1.0;
+            entry_view( i, j, k, 2 ) = -1.0;
+            entry_view( i, j, k, 3 ) = -1.0;
+            entry_view( i, j, k, 4 ) = -1.0;
+            entry_view( i, j, k, 5 ) = -1.0;
+            entry_view( i, j, k, 6 ) = -1.0;
         } );
 
     solver->setMatrixValues( *matrix_entries );
@@ -132,13 +132,13 @@ void poissonTest( const std::string& solver_type,
             int gi = i + global_space.min( Dim::I ) - owned_space.min( Dim::I );
             int gj = j + global_space.min( Dim::J ) - owned_space.min( Dim::J );
             int gk = k + global_space.min( Dim::K ) - owned_space.min( Dim::K );
-            matrix_view( i, j, k, 0 ) = -6.0;
-            matrix_view( i, j, k, 1 ) = ( gi - 1 >= 0 ) ? 1.0 : 0.0;
-            matrix_view( i, j, k, 2 ) = ( gi + 1 < ncell_i ) ? 1.0 : 0.0;
-            matrix_view( i, j, k, 3 ) = ( gj - 1 >= 0 ) ? 1.0 : 0.0;
-            matrix_view( i, j, k, 4 ) = ( gj + 1 < ncell_j ) ? 1.0 : 0.0;
-            matrix_view( i, j, k, 5 ) = ( gk - 1 >= 0 ) ? 1.0 : 0.0;
-            matrix_view( i, j, k, 6 ) = ( gk + 1 < ncell_k ) ? 1.0 : 0.0;
+            matrix_view( i, j, k, 0 ) = 6.0;
+            matrix_view( i, j, k, 1 ) = ( gi - 1 >= 0 ) ? -1.0 : 0.0;
+            matrix_view( i, j, k, 2 ) = ( gi + 1 < ncell_i ) ? -1.0 : 0.0;
+            matrix_view( i, j, k, 3 ) = ( gj - 1 >= 0 ) ? -1.0 : 0.0;
+            matrix_view( i, j, k, 4 ) = ( gj + 1 < ncell_j ) ? -1.0 : 0.0;
+            matrix_view( i, j, k, 5 ) = ( gk - 1 >= 0 ) ? -1.0 : 0.0;
+            matrix_view( i, j, k, 6 ) = ( gk + 1 < ncell_k ) ? -1.0 : 0.0;
         } );
 
     std::vector<std::array<int, 3>> diag_stencil = { { 0, 0, 0 } };
@@ -149,7 +149,7 @@ void poissonTest( const std::string& solver_type,
         "fill_preconditioner_entries",
         createExecutionPolicy( owned_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
-            preconditioner_view( i, j, k, 0 ) = -1.0 / 6.0;
+            preconditioner_view( i, j, k, 0 ) = 1.0 / 6.0;
         } );
 
     ref_solver->setTolerance( 1.0e-11 );


### PR DESCRIPTION
Fixes a silly math error, improves Hypre error handling, and updates the GitHub CI to use Hypre version 2.20 (the latest). Closes #387 