### PR TITLE
CI: allow rawhide to fail

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   CI:
     # FIXME: remove failing distributions here when passing
-    continue-on-error: ${{ matrix.kokkos_ver == 'develop' || (matrix.distro == 'fedora:intel' && matrix.openmp == 'OFF' && matrix.cmake_build_type == 'Release') }}
+    continue-on-error: ${{ matrix.kokkos_ver == 'develop' || matrix.distro == 'fedora:rawhide' || (matrix.distro == 'fedora:intel' && matrix.openmp == 'OFF' && matrix.cmake_build_type == 'Release') }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Due to https://github.com/kokkos/ci-containers/issues/19 CI on rawhide is currently broken, so allow it to fail.