### PR TITLE
Preparation to include non equi block partitioning by liball.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 *~
+*.swp

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -160,7 +160,7 @@ class GlobalGrid
     //! \brief Set the owned number of cells in a given dimension of this block.
     //! \param dim Spatial dimension.
     //! \param num_cell New number of owned cells.
-    void setOwnedNumCell( const int dim, const int num_cell );
+    void setOwnedNumCell( const std::array<int, num_space_dim>& num_cell );
 
     //! \brief Get the global offset in a given dimension. This is where our
     //! block starts in the global indexing scheme.

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -183,6 +183,9 @@ class GlobalGrid
     std::array<int, num_space_dim> _global_cell_offset;
     std::array<bool, num_space_dim> _boundary_lo;
     std::array<bool, num_space_dim> _boundary_hi;
+
+    //! \brief Recompute global offset according to topology and _owned_num_cell
+    void computeGlobalOffset();
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -54,22 +54,6 @@ class GlobalGrid
                 const std::array<bool, num_space_dim>& periodic,
                 const BlockPartitioner<num_space_dim>& partitioner );
 
-    /*!
-     \brief Constructor.
-     \param comm The communicator over which to define the grid.
-     \param global_mesh The global mesh data.
-     \param periodic Whether each logical dimension is periodic.
-     \param partitioner The grid partitioner.
-     \param local_offset The offset of the local grid
-     \param local_num_cell The number of owned cells of the local grid
-    */
-    GlobalGrid( MPI_Comm comm,
-                const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
-                const std::array<bool, num_space_dim>& periodic,
-                const BlockPartitioner<num_space_dim>& partitioner,
-                const std::array<int, num_space_dim>& local_offset,
-                const std::array<int, num_space_dim>& local_num_cell );
-
     // Destructor.
     ~GlobalGrid();
 
@@ -220,28 +204,6 @@ createGlobalGrid( MPI_Comm comm,
 {
     return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
                                                    partitioner );
-}
-
-/*!
-  \brief Create a global grid.
-  \param comm The communicator over which to define the grid.
-  \param global_mesh The global mesh data.
-  \param periodic Whether each logical dimension is periodic.
-  \param partitioner The grid partitioner.
-  \param local_offset The offset of the local grid
-  \param local_num_cell The number of owned cells of the local grid
-*/
-template <class MeshType>
-std::shared_ptr<GlobalGrid<MeshType>> createGlobalGrid(
-    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
-    const std::array<bool, MeshType::num_space_dim>& periodic,
-    const BlockPartitioner<MeshType::num_space_dim>& partitioner,
-    const std::array<int, MeshType::num_space_dim>& local_offset,
-    const std::array<int, MeshType::num_space_dim>& local_num_cell )
-{
-    return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
-                                                   partitioner, local_offset,
-                                                   local_num_cell );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -59,7 +59,7 @@ class GlobalGrid
                 const std::array<bool, num_space_dim>& periodic,
                 const BlockPartitioner<num_space_dim>& partitioner,
                 const std::array<int, num_space_dim>& local_offset,
-                const std::array<int, num_space_dim>& local_num_cell);
+                const std::array<int, num_space_dim>& local_num_cell );
 
     // Destructor.
     ~GlobalGrid();
@@ -213,13 +213,12 @@ createGlobalGrid( MPI_Comm comm,
                                                    partitioner );
 }
 template <class MeshType>
-std::shared_ptr<GlobalGrid<MeshType>>
-createGlobalGrid( MPI_Comm comm,
-                  const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
-                  const std::array<bool, MeshType::num_space_dim>& periodic,
-                  const BlockPartitioner<MeshType::num_space_dim>& partitioner,
-                  const std::array<int, MeshType::num_space_dim>& local_offset,
-                  const std::array<int, MeshType::num_space_dim>& local_num_cell)
+std::shared_ptr<GlobalGrid<MeshType>> createGlobalGrid(
+    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+    const std::array<bool, MeshType::num_space_dim>& periodic,
+    const BlockPartitioner<MeshType::num_space_dim>& partitioner,
+    const std::array<int, MeshType::num_space_dim>& local_offset,
+    const std::array<int, MeshType::num_space_dim>& local_num_cell )
 {
     return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
                                                    partitioner, local_offset,

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -54,6 +54,13 @@ class GlobalGrid
                 const std::array<bool, num_space_dim>& periodic,
                 const BlockPartitioner<num_space_dim>& partitioner );
 
+    GlobalGrid( MPI_Comm comm,
+                const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+                const std::array<bool, num_space_dim>& periodic,
+                const BlockPartitioner<num_space_dim>& partitioner,
+                const std::array<int, num_space_dim>& local_offset,
+                const std::array<int, num_space_dim>& local_num_cell);
+
     // Destructor.
     ~GlobalGrid();
 
@@ -157,10 +164,21 @@ class GlobalGrid
     //! \param dim Spatial dimension.
     int ownedNumCell( const int dim ) const;
 
+    //! \brief Set the owned number of cells in a given dimension of this block.
+    //! \param dim Spatial dimension.
+    //! \param num_cell New number of owned cells.
+    void setOwnedNumCell( const int dim, const int num_cell );
+
     //! \brief Get the global offset in a given dimension. This is where our
     //! block starts in the global indexing scheme.
     //! \param dim Spatial dimension.
     int globalOffset( const int dim ) const;
+
+    //! \brief Set the global offset in a given dimension. This is where our
+    //! block start in the global indexing scheme.
+    //! \param dim Spatial dimension.
+    //! \param off New offset
+    void setGlobalOffset( const int dim, const int off );
 
   private:
     MPI_Comm _cart_comm;
@@ -193,6 +211,19 @@ createGlobalGrid( MPI_Comm comm,
 {
     return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
                                                    partitioner );
+}
+template <class MeshType>
+std::shared_ptr<GlobalGrid<MeshType>>
+createGlobalGrid( MPI_Comm comm,
+                  const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
+                  const std::array<bool, MeshType::num_space_dim>& periodic,
+                  const BlockPartitioner<MeshType::num_space_dim>& partitioner,
+                  const std::array<int, MeshType::num_space_dim>& local_offset,
+                  const std::array<int, MeshType::num_space_dim>& local_num_cell)
+{
+    return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
+                                                   partitioner, local_offset,
+                                                   local_num_cell );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -157,9 +157,8 @@ class GlobalGrid
     //! \param dim Spatial dimension.
     int ownedNumCell( const int dim ) const;
 
-    //! \brief Set the owned number of cells in a given dimension of this block.
-    //! \param dim Spatial dimension.
-    //! \param num_cell New number of owned cells.
+    //! \brief Set the owned number of cells for all dimensions of this block.
+    //! \param num_cell New number of owned cells for all dimensions.
     void setOwnedNumCell( const std::array<int, num_space_dim>& num_cell );
 
     //! \brief Get the global offset in a given dimension. This is where our

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -54,6 +54,15 @@ class GlobalGrid
                 const std::array<bool, num_space_dim>& periodic,
                 const BlockPartitioner<num_space_dim>& partitioner );
 
+    /*!
+     \brief Constructor.
+     \param comm The communicator over which to define the grid.
+     \param global_mesh The global mesh data.
+     \param periodic Whether each logical dimension is periodic.
+     \param partitioner The grid partitioner.
+     \param local_offset The offset of the local grid
+     \param local_num_cell The number of owned cells of the local grid
+    */
     GlobalGrid( MPI_Comm comm,
                 const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
                 const std::array<bool, num_space_dim>& periodic,
@@ -212,6 +221,16 @@ createGlobalGrid( MPI_Comm comm,
     return std::make_shared<GlobalGrid<MeshType>>( comm, global_mesh, periodic,
                                                    partitioner );
 }
+
+/*!
+  \brief Create a global grid.
+  \param comm The communicator over which to define the grid.
+  \param global_mesh The global mesh data.
+  \param periodic Whether each logical dimension is periodic.
+  \param partitioner The grid partitioner.
+  \param local_offset The offset of the local grid
+  \param local_num_cell The number of owned cells of the local grid
+*/
 template <class MeshType>
 std::shared_ptr<GlobalGrid<MeshType>> createGlobalGrid(
     MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,

--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -157,20 +157,17 @@ class GlobalGrid
     //! \param dim Spatial dimension.
     int ownedNumCell( const int dim ) const;
 
-    //! \brief Set the owned number of cells for all dimensions of this block.
-    //! \param num_cell New number of owned cells for all dimensions.
-    void setOwnedNumCell( const std::array<int, num_space_dim>& num_cell );
-
     //! \brief Get the global offset in a given dimension. This is where our
     //! block starts in the global indexing scheme.
     //! \param dim Spatial dimension.
     int globalOffset( const int dim ) const;
 
-    //! \brief Set the global offset in a given dimension. This is where our
-    //! block start in the global indexing scheme.
-    //! \param dim Spatial dimension.
-    //! \param off New offset
-    void setGlobalOffset( const int dim, const int off );
+    //! \brief Set number of cells and offset of local part of the grid. Make
+    //! sure these are consistent across all ranks.
+    //! \param num_cell New number of owned cells for all dimensions.
+    //! \param offset New global offset for all dimensions.
+    void setNumCellAndOffset( const std::array<int, num_space_dim>& num_cell,
+                              const std::array<int, num_space_dim>& offset );
 
   private:
     MPI_Comm _cart_comm;
@@ -182,9 +179,6 @@ class GlobalGrid
     std::array<int, num_space_dim> _global_cell_offset;
     std::array<bool, num_space_dim> _boundary_lo;
     std::array<bool, num_space_dim> _boundary_hi;
-
-    //! \brief Recompute global offset according to topology and _owned_num_cell
-    void computeGlobalOffset();
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -358,7 +358,6 @@ int GlobalGrid<MeshType>::ownedNumCell( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setOwnedNumCell( const int dim, const int num_cell )
 {
-    printf(">> %s dim: %d, num_cell: %d\n", __func__, dim, num_cell);
     _owned_num_cell[dim] = num_cell;
 }
 
@@ -377,7 +376,6 @@ int GlobalGrid<MeshType>::globalOffset( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setGlobalOffset( const int dim, const int off )
 {
-    printf(">> %s dim: %d, off: %d\n", __func__, dim, off);
     _global_cell_offset[dim] = off;
 }
 

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -313,9 +313,11 @@ int GlobalGrid<MeshType>::ownedNumCell( const int dim ) const
 //---------------------------------------------------------------------------//
 // Set the owned number of cells in a given dimension of this block.
 template <class MeshType>
-void GlobalGrid<MeshType>::setOwnedNumCell( const int dim, const int num_cell )
+void GlobalGrid<MeshType>::setOwnedNumCell(
+    const std::array<int, num_space_dim>& num_cell )
 {
-    _owned_num_cell[dim] = num_cell;
+    std::copy( std::begin( num_cell ), std::end( num_cell ),
+               std::begin( _owned_num_cell ) );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -88,49 +88,6 @@ GlobalGrid<MeshType>::GlobalGrid(
     }
 }
 
-template <class MeshType>
-GlobalGrid<MeshType>::GlobalGrid(
-    MPI_Comm comm, const std::shared_ptr<GlobalMesh<MeshType>>& global_mesh,
-    const std::array<bool, num_space_dim>& periodic,
-    const BlockPartitioner<num_space_dim>& partitioner,
-    const std::array<int, num_space_dim>& local_offset,
-    const std::array<int, num_space_dim>& local_num_cell )
-    : _global_mesh( global_mesh )
-    , _periodic( periodic )
-    , _owned_num_cell( local_num_cell )
-    , _global_cell_offset( local_offset )
-{
-    // Partition the problem.
-    std::array<int, num_space_dim> global_num_cell;
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-        global_num_cell[d] = _global_mesh->globalNumCell( d );
-    _ranks_per_dim = partitioner.ranksPerDimension( comm, global_num_cell );
-
-    // Extract the periodicity of the boundary as integers.
-    std::array<int, num_space_dim> periodic_dims;
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-        periodic_dims[d] = _periodic[d];
-
-    // Generate a communicator with a Cartesian topology.
-    int reorder_cart_ranks = 1;
-    MPI_Cart_create( comm, num_space_dim, _ranks_per_dim.data(),
-                     periodic_dims.data(), reorder_cart_ranks, &_cart_comm );
-
-    // Get the Cartesian topology index of this rank.
-    int linear_rank;
-    MPI_Comm_rank( _cart_comm, &linear_rank );
-    MPI_Cart_coords( _cart_comm, linear_rank, num_space_dim,
-                     _cart_rank.data() );
-
-    // todo(sschulz): Check if given local_offset and local_num_cell make sense
-
-    // Determine if a block is on the low or high boundaries.
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-    {
-        _boundary_lo[d] = ( 0 == _cart_rank[d] );
-        _boundary_hi[d] = ( _ranks_per_dim[d] - 1 == _cart_rank[d] );
-    }
-}
 //---------------------------------------------------------------------------//
 // Destructor.
 template <class MeshType>

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -315,7 +315,7 @@ int GlobalGrid<MeshType>::ownedNumCell( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setOwnedNumCell( const int dim, const int num_cell )
 {
-    _owned_num_cell[dim] = num_cell;
+    _owned_num_cell[dim] = num_cell + 1;
 }
 
 //---------------------------------------------------------------------------//
@@ -333,7 +333,7 @@ int GlobalGrid<MeshType>::globalOffset( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setGlobalOffset( const int dim, const int off )
 {
-    _global_cell_offset[dim] = off;
+    _global_cell_offset[dim] = off + 1;
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -358,6 +358,7 @@ int GlobalGrid<MeshType>::ownedNumCell( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setOwnedNumCell( const int dim, const int num_cell )
 {
+    printf(">> %s dim: %d, num_cell: %d\n", __func__, dim, num_cell);
     _owned_num_cell[dim] = num_cell;
 }
 
@@ -376,6 +377,7 @@ int GlobalGrid<MeshType>::globalOffset( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setGlobalOffset( const int dim, const int off )
 {
+    printf(">> %s dim: %d, off: %d\n", __func__, dim, off);
     _global_cell_offset[dim] = off;
 }
 

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -318,6 +318,7 @@ void GlobalGrid<MeshType>::setOwnedNumCell(
 {
     std::copy( std::begin( num_cell ), std::end( num_cell ),
                std::begin( _owned_num_cell ) );
+    computeGlobalOffset();
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -94,7 +94,7 @@ GlobalGrid<MeshType>::GlobalGrid(
     const std::array<bool, num_space_dim>& periodic,
     const BlockPartitioner<num_space_dim>& partitioner,
     const std::array<int, num_space_dim>& local_offset,
-    const std::array<int, num_space_dim>& local_num_cell)
+    const std::array<int, num_space_dim>& local_num_cell )
     : _global_mesh( global_mesh )
     , _periodic( periodic )
     , _owned_num_cell( local_num_cell )
@@ -378,8 +378,6 @@ void GlobalGrid<MeshType>::setGlobalOffset( const int dim, const int off )
 {
     _global_cell_offset[dim] = off;
 }
-
-
 
 //---------------------------------------------------------------------------//
 } // end namespace Cajita

--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -315,7 +315,7 @@ int GlobalGrid<MeshType>::ownedNumCell( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setOwnedNumCell( const int dim, const int num_cell )
 {
-    _owned_num_cell[dim] = num_cell + 1;
+    _owned_num_cell[dim] = num_cell;
 }
 
 //---------------------------------------------------------------------------//
@@ -333,7 +333,7 @@ int GlobalGrid<MeshType>::globalOffset( const int dim ) const
 template <class MeshType>
 void GlobalGrid<MeshType>::setGlobalOffset( const int dim, const int off )
 {
-    _global_cell_offset[dim] = off + 1;
+    _global_cell_offset[dim] = off;
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -53,7 +53,7 @@ class LocalGrid
                const int halo_cell_width );
 
     //! \brief Get the global grid that owns the local grid.
-    const GlobalGrid<MeshType>& globalGrid() const;
+    const GlobalGrid<MeshType>& globalGrid();
 
     //! \brief Get the number of cells in the halo.
     int haloCellWidth() const;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -53,7 +53,10 @@ class LocalGrid
                const int halo_cell_width );
 
     //! \brief Get the global grid that owns the local grid.
-    const GlobalGrid<MeshType>& globalGrid();
+    const GlobalGrid<MeshType>& globalGrid() const;
+
+    //! \brief Get a mutable version of the global grid that own the local grid
+    GlobalGrid<MeshType>& mutGlobalGrid() const;
 
     //! \brief Get the number of cells in the halo.
     int haloCellWidth() const;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -56,7 +56,7 @@ class LocalGrid
     const GlobalGrid<MeshType>& globalGrid() const;
 
     //! \brief Get a mutable version of the global grid that own the local grid
-    const GlobalGrid<MeshType>& mutGlobalGrid() const;
+    GlobalGrid<MeshType>& mutGlobalGrid();
 
     //! \brief Get the number of cells in the halo.
     int haloCellWidth() const;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -56,7 +56,7 @@ class LocalGrid
     const GlobalGrid<MeshType>& globalGrid() const;
 
     //! \brief Get a mutable version of the global grid that own the local grid
-    GlobalGrid<MeshType>& mutGlobalGrid() const;
+    const GlobalGrid<MeshType>& mutGlobalGrid() const;
 
     //! \brief Get the number of cells in the halo.
     int haloCellWidth() const;

--- a/cajita/src/Cajita_LocalGrid.hpp
+++ b/cajita/src/Cajita_LocalGrid.hpp
@@ -56,7 +56,7 @@ class LocalGrid
     const GlobalGrid<MeshType>& globalGrid() const;
 
     //! \brief Get a mutable version of the global grid that own the local grid
-    GlobalGrid<MeshType>& mutGlobalGrid();
+    GlobalGrid<MeshType>& globalGrid();
 
     //! \brief Get the number of cells in the halo.
     int haloCellWidth() const;

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -28,7 +28,7 @@ LocalGrid<MeshType>::LocalGrid(
 //---------------------------------------------------------------------------//
 // Get the global grid that owns the local grid.
 template <class MeshType>
-const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
+const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid()
 {
     return *_global_grid;
 }

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -36,7 +36,7 @@ const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
 //---------------------------------------------------------------------------//
 // Get a mutable version of the global grid that own the local grid.
 template <class MeshType>
-GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid()
+GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid()
 {
     return *_global_grid;
 }

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -36,7 +36,7 @@ const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
 //---------------------------------------------------------------------------//
 // Get a mutable version of the global grid that own the local grid.
 template <class MeshType>
-GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid() const
+const GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid() const
 {
     return *_global_grid;
 }

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -28,7 +28,15 @@ LocalGrid<MeshType>::LocalGrid(
 //---------------------------------------------------------------------------//
 // Get the global grid that owns the local grid.
 template <class MeshType>
-const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid()
+const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
+{
+    return *_global_grid;
+}
+
+//---------------------------------------------------------------------------//
+// Get a mutable version of the global grid that own the local grid.
+template <class MeshType>
+GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid() const
 {
     return *_global_grid;
 }

--- a/cajita/src/Cajita_LocalGrid_impl.hpp
+++ b/cajita/src/Cajita_LocalGrid_impl.hpp
@@ -36,7 +36,7 @@ const GlobalGrid<MeshType>& LocalGrid<MeshType>::globalGrid() const
 //---------------------------------------------------------------------------//
 // Get a mutable version of the global grid that own the local grid.
 template <class MeshType>
-const GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid() const
+GlobalGrid<MeshType>& LocalGrid<MeshType>::mutGlobalGrid()
 {
     return *_global_grid;
 }

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -368,17 +368,17 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
             -1 );
 
     // Check setting of _owned_num_cell
-    for(std::size_t i=0; i<2; ++i)
+    for ( std::size_t i = 0; i < 2; ++i )
     {
-        global_grid->setOwnedNumCell(i, 314);
-        EXPECT_EQ( global_grid->ownedNumCell(i), 314 );
+        global_grid->setOwnedNumCell( i, 314 );
+        EXPECT_EQ( global_grid->ownedNumCell( i ), 314 );
     }
 
     // Check setting of _globa_cell_offset
-    for(std::size_t i=0; i<2; ++i)
+    for ( std::size_t i = 0; i < 2; ++i )
     {
-        global_grid->setGlobalOffset(i, 314);
-        EXPECT_EQ( global_grid->globalOffset(i), 314);
+        global_grid->setGlobalOffset( i, 314 );
+        EXPECT_EQ( global_grid->globalOffset( i ), 314 );
     }
 }
 

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -235,6 +235,20 @@ void gridTest3d( const std::array<bool, 3>& is_dim_periodic )
         EXPECT_EQ(
             global_grid->blockRank( 0, 0, global_grid->dimNumBlock( Dim::K ) ),
             -1 );
+
+    // Check setting of _owned_num_cell
+    for ( std::size_t i = 0; i < 3; ++i )
+    {
+        global_grid->setOwnedNumCell( i, 314 );
+        EXPECT_EQ( global_grid->ownedNumCell( i ), 314 );
+    }
+
+    // Check setting of _globa_cell_offset
+    for ( std::size_t i = 0; i < 3; ++i )
+    {
+        global_grid->setGlobalOffset( i, 314 );
+        EXPECT_EQ( global_grid->globalOffset( i ), 314 );
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -237,13 +237,14 @@ void gridTest3d( const std::array<bool, 3>& is_dim_periodic )
             -1 );
 
     // Check setting of _owned_num_cell
+    std::array<int, 3> num_cell = { 314, 314, 314 };
+    global_grid->setOwnedNumCell( num_cell );
     for ( std::size_t i = 0; i < 3; ++i )
     {
-        global_grid->setOwnedNumCell( i, 314 );
-        EXPECT_EQ( global_grid->ownedNumCell( i ), 314 );
+        EXPECT_EQ( global_grid->ownedNumCell( i ), num_cell[i] );
     }
 
-    // Check setting of _globa_cell_offset
+    // Check setting of _global_cell_offset
     for ( std::size_t i = 0; i < 3; ++i )
     {
         global_grid->setGlobalOffset( i, 314 );
@@ -381,11 +382,11 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
             global_grid->blockRank( 0, global_grid->dimNumBlock( Dim::J ) ),
             -1 );
 
-    // Check setting of _owned_num_cell
+    std::array<int, 2> num_cell = { 314, 314 };
+    global_grid->setOwnedNumCell( num_cell );
     for ( std::size_t i = 0; i < 2; ++i )
     {
-        global_grid->setOwnedNumCell( i, 314 );
-        EXPECT_EQ( global_grid->ownedNumCell( i ), 314 );
+        EXPECT_EQ( global_grid->ownedNumCell( i ), num_cell[i] );
     }
 
     // Check setting of _globa_cell_offset

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -366,6 +366,20 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
         EXPECT_EQ(
             global_grid->blockRank( 0, global_grid->dimNumBlock( Dim::J ) ),
             -1 );
+
+    // Check setting of _owned_num_cell
+    for(std::size_t i=0; i<2; ++i)
+    {
+        global_grid->setOwnedNumCell(i, 314);
+        EXPECT_EQ( global_grid->ownedNumCell(i), 314 );
+    }
+
+    // Check setting of _globa_cell_offset
+    for(std::size_t i=0; i<2; ++i)
+    {
+        global_grid->setGlobalOffset(i, 314);
+        EXPECT_EQ( global_grid->globalOffset(i), 314);
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -236,19 +236,15 @@ void gridTest3d( const std::array<bool, 3>& is_dim_periodic )
             global_grid->blockRank( 0, 0, global_grid->dimNumBlock( Dim::K ) ),
             -1 );
 
-    // Check setting of _owned_num_cell
+    // Check setNumCellAndOffset
+    // todo(sschulz): Need to have a more realistic change, since there might
+    // be some checking involved within the function.
     std::array<int, 3> num_cell = { 314, 314, 314 };
-    global_grid->setOwnedNumCell( num_cell );
+    global_grid->setNumCellAndOffset( num_cell, num_cell );
     for ( std::size_t i = 0; i < 3; ++i )
     {
         EXPECT_EQ( global_grid->ownedNumCell( i ), num_cell[i] );
-    }
-
-    // Check setting of _global_cell_offset
-    for ( std::size_t i = 0; i < 3; ++i )
-    {
-        global_grid->setGlobalOffset( i, 314 );
-        EXPECT_EQ( global_grid->globalOffset( i ), 314 );
+        EXPECT_EQ( global_grid->globalOffset( i ), num_cell[i] );
     }
 }
 
@@ -382,18 +378,15 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
             global_grid->blockRank( 0, global_grid->dimNumBlock( Dim::J ) ),
             -1 );
 
+    // Check setNumCellAndOffset
+    // todo(sschulz): Need to have a more realistic change, since there might
+    // be some checking involved within the function.
     std::array<int, 2> num_cell = { 314, 314 };
-    global_grid->setOwnedNumCell( num_cell );
+    global_grid->setNumCellAndOffset( num_cell, num_cell );
     for ( std::size_t i = 0; i < 2; ++i )
     {
         EXPECT_EQ( global_grid->ownedNumCell( i ), num_cell[i] );
-    }
-
-    // Check setting of _globa_cell_offset
-    for ( std::size_t i = 0; i < 2; ++i )
-    {
-        global_grid->setGlobalOffset( i, 314 );
-        EXPECT_EQ( global_grid->globalOffset( i ), 314 );
+        EXPECT_EQ( global_grid->globalOffset( i ), num_cell[i] );
     }
 }
 

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3380,7 +3380,8 @@ void mutabilityTest()
     // Test mutability of mutGlobalGrid
     Cajita::GlobalGrid<Cajita::UniformMesh<double, 3>>& mutGlobalGrid =
         local_grid->globalGrid();
-    mutGlobalGrid.setGlobalOffset( 0, 0 );
+    std::array<int, 3> num_cell = { 0, 0, 0 };
+    mutGlobalGrid.setNumCellAndOffset( num_cell, num_cell );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3352,6 +3352,36 @@ void notPeriodicTest2d()
     MPI_Comm_free( &serial_comm );
 }
 
+void mutabilityTest()
+{
+    // Let MPI compute the partitioning for this test.
+    UniformDimPartitioner partitioner;
+
+    // Create the global mesh.
+    double cell_size = 0.23;
+    std::array<int, 3> global_num_cell = { 47, 38, 53 };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createUniformGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Create the global grid.
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Create a local grid.
+    int halo_width = 2;
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+
+    // Test mutability of mutGlobalGrid
+    auto mutGlobalGrid = local_grid->mutGlobalGrid();
+    mutGlobalGrid.setGlobalOffset(0, 0);
+}
+
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
@@ -3365,6 +3395,11 @@ TEST( local_grid, 2d_api_test )
 {
     periodicTest2d();
     notPeriodicTest2d();
+}
+
+TEST( local_grid, mutability_test )
+{
+    mutabilityTest();
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3378,7 +3378,8 @@ void mutabilityTest()
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Test mutability of mutGlobalGrid
-    Cajita::GlobalGrid<Cajita::UniformMesh<double, 3>>& mutGlobalGrid = local_grid->mutGlobalGrid();
+    Cajita::GlobalGrid<Cajita::UniformMesh<double, 3>>& mutGlobalGrid =
+        local_grid->mutGlobalGrid();
     mutGlobalGrid.setGlobalOffset( 0, 0 );
 }
 

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3379,7 +3379,7 @@ void mutabilityTest()
 
     // Test mutability of mutGlobalGrid
     auto mutGlobalGrid = local_grid->mutGlobalGrid();
-    mutGlobalGrid.setGlobalOffset(0, 0);
+    mutGlobalGrid.setGlobalOffset( 0, 0 );
 }
 
 //---------------------------------------------------------------------------//
@@ -3397,10 +3397,7 @@ TEST( local_grid, 2d_api_test )
     notPeriodicTest2d();
 }
 
-TEST( local_grid, mutability_test )
-{
-    mutabilityTest();
-}
+TEST( local_grid, mutability_test ) { mutabilityTest(); }
 
 //---------------------------------------------------------------------------//
 

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3378,7 +3378,7 @@ void mutabilityTest()
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Test mutability of mutGlobalGrid
-    auto mutGlobalGrid = local_grid->mutGlobalGrid();
+    Cajita::GlobalGrid<Cajita::UniformMesh<double, 3>>& mutGlobalGrid = local_grid->mutGlobalGrid();
     mutGlobalGrid.setGlobalOffset( 0, 0 );
 }
 

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -3379,7 +3379,7 @@ void mutabilityTest()
 
     // Test mutability of mutGlobalGrid
     Cajita::GlobalGrid<Cajita::UniformMesh<double, 3>>& mutGlobalGrid =
-        local_grid->mutGlobalGrid();
+        local_grid->globalGrid();
     mutGlobalGrid.setGlobalOffset( 0, 0 );
 }
 


### PR DESCRIPTION
Very rough changes for now that are required by the corresponding `all_lb` branch of ExaMPM.

At the moment it allows one to get a mutable version of the global grid from the local grid. The global grid also allows to change the global cell offset and number of owned cells. Basically allowing to change the position and extent of the local grid.


(This also needs clean up, since not all changes are required and still remnants of tests)