### PR TITLE
Update to heFFTe 2.1 and enable MKL

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -68,6 +68,15 @@ jobs:
             heffte: 'NoheFFTe'
             hypre: 'NoHYPRE'
             coverage: 'OFF'
+          - distro: 'fedora:intel'
+            cxx: 'icpc'
+            openmp: 'OFF'
+            cmake_build_type: 'Debug'
+            kokkos_ver: 'master'
+            arborx: 'NoArborX'
+            heffte: 'heFFTe_MKL'
+            hypre: 'NoHYPRE'
+            coverage: 'OFF'
           - distro: 'fedora:latest'
             cxx: 'g++'
             openmp: 'ON'
@@ -235,7 +244,7 @@ jobs:
         if: ${{ matrix.heffte != 'NoheFFTe' }}
         # actions/checkout doesn't work for external repos yet
         run: |
-          git clone --depth 1 --branch v2.0.0 https://bitbucket.org/icl/heffte.git heffte
+          git clone --depth 1 --branch v2.1.0 https://bitbucket.org/icl/heffte.git heffte
       - name: Build heffte
         if: ${{ matrix.heffte != 'NoheFFTe' }}
         working-directory: heffte
@@ -245,11 +254,12 @@ jobs:
           cmake -B build \
             -DCMAKE_CXX_STANDARD="11" \
             -DBUILD_SHARED_LIBS=ON \
-            -DMKL_ROOT=/opt/intel/mkl \
             -DCMAKE_INSTALL_PREFIX=$HOME/heffte \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+            -DMKL_ROOT=/opt/intel/oneapi/mkl/latest \
+            -DHeffte_MKL_IOMP5=/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libiomp5.so \
             ${heffte_cmake_opts}
           cmake --build build --parallel 2
           cmake --install build

--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -251,6 +251,7 @@ jobs:
         run: |
           [[ ${{ matrix.heffte }} == "heFFTe_FFTW" ]] && heffte_cmake_opts+=( -DHeffte_ENABLE_FFTW=ON )
           [[ ${{ matrix.heffte }} == "heFFTe_MKL" ]] && heffte_cmake_opts+=( -DHeffte_ENABLE_MKL=ON )
+          # FIXME: Remove MKL path below when we update heFFTe
           cmake -B build \
             -DCMAKE_CXX_STANDARD="11" \
             -DBUILD_SHARED_LIBS=ON \

--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   CI:
     # FIXME: remove failing distributions here when passing
-    continue-on-error: ${{ matrix.kokkos_ver == 'develop' || matrix.distro == 'fedora:intel' }}
+    continue-on-error: ${{ matrix.kokkos_ver == 'develop' || (matrix.distro == 'fedora:intel' && matrix.openmp == 'OFF' && matrix.cmake_build_type == 'Release') }}
     defaults:
       run:
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ find_package( CLANG_FORMAT 10 )
 Cabana_add_dependency( PACKAGE HYPRE VERSION 2.22.0 )
 
 # find heffte
-Cabana_add_dependency( PACKAGE Heffte VERSION 2.0.0 )
+Cabana_add_dependency( PACKAGE Heffte VERSION 2.1.0 )
 
 #------------------------------------------------------------------------------#
 # Architecture

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -364,6 +364,7 @@ struct HeffteBackendTraits<Kokkos::Cuda, Impl::FFTBackendDefault>
 };
 #endif
 #endif
+#ifdef Heffte_ENABLE_ROCM
 #ifdef KOKKOS_ENABLE_HIP
 template <>
 struct HeffteBackendTraits<Kokkos::Experimental::HIP, Impl::FFTBackendDefault>
@@ -371,7 +372,7 @@ struct HeffteBackendTraits<Kokkos::Experimental::HIP, Impl::FFTBackendDefault>
     using backend_type = heffte::backend::rocfft;
 };
 #endif
-
+#endif
 template <class ScaleType>
 struct HeffteScalingTraits
 {

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -354,6 +354,13 @@ struct HeffteBackendTraits<ExecutionSpace, FFTBackendMKL>
 {
     using backend_type = heffte::backend::mkl;
 };
+#ifndef Heffte_ENABLE_FFTW
+template <class ExecutionSpace>
+struct HeffteBackendTraits<ExecutionSpace, Impl::FFTBackendDefault>
+{
+    using backend_type = heffte::backend::mkl;
+};
+#endif
 #endif
 #ifdef Heffte_ENABLE_CUDA
 #ifdef KOKKOS_ENABLE_CUDA

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -440,8 +440,8 @@ class HeffteFastFourierTransform
                                          DeviceType, BackendType>>( layout )
     {
         // heFFTe correctly handles 2D or 3D domains within "box3d"
-        heffte::box3d inbox = { this->global_low, this->global_high };
-        heffte::box3d outbox = { this->global_low, this->global_high };
+        heffte::box3d<> inbox = { this->global_low, this->global_high };
+        heffte::box3d<> outbox = { this->global_low, this->global_high };
 
         heffte::plan_options heffte_params =
             heffte::default_options<heffte_backend_type>();

--- a/cajita/unit_test/tstFastFourierTransform.hpp
+++ b/cajita/unit_test/tstFastFourierTransform.hpp
@@ -232,8 +232,8 @@ void forwardReverseTest2d( bool use_default, bool use_params )
 TEST( fast_fourier_transform, forward_reverse_3d_test )
 {
     // Dummy template argument.
-    forwardReverseTest3d<Experimental::FFTBackendFFTW>( true, true );
-    forwardReverseTest3d<Experimental::FFTBackendFFTW>( true, false );
+    forwardReverseTest3d<Experimental::Impl::FFTBackendDefault>( true, true );
+    forwardReverseTest3d<Experimental::Impl::FFTBackendDefault>( true, false );
 
 #ifdef Heffte_ENABLE_FFTW
     forwardReverseTest3d<Experimental::FFTBackendFFTW>( false, true );
@@ -248,8 +248,8 @@ TEST( fast_fourier_transform, forward_reverse_3d_test )
 TEST( fast_fourier_transform, forward_reverse_2d_test )
 {
     // Dummy template argument.
-    forwardReverseTest2d<Experimental::FFTBackendFFTW>( true, true );
-    forwardReverseTest2d<Experimental::FFTBackendFFTW>( true, false );
+    forwardReverseTest2d<Experimental::Impl::FFTBackendDefault>( true, true );
+    forwardReverseTest2d<Experimental::Impl::FFTBackendDefault>( true, false );
 
 #ifdef Heffte_ENABLE_FFTW
     forwardReverseTest2d<Experimental::FFTBackendFFTW>( false, true );

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,7 +124,7 @@ RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
     rm -rf ${SCRATCH_DIR}
 
 # Install heffte
-ARG HEFFTE_VERSION=2.0.0
+ARG HEFFTE_VERSION=2.1.0
 ENV HEFFTE_DIR=/opt/heffte
 RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
     HEFFTE_ARCHIVE=heffte.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -132,7 +132,7 @@ RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
     rm -rf ${SCRATCH_DIR}
 
 # Install heffte
-ARG HEFFTE_VERSION=2.0.0
+ARG HEFFTE_VERSION=2.1.0
 ENV HEFFTE_DIR=/opt/heffte
 RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
     HEFFTE_ARCHIVE=heffte.tar.gz && \


### PR DESCRIPTION
This adds FFT testing on the CPU for MKL and fixes cases with multiple host FFT backends

Previously added OneAPI/SYCL build, but will be moved to a separate PR (done on the host: it may be possible using Cuda SYCL, but probably not straightforward)