### PR TITLE
Verify valid ranges for neighbor lists

### DIFF
--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -276,6 +276,8 @@ auto makeNeighborList( Tag, Slice const& coordinate_slice,
                        typename Slice::value_type radius, int buffer_size = 0 )
 {
     assert( buffer_size >= 0 );
+    assert( last >= first );
+    assert( last <= coordinate_slice.size() );
 
     using MemorySpace = typename DeviceType::memory_space;
     using ExecutionSpace = typename DeviceType::execution_space;
@@ -340,6 +342,8 @@ auto make2DNeighborList( Tag, Slice const& coordinate_slice,
                          int buffer_size = 0 )
 {
     assert( buffer_size >= 0 );
+    assert( last >= first );
+    assert( last <= coordinate_slice.size() );
 
     using MemorySpace = typename DeviceType::memory_space;
     using ExecutionSpace = typename DeviceType::execution_space;

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -23,6 +23,8 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_ScatterView.hpp>
 
+#include <cassert>
+
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
@@ -232,6 +234,9 @@ class LinkedCellList
     void build( SliceType positions, const std::size_t begin,
                 const std::size_t end )
     {
+        assert( end >= begin );
+        assert( end <= positions.size() );
+
         // Resize the binning data. Note that the permutation vector spans
         // only the length of begin-end;
         std::size_t ncell = totalBins();

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -23,6 +23,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <cassert>
+
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
@@ -741,6 +743,9 @@ class VerletList
                 const std::size_t max_neigh = 0 )
     {
         static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
+        assert( end >= begin );
+        assert( end <= x.size() );
 
         using device_type = Kokkos::Device<ExecutionSpace, memory_space>;
 


### PR DESCRIPTION
Give clear error for particle ranges that are invalid. Would have flagged bad test fixed in #449 