### PR TITLE
Fix up CabanaConfig.cmake

### DIFF
--- a/cmake/CabanaConfig.cmakein
+++ b/cmake/CabanaConfig.cmakein
@@ -33,9 +33,9 @@ if(Cabana_ENABLE_HYPRE)
   # to ensure those targets are found for HYPRE:
   # https://github.com/hypre-space/hypre/pull/423
   enable_language( C )
-  find_dependency(HYPRE REQUIRED VERSION @HYPRE_VERSION@)
+  find_dependency(HYPRE @HYPRE_VERSION@ REQUIRED)
 endif()
 set(Cabana_ENABLE_HEFFTE @Cabana_ENABLE_HEFFTE@)
 if(Cabana_ENABLE_HEFFTE)
-  find_dependency(Heffte REQUIRED VERSION @Heffte_VERSION@)
+  find_dependency(Heffte @Heffte_VERSION@ REQUIRED)
 endif()


### PR DESCRIPTION
Fix up for #435 

just a syntax error.

We should really test the exported target in the CI again.