### PR TITLE
Update Jenkins SYCL tests

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -109,6 +109,9 @@ pipeline {
                               -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
                               -D CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Wno-unknown-cuda-version -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice" \
                               -D CMAKE_PREFIX_PATH="$KOKKOS_DIR" \
+                              -D MPIEXEC_MAX_NUMPROCS=1 \
+                              -D MPIEXEC_PREFLAGS="--allow-run-as-root" \
+                              -D Cabana_REQUIRE_MPI=ON \
                               -D Cabana_REQUIRE_SYCL=ON \
                               -D Cabana_ENABLE_TESTING=ON \
                               -D Cabana_ENABLE_EXAMPLES=ON \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -57,8 +57,8 @@ RUN SYCL_VERSION=20210311 && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${SYCL_DIR}/bin:$PATH
 
-# Install Kokkos (this commit is develop branch March 2021)
-ARG KOKKOS_VERSION=e31f52e54dc20c775cad7ea197f14c12cbe9b582
+# Install Kokkos
+ARG KOKKOS_VERSION=3.4.01
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_CXX_STANDARD=17"
 ENV KOKKOS_DIR=/opt/kokkos
 RUN KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \

--- a/docker/Dockerfile.sycl
+++ b/docker/Dockerfile.sycl
@@ -57,6 +57,25 @@ RUN SYCL_VERSION=20210311 && \
     rm -rf ${SCRATCH_DIR}
 ENV PATH=${SYCL_DIR}/bin:$PATH
 
+# Install CUDA-aware Open MPI
+ENV OPENMPI_DIR=/opt/openmpi
+RUN OPENMPI_VERSION=4.0.2 && \
+    OPENMPI_VERSION_SHORT=4.0 && \
+    OPENMPI_SHA1=32ce3761288575fb8e4f6296c9105c3a25cf3235 && \
+    OPENMPI_URL=https://download.open-mpi.org/release/open-mpi/v${OPENMPI_VERSION_SHORT}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    OPENMPI_ARCHIVE=openmpi-${OPENMPI_VERSION}.tar.bz2 && \
+    [ ! -z "${CUDA_VERSION}" ] && CUDA_OPTIONS=--with-cuda || true && \
+    SCRATCH_DIR=/scratch && mkdir -p ${SCRATCH_DIR} && cd ${SCRATCH_DIR} && \
+    wget --quiet ${OPENMPI_URL} --output-document=${OPENMPI_ARCHIVE} && \
+    echo "${OPENMPI_SHA1} ${OPENMPI_ARCHIVE}" | sha1sum -c && \
+    mkdir -p openmpi && \
+    tar -xf ${OPENMPI_ARCHIVE} -C openmpi --strip-components=1 && \
+    mkdir -p build && cd build && \
+    ../openmpi/configure --prefix=${OPENMPI_DIR} ${CUDA_OPTIONS} CFLAGS=-w && \
+    make -j${NPROCS} install && \
+    rm -rf ${SCRATCH_DIR}
+ENV PATH=${OPENMPI_DIR}/bin:$PATH
+
 # Install Kokkos
 ARG KOKKOS_VERSION=3.4.01
 ARG KOKKOS_OPTIONS="-DKokkos_ENABLE_SYCL=ON -DCMAKE_CXX_FLAGS=-Wno-unknown-cuda-version -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON -DKokkos_ARCH_VOLTA70=ON -DCMAKE_CXX_STANDARD=17"


### PR DESCRIPTION
- Update SYCL test to Kokkos 3.4 (previously develop branch)
- Add core MPI tests with SYCL
- Some SYCL Cajita tests still failing when running on NVIDIA GPU

Part of #332 