### PR TITLE
add missing namespace alias for Cajita

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -49,6 +49,7 @@ if(Cabana_ENABLE_HEFFTE)
 endif()
 
 add_library(Cajita INTERFACE)
+add_library(Cabana::Cajita ALIAS Cajita)
 
 target_link_libraries(Cajita INTERFACE
   Cabana::cabanacore


### PR DESCRIPTION
For uniformity between `add_subdirectory` and `find_package` Cajita also needs a namespace alias similar to https://github.com/ECP-copa/Cabana/blob/60c38ffbb361369530d48fe1fa9f9446483848d4/core/src/CMakeLists.txt#L89