### PR TITLE
Add doxygen namespace doc

### DIFF
--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -9,6 +9,10 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+/*!
+  \namespace Cajita
+  \brief Cajita: grid and particle-grid data structures and algorithms
+*/
 #ifndef CAJITA_HPP
 #define CAJITA_HPP
 

--- a/core/src/Cabana_Core.hpp
+++ b/core/src/Cabana_Core.hpp
@@ -9,6 +9,10 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+/*!
+  \namespace Cabana
+  \brief Core: particle data structures and algorithms
+*/
 #ifndef CABANA_CORE_HPP
 #define CABANA_CORE_HPP
 


### PR DESCRIPTION
Apparently doxygen doesn't include free function documentation without a namespace level comment