### PR TITLE
Fix 398

### DIFF
--- a/core/unit_test/neighbor_unit_test.hpp
+++ b/core/unit_test/neighbor_unit_test.hpp
@@ -316,6 +316,10 @@ void checkFirstNeighborParallelFor( const ListType& nlist,
                                                     num_particle );
     Kokkos::View<int*, memory_space> team_result( "team_result", num_particle );
 
+    Kokkos::deep_copy( N2_result, 0.0 );
+    Kokkos::deep_copy( serial_result, 0.0 );
+    Kokkos::deep_copy( team_result, 0.0 );
+
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
     auto serial_count_op = KOKKOS_LAMBDA( const int i, const int n )
@@ -367,6 +371,10 @@ void checkSecondNeighborParallelFor( const ListType& nlist,
     Kokkos::View<int*, memory_space> team_result( "team_result", num_particle );
     Kokkos::View<int*, memory_space> vector_result( "vector_result",
                                                     num_particle );
+    Kokkos::deep_copy( N2_result, 0.0 );
+    Kokkos::deep_copy( serial_result, 0.0 );
+    Kokkos::deep_copy( team_result, 0.0 );
+    Kokkos::deep_copy( vector_result, 0.0 );
 
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle and compare to counts.
@@ -436,6 +444,10 @@ void checkSplitFirstNeighborParallelFor( const ListType& nlist,
     Kokkos::View<int*, memory_space> serial_result( "serial_result",
                                                     num_particle );
     Kokkos::View<int*, memory_space> team_result( "team_result", num_particle );
+
+    Kokkos::deep_copy( N2_result, 0.0 );
+    Kokkos::deep_copy( serial_result, 0.0 );
+    Kokkos::deep_copy( team_result, 0.0 );
 
     Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, num_particle );
     const auto range_begin = policy.begin();


### PR DESCRIPTION
Attempt to fix #398 by initializing views before sums. Not clear if this is the issue due to Kokkos initializing views to zero by default but given the randomness of the failures it would seem as though it was a memory or uninitialized memory error.

Closes #398 