### PR TITLE
Fix VerletList memory space

### DIFF
--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -117,12 +117,20 @@ void testVerletListFull()
             nlist_full( position, 0, position.size(), test_data.test_radius,
                         test_data.cell_size_ratio, test_data.grid_min,
                         test_data.grid_max );
+        // Test default construction.
         Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
                            BuildTag>
             nlist;
 
         nlist = nlist_full;
 
+        checkFullNeighborList( nlist, test_data.N2_list_copy,
+                               test_data.num_particle );
+
+        // Test rebuild function with explict execution space.
+        nlist.build( TEST_EXECSPACE{}, position, 0, position.size(),
+                     test_data.test_radius, test_data.cell_size_ratio,
+                     test_data.grid_min, test_data.grid_max );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }

--- a/example/core_tutorial/09_verlet_list/verlet_list_example.cpp
+++ b/example/core_tutorial/09_verlet_list/verlet_list_example.cpp
@@ -131,7 +131,7 @@ void verletListExample()
     double cell_ratio = 1.0;
     using ListAlgorithm = Cabana::FullNeighborTag;
     using ListType =
-        Cabana::VerletList<DeviceType, ListAlgorithm, Cabana::VerletLayoutCSR,
+        Cabana::VerletList<MemorySpace, ListAlgorithm, Cabana::VerletLayoutCSR,
                            Cabana::TeamOpTag>;
     ListType verlet_list( positions, 0, positions.size(), neighborhood_radius,
                           cell_ratio, grid_min, grid_max );


### PR DESCRIPTION
`VerletList` used `DeviceType` as a template parameter which was inconsistent with the `NeighborList` bridge pattern. 

This PR: 
- Simplifies the `VerletListData` (which does not need an `ExecutionSpace`)
- converts `VerletList` to use `MemorySpace`
- adds a `VerletList` `build` function which can use a separate (accessible) `ExecutionSpace` which defaults to the Kokkos `MemorySpace` default

Fixes #405 