### PR TITLE
Update GlobalGrid and Partitioner

### DIFF
--- a/cajita/src/Cajita_GlobalGrid_impl.hpp
+++ b/cajita/src/Cajita_GlobalGrid_impl.hpp
@@ -51,34 +51,8 @@ GlobalGrid<MeshType>::GlobalGrid(
                      _cart_rank.data() );
 
     // Get the cells per dimension and the remainder.
-    std::array<int, num_space_dim> cells_per_dim;
-    std::array<int, num_space_dim> dim_remainder;
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-    {
-        cells_per_dim[d] = global_num_cell[d] / _ranks_per_dim[d];
-        dim_remainder[d] = global_num_cell[d] % _ranks_per_dim[d];
-    }
-
-    // Compute the global cell offset and the local low corner on this rank by
-    // computing the starting global cell index via exclusive scan.
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-    {
-        _global_cell_offset[d] = 0;
-        for ( int r = 0; r < _cart_rank[d]; ++r )
-        {
-            _global_cell_offset[d] += cells_per_dim[d];
-            if ( dim_remainder[d] > r )
-                ++_global_cell_offset[d];
-        }
-    }
-
-    // Compute the number of local cells in this rank in each dimension.
-    for ( std::size_t d = 0; d < num_space_dim; ++d )
-    {
-        _owned_num_cell[d] = cells_per_dim[d];
-        if ( dim_remainder[d] > _cart_rank[d] )
-            ++_owned_num_cell[d];
-    }
+    partitioner.ownedCellInfo( _cart_comm, global_num_cell, _owned_num_cell,
+                               _global_cell_offset );
 
     // Determine if a block is on the low or high boundaries.
     for ( std::size_t d = 0; d < num_space_dim; ++d )

--- a/cajita/src/Cajita_Partitioner.hpp
+++ b/cajita/src/Cajita_Partitioner.hpp
@@ -27,7 +27,6 @@ namespace Cajita
 /*!
   \brief Block partitioner base class.
   \tparam NumSpaceDim Spatial dimension.
-
   Given global mesh parameters, the block partitioner computes how many MPI
   ranks are assigned to each logical dimension.
 */
@@ -46,16 +45,31 @@ class BlockPartitioner
       \param global_cells_per_dim The number of global cells in each dimension.
       \return The number of MPI ranks in each dimension of the grid.
     */
-    virtual std::array<int, NumSpaceDim> ranksPerDimension(
+    virtual std::array<int, num_space_dim> ranksPerDimension(
         MPI_Comm comm,
-        const std::array<int, NumSpaceDim>& global_cells_per_dim ) const = 0;
+        const std::array<int, num_space_dim>& global_cells_per_dim ) const = 0;
+
+    /*!
+      \brief Get the owned number of cells and global cell offset of the current
+      MPI rank.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells in each dimension.
+      \param owned_num_cell (Return) The owned number of cells of the current
+      MPI rank in each dimension.
+      \param global_cell_offset (Return) The global cell offset of the current
+      MPI rank in each dimension
+    */
+    virtual void ownedCellInfo(
+        MPI_Comm cart_comm,
+        const std::array<int, num_space_dim>& global_cells_per_dim,
+        std::array<int, num_space_dim>& owned_num_cell,
+        std::array<int, num_space_dim>& global_cell_offset ) const = 0;
 };
 
 //---------------------------------------------------------------------------//
 /*!
   \brief Manual block partitioner.
   \tparam NumSpaceDim Spatial dimension.
-
   Assign MPI blocks from a fixed user input.
 */
 template <std::size_t NumSpaceDim>
@@ -93,6 +107,148 @@ class ManualBlockPartitioner : public BlockPartitioner<NumSpaceDim>
         return _ranks_per_dim;
     }
 
+    /*!
+      \brief Get the owned number of cells of the current MPI rank.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells and the global
+      cell offset in each dimension.
+      \param owned_num_cell (Return) The owned number of cells of the current
+      MPI rank in each dimension.
+      \param global_cell_offset (Return) The global cell offset of the current
+      MPI rank in each dimension
+    */
+    void ownedCellInfo(
+        MPI_Comm cart_comm,
+        const std::array<int, num_space_dim>& global_cells_per_dim,
+        std::array<int, num_space_dim>& owned_num_cell,
+        std::array<int, num_space_dim>& global_cell_offset ) const override
+    {
+        // Get the cells per dimension and the remainder.
+        std::array<int, num_space_dim> cells_per_dim;
+        std::array<int, num_space_dim> dim_remainder;
+        std::array<int, num_space_dim> cart_rank;
+        averageCellInfo( cart_comm, global_cells_per_dim, cart_rank,
+                         cells_per_dim, dim_remainder );
+
+        // Compute the global cell offset and the local low corner on this rank
+        // by computing the starting global cell index via exclusive scan.
+        global_cell_offset =
+            globalCellOffsetHelper( cart_rank, cells_per_dim, dim_remainder );
+
+        // Compute the number of local cells in this rank in each dimension.
+        owned_num_cell =
+            ownedCellsHelper( cart_rank, cells_per_dim, dim_remainder );
+    }
+
+    /*!
+      \brief Get the owned number of cells of the
+      current MPI rank.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells in each dimension.
+      \return The owned number of cells of the current
+      MPI rank in each dimension.
+    */
+    std::array<int, num_space_dim> ownedCellsPerDimension(
+        MPI_Comm cart_comm,
+        const std::array<int, num_space_dim>& global_cells_per_dim ) const
+    {
+        // Get the cells per dimension and the remainder.
+        std::array<int, num_space_dim> cells_per_dim;
+        std::array<int, num_space_dim> dim_remainder;
+        std::array<int, num_space_dim> cart_rank;
+        averageCellInfo( cart_comm, global_cells_per_dim, cart_rank,
+                         cells_per_dim, dim_remainder );
+
+        // Compute the number of local cells in this rank in each dimension.
+        return ownedCellsHelper( cart_rank, cells_per_dim, dim_remainder );
+    }
+
+  private:
+    /*!
+    \brief Get the average owned number of cells and the remainder.
+    \param cart_comm The MPI Cartesian communicator for the partitioning.
+    \param global_cells_per_dim The number of global cells in each dimension.
+    \param cart_rank MPI Cartesian rank index
+    \param cells_per_dim (Return) The average owned number of cells in each
+    dimension.
+    \param dim_remainder (Return) The cell remainder after averagely assign
+    cells to MPI ranks in each dimension.
+    */
+    inline void
+    averageCellInfo( MPI_Comm cart_comm,
+                     const std::array<int, num_space_dim>& global_cells_per_dim,
+                     std::array<int, num_space_dim>& cart_rank,
+                     std::array<int, num_space_dim>& cells_per_dim,
+                     std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        // Get the Cartesian size and topology index of this rank.
+        int linear_rank;
+        MPI_Comm_rank( cart_comm, &linear_rank );
+        MPI_Cart_coords( cart_comm, linear_rank, num_space_dim,
+                         cart_rank.data() );
+        // Get the cells per dimension and the remainder.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            cells_per_dim[d] = global_cells_per_dim[d] / _ranks_per_dim[d];
+            dim_remainder[d] = global_cells_per_dim[d] % _ranks_per_dim[d];
+        }
+    }
+
+    /*!
+      \brief Get the owned number of cells in this rank in each dimension.
+      \param cart_rank MPI Cartesian rank index.
+      \param cells_per_dim The average owned number of cells in each
+      dimension.
+      \param dim_remainder The cell remainder after averagely assign
+      cells to MPI ranks in each dimension.
+      \return Owned cell number in this rank in each dimension
+    */
+    inline std::array<int, num_space_dim> ownedCellsHelper(
+        const std::array<int, num_space_dim>& cart_rank,
+        const std::array<int, num_space_dim>& cells_per_dim,
+        const std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        std::array<int, num_space_dim> owned_num_cell;
+        // Compute the number of local cells in this rank in each dimension.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            owned_num_cell[d] = cells_per_dim[d];
+            if ( dim_remainder[d] > cart_rank[d] )
+                ++owned_num_cell[d];
+        }
+        return owned_num_cell;
+    }
+
+    /*!
+      \brief Get the global cell offset in this rank ineach dimension.
+      \param cart_rank MPI Cartesian rank index.
+      \param cells_per_dim (Return) The average owned number of cells in each
+      dimension.
+      \param dim_remainder (Return) The cell remainder after averagely assign
+      cells to MPI ranks in each dimension.
+      \return Global cell offset in this rank in each dimension.
+    */
+    inline std::array<int, num_space_dim> globalCellOffsetHelper(
+        const std::array<int, num_space_dim>& cart_rank,
+        const std::array<int, num_space_dim>& cells_per_dim,
+        const std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        std::array<int, num_space_dim> global_cell_offset;
+        // Compute the global cell offset and the local low corner on this rank
+        // by computing the starting global cell index via exclusive scan.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            global_cell_offset[d] = 0;
+            for ( int r = 0; r < cart_rank[d]; ++r )
+            {
+                global_cell_offset[d] += cells_per_dim[d];
+                if ( dim_remainder[d] > r )
+                    ++global_cell_offset[d];
+            }
+        }
+        return global_cell_offset;
+    }
+
   private:
     std::array<int, NumSpaceDim> _ranks_per_dim;
 };
@@ -101,7 +257,6 @@ class ManualBlockPartitioner : public BlockPartitioner<NumSpaceDim>
 /*!
   \brief Dimension-only partitioner.
   \tparam NumSpaceDim Spatial dimension.
-
   Use MPI to compute the most uniform block distribution possible (i.e. the one
   that has the minimal number of neighbor communication messages in halo
   exchange). This distribution is independent of mesh parameters - only the size
@@ -134,6 +289,149 @@ class DimBlockPartitioner : public BlockPartitioner<NumSpaceDim>
         MPI_Dims_create( comm_size, NumSpaceDim, ranks_per_dim.data() );
 
         return ranks_per_dim;
+    }
+
+    /*!
+      \brief Get the owned number of cells and the global cell offset of the
+      current MPI rank.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells in each dimension.
+      \param owned_num_cell (Return) The owned number of cells of the current
+      MPI rank in each dimension.
+      \param global_cell_offset (Return) The global cell offset of the current
+      MPI rank in each dimension
+    */
+    void ownedCellInfo(
+        MPI_Comm cart_comm,
+        const std::array<int, num_space_dim>& global_cells_per_dim,
+        std::array<int, num_space_dim>& owned_num_cell,
+        std::array<int, num_space_dim>& global_cell_offset ) const override
+    {
+        // Get the cells per dimension and the remainder.
+        std::array<int, num_space_dim> cells_per_dim;
+        std::array<int, num_space_dim> dim_remainder;
+        std::array<int, num_space_dim> cart_rank;
+        averageCellInfo( cart_comm, global_cells_per_dim, cart_rank,
+                         cells_per_dim, dim_remainder );
+
+        // Compute the global cell offset and the local low corner on this rank
+        // by computing the starting global cell index via exclusive scan.
+        global_cell_offset =
+            globalCellOffsetHelper( cart_rank, cells_per_dim, dim_remainder );
+
+        // Compute the number of local cells in this rank in each dimension.
+        owned_num_cell =
+            ownedCellsHelper( cart_rank, cells_per_dim, dim_remainder );
+    }
+
+    /*!
+      \brief Get the owned number of cells of the
+      current MPI rank.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells in each dimension.
+      \return The owned number of cells of the current
+      MPI rank in each dimension.
+    */
+    std::array<int, num_space_dim> ownedCellsPerDimension(
+        MPI_Comm cart_comm,
+        const std::array<int, num_space_dim>& global_cells_per_dim ) const
+    {
+        // Get the cells per dimension and the remainder.
+        std::array<int, num_space_dim> cells_per_dim;
+        std::array<int, num_space_dim> dim_remainder;
+        std::array<int, num_space_dim> cart_rank;
+        averageCellInfo( cart_comm, global_cells_per_dim, cart_rank,
+                         cells_per_dim, dim_remainder );
+
+        // Compute the number of local cells in this rank in each dimension.
+        return ownedCellsHelper( cart_rank, cells_per_dim, dim_remainder );
+    }
+
+  private:
+    /*!
+      \brief Get the average owned number of cells and the remainder.
+      \param cart_comm The MPI Cartesian communicator for the partitioning.
+      \param global_cells_per_dim The number of global cells in each dimension.
+      \param cart_rank MPI Cartesian rank index
+      \param cells_per_dim (Return) The average owned number of cells in each
+      dimension.
+      \param dim_remainder (Return) The cell remainder after averagely assign
+      cells to MPI ranks in each dimension.
+    */
+    inline void
+    averageCellInfo( MPI_Comm cart_comm,
+                     const std::array<int, num_space_dim>& global_cells_per_dim,
+                     std::array<int, num_space_dim>& cart_rank,
+                     std::array<int, num_space_dim>& cells_per_dim,
+                     std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        // Get the Cartesian size and topology index of this rank.
+        std::array<int, num_space_dim> ranks_per_dim;
+        std::array<int, num_space_dim> cart_period;
+        MPI_Cart_get( cart_comm, num_space_dim, ranks_per_dim.data(),
+                      cart_period.data(), cart_rank.data() );
+
+        // Get the cells per dimension and the remainder.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            cells_per_dim[d] = global_cells_per_dim[d] / ranks_per_dim[d];
+            dim_remainder[d] = global_cells_per_dim[d] % ranks_per_dim[d];
+        }
+    }
+
+    /*!
+      \brief Get the owned number of cells in this rank in each dimension.
+      \param cart_rank MPI Cartesian rank index.
+      \param cells_per_dim The average owned number of cells in each
+      dimension.
+      \param dim_remainder The cell remainder after averagely assign
+      cells to MPI ranks in each dimension.
+      \return Owned cell number in this rank in each dimension
+    */
+    inline std::array<int, num_space_dim> ownedCellsHelper(
+        const std::array<int, num_space_dim>& cart_rank,
+        const std::array<int, num_space_dim>& cells_per_dim,
+        const std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        std::array<int, num_space_dim> owned_num_cell;
+        // Compute the number of local cells in this rank in each dimension.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            owned_num_cell[d] = cells_per_dim[d];
+            if ( dim_remainder[d] > cart_rank[d] )
+                ++owned_num_cell[d];
+        }
+        return owned_num_cell;
+    }
+
+    /*!
+      \brief Get the global cell offset in this rank ineach dimension.
+      \param cart_rank MPI Cartesian rank index.
+      \param cells_per_dim (Return) The average owned number of cells in each
+      dimension.
+      \param dim_remainder (Return) The cell remainder after averagely assign
+      cells to MPI ranks in each dimension.
+      \return Global cell offset in this rank in each dimension.
+    */
+    inline std::array<int, num_space_dim> globalCellOffsetHelper(
+        const std::array<int, num_space_dim>& cart_rank,
+        const std::array<int, num_space_dim>& cells_per_dim,
+        const std::array<int, num_space_dim>& dim_remainder ) const
+    {
+        std::array<int, num_space_dim> global_cell_offset;
+        // Compute the global cell offset and the local low corner on this rank
+        // by computing the starting global cell index via exclusive scan.
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            global_cell_offset[d] = 0;
+            for ( int r = 0; r < cart_rank[d]; ++r )
+            {
+                global_cell_offset[d] += cells_per_dim[d];
+                if ( dim_remainder[d] > r )
+                    ++global_cell_offset[d];
+            }
+        }
+        return global_cell_offset;
     }
 };
 

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MPI_TESTS
   BovWriter
   Parallel
   SparseDimPartitioner
+  Partitioner
   )
 
 if(Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -11,6 +11,7 @@
 
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_GlobalMesh.hpp>
+#include <Cajita_SparseDimPartitioner.hpp>
 #include <Cajita_Types.hpp>
 #include <Cajita_UniformDimPartitioner.hpp>
 
@@ -168,6 +169,11 @@ void gridTest3d( const std::array<bool, 3>& is_dim_periodic )
         EXPECT_EQ( global_grid->dimBlockId( d ), cart_rank[d] );
         EXPECT_EQ( global_grid->dimNumBlock( d ), ranks_per_dim[d] );
     }
+
+    auto owned_cells_partitioner = partitioner.ownedCellsPerDimension(
+        global_grid->comm(), global_num_cell );
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_EQ( global_grid->ownedNumCell( d ), owned_cells_partitioner[d] );
 
     for ( int d = 0; d < 3; ++d )
     {
@@ -327,6 +333,11 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
         EXPECT_EQ( global_grid->dimNumBlock( d ), ranks_per_dim[d] );
     }
 
+    auto owned_cells_partitioner = partitioner.ownedCellsPerDimension(
+        global_grid->comm(), global_num_cell );
+    for ( int d = 0; d < 2; ++d )
+        EXPECT_EQ( global_grid->ownedNumCell( d ), owned_cells_partitioner[d] );
+
     for ( int d = 0; d < 2; ++d )
     {
         std::vector<int> dim_cells_per_rank( global_grid->dimNumBlock( d ), 0 );
@@ -390,6 +401,196 @@ void gridTest2d( const std::array<bool, 2>& is_dim_periodic )
     }
 }
 
+void sparseGridTest3d()
+{
+    // Spares grid related settings
+    constexpr int cell_per_tile_dim = 4;
+    const std::array<bool, 3> is_dim_periodic = { false, false, false };
+
+    // Create Sparse global mesh
+    std::array<int, 3> global_num_tile = { 16, 8, 4 };
+    std::array<int, 3> global_num_cell = {
+        global_num_tile[0] * cell_per_tile_dim,
+        global_num_tile[1] * cell_per_tile_dim,
+        global_num_tile[2] * cell_per_tile_dim };
+
+    double cell_size = 0.1;
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+
+    auto global_mesh = createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Sparse paritioner
+    float max_workload_coeff = 1.5;
+    int workload_num =
+        global_num_cell[0] * global_num_cell[1] * global_num_cell[2];
+    int num_step_rebalance = 100;
+    int max_optimize_iteration = 10;
+
+    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+        MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
+        global_num_cell, max_optimize_iteration );
+
+    // test ranks per dim
+    auto ranks_per_dim =
+        partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
+    // initialize partitions (averagely divide the whole domain)
+    std::array<std::vector<int>, 3> rec_partitions;
+    for ( int d = 0; d < 3; ++d )
+    {
+        int ele = global_num_tile[d] / ranks_per_dim[d];
+        int part = 0;
+        for ( int i = 0; i < ranks_per_dim[d]; ++i )
+        {
+            rec_partitions[d].push_back( part );
+            part += ele;
+        }
+        rec_partitions[d].push_back( global_num_tile[d] );
+    }
+    partitioner.initializeRecPartition( rec_partitions[0], rec_partitions[1],
+                                        rec_partitions[2] );
+
+    // Create spares global grid
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+
+    // Check the number of entities.
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( global_num_cell[d],
+                   global_grid->globalNumEntity( Cell(), d ) );
+        if ( is_dim_periodic[d] )
+            EXPECT_EQ( global_num_cell[d],
+                       global_grid->globalNumEntity( Node(), d ) );
+        else
+            EXPECT_EQ( global_num_cell[d] + 1,
+                       global_grid->globalNumEntity( Node(), d ) );
+    }
+
+    // Check the number of faces entries
+    {
+        // Number of I faces
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+
+        // Number of J faces.
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+
+        // Number of K faces.
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+    }
+
+    // Check the number of edges entires
+    {
+        // Number of I edges
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+
+        // Number of J edges
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+
+        // Number of K edges
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+    }
+
+    // Check the partitioning. The grid communicator has a Cartesian topology.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    auto grid_comm = global_grid->comm();
+    int grid_comm_size;
+    MPI_Comm_size( grid_comm, &grid_comm_size );
+    int grid_comm_rank;
+    MPI_Comm_rank( grid_comm, &grid_comm_rank );
+    EXPECT_EQ( grid_comm_size, comm_size );
+    EXPECT_EQ( global_grid->totalNumBlock(), grid_comm_size );
+    EXPECT_EQ( global_grid->blockId(), grid_comm_rank );
+
+    std::vector<int> cart_dims( 3 );
+    std::vector<int> cart_period( 3 );
+    std::vector<int> cart_rank( 3 );
+    MPI_Cart_get( grid_comm, 3, cart_dims.data(), cart_period.data(),
+                  cart_rank.data() );
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( cart_period[d], is_dim_periodic[d] );
+        EXPECT_EQ( global_grid->dimBlockId( d ), cart_rank[d] );
+        EXPECT_EQ( global_grid->dimNumBlock( d ), ranks_per_dim[d] );
+    }
+
+    auto owned_cells_partitioner =
+        partitioner.ownedCellsPerDimension( global_grid->comm() );
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_EQ( global_grid->ownedNumCell( d ), owned_cells_partitioner[d] );
+
+    // Update partitioner and check num cell and global offset
+    auto part = partitioner.getCurrentPartition();
+    for ( int d = 0; d < 3; ++d )
+        for ( int id = 1; id < ranks_per_dim[d]; id++ )
+            part[d][id] += 1;
+
+    partitioner.initializeRecPartition( part[0], part[1], part[2] );
+
+    std::array<int, 3> new_owned_num_cell;
+    std::array<int, 3> new_global_cell_offset;
+    partitioner.ownedCellInfo( global_grid->comm(), global_num_cell,
+                               new_owned_num_cell, new_global_cell_offset );
+
+    // Check setNumCellAndOffset
+    // todo(sschulz): Need to have a more realistic change, since there might
+    // be some checking involved within the function.
+    global_grid->setNumCellAndOffset( new_owned_num_cell,
+                                      new_global_cell_offset );
+    for ( std::size_t i = 0; i < 3; ++i )
+        EXPECT_EQ( global_grid->globalOffset( i ), new_global_cell_offset[i] );
+
+    owned_cells_partitioner =
+        partitioner.ownedCellsPerDimension( global_grid->comm() );
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( owned_cells_partitioner[d], new_owned_num_cell[d] );
+        EXPECT_EQ( global_grid->ownedNumCell( d ), owned_cells_partitioner[d] );
+    }
+}
+
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
@@ -408,6 +609,8 @@ TEST( global_grid, 2d_grid_test )
     std::array<bool, 2> not_periodic = { false, false };
     gridTest2d( not_periodic );
 }
+
+TEST( global_grid, 3d_sparse_grid_test ) { sparseGridTest3d(); }
 
 //---------------------------------------------------------------------------//
 

--- a/cajita/unit_test/tstPartitioner.hpp
+++ b/cajita/unit_test/tstPartitioner.hpp
@@ -1,0 +1,225 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_ManualPartitioner.hpp>
+#include <Cajita_Partitioner.hpp>
+#include <Cajita_SparseDimPartitioner.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <ctime>
+#include <gtest/gtest.h>
+#include <set>
+
+#include <mpi.h>
+
+using namespace Cajita;
+
+namespace Test
+{
+template <typename PartitionerType>
+void owned_cell_info_test_3d( PartitionerType& partitioner )
+{
+
+    // Create Ground Truth Settings
+    std::array<int, 3> local_num_cell = { 104, 55, 97 };
+    std::array<int, 3> global_num_cell = { 0, 0, 0 };
+
+    auto ranks_per_dim =
+        partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
+    // Extract the periodicity of the boundary as integers.
+    std::array<int, 3> periodic_dims = { (int)true, (int)true, (int)true };
+
+    // Generate a communicator with a Cartesian topology.
+    MPI_Comm cart_comm;
+    int reorder_cart_ranks = 1;
+    MPI_Cart_create( MPI_COMM_WORLD, 3, ranks_per_dim.data(),
+                     periodic_dims.data(), reorder_cart_ranks, &cart_comm );
+
+    // Get the Cartesian topology index of this rank.
+    int linear_rank;
+    std::array<int, 3> cart_rank;
+    MPI_Comm_rank( cart_comm, &linear_rank );
+    MPI_Cart_coords( cart_comm, linear_rank, 3, cart_rank.data() );
+
+    // Set the cells per dimension and the remainde groud truth.
+    std::array<int, 3> owned_num_cell_gt;
+    std::array<int, 3> global_cell_offset_gt;
+    // Creating GT value from local_num_cell:
+    //   for each dimension, the N-th rank will have local_num_cell[d]-1 cells
+    //   the others will have local_num_cell[d]
+    for ( int d = 0; d < 3; ++d )
+    {
+        // the N-th rank will have local_num_cell[d]-1
+        if ( cart_rank[d] == ranks_per_dim[d] - 1 )
+            owned_num_cell_gt[d] = local_num_cell[d] - 1;
+        else // the others will have local_num_cell[d]
+            owned_num_cell_gt[d] = local_num_cell[d];
+
+        global_cell_offset_gt[d] = local_num_cell[d] * cart_rank[d];
+        global_num_cell[d] = local_num_cell[d] * ranks_per_dim[d] - 1;
+    }
+
+    // Get the cells per dimension and the remainder with partitioner
+    std::array<int, 3> owned_num_cell;
+    std::array<int, 3> global_cell_offset;
+
+    // The total global cells are avaragely assgined to all ranks
+    // The remainder is averagely spreaded in the first several ranks
+    partitioner.ownedCellInfo( cart_comm, global_num_cell, owned_num_cell,
+                               global_cell_offset );
+
+    for ( std::size_t d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( owned_num_cell[d], owned_num_cell_gt[d] );
+        EXPECT_EQ( global_cell_offset[d], global_cell_offset_gt[d] );
+    }
+}
+
+template <typename PartitionerType>
+void owned_cell_info_test_2d( PartitionerType& partitioner )
+{
+
+    // Create Ground Truth Settings
+    std::array<int, 2> local_num_cell = { 69, 203 };
+    std::array<int, 2> global_num_cell = { 0, 0 };
+
+    auto ranks_per_dim =
+        partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
+    // Extract the periodicity of the boundary as integers.
+    std::array<int, 2> periodic_dims = { (int)true, (int)true };
+
+    // Generate a communicator with a Cartesian topology.
+    MPI_Comm cart_comm;
+    int reorder_cart_ranks = 1;
+    MPI_Cart_create( MPI_COMM_WORLD, 2, ranks_per_dim.data(),
+                     periodic_dims.data(), reorder_cart_ranks, &cart_comm );
+
+    // Get the Cartesian topology index of this rank.
+    int linear_rank;
+    std::array<int, 2> cart_rank;
+    MPI_Comm_rank( cart_comm, &linear_rank );
+    MPI_Cart_coords( cart_comm, linear_rank, 2, cart_rank.data() );
+
+    // Set the cells per dimension and the remainde groud truth.
+    std::array<int, 2> owned_num_cell_gt;
+    std::array<int, 2> global_cell_offset_gt;
+    // Creating GT value from local_num_cell:
+    //   for each dimension, the N-th rank will have local_num_cell[d]-1 cells
+    //   the others will have local_num_cell[d]
+    for ( int d = 0; d < 2; ++d )
+    {
+        if ( cart_rank[d] == ranks_per_dim[d] - 1 )
+            owned_num_cell_gt[d] = local_num_cell[d] - 1;
+        else
+            owned_num_cell_gt[d] = local_num_cell[d];
+
+        global_cell_offset_gt[d] = local_num_cell[d] * cart_rank[d];
+        global_num_cell[d] = local_num_cell[d] * ranks_per_dim[d] - 1;
+    }
+
+    // Get the cells per dimension and the remainder with partitioner
+    std::array<int, 2> owned_num_cell;
+    std::array<int, 2> global_cell_offset;
+
+    // The total global cells are avaragely assgined to all ranks
+    // The remainder is averagely spreaded in the first several ranks
+    partitioner.ownedCellInfo( cart_comm, global_num_cell, owned_num_cell,
+                               global_cell_offset );
+
+    for ( std::size_t d = 0; d < 2; ++d )
+    {
+        EXPECT_EQ( owned_num_cell[d], owned_num_cell_gt[d] );
+        EXPECT_EQ( global_cell_offset[d], global_cell_offset_gt[d] );
+    }
+}
+
+void testBlockPartitioner3d()
+{
+    DimBlockPartitioner<3> partitioner;
+    owned_cell_info_test_3d( partitioner );
+}
+
+void testManualPartitioner3d()
+{
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
+    MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
+
+    {
+        ManualBlockPartitioner<3> partitioner( ranks_per_dim );
+        owned_cell_info_test_3d( partitioner );
+    }
+
+    if ( ranks_per_dim[0] != ranks_per_dim[1] )
+    {
+        std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+        ManualBlockPartitioner<3> partitioner( ranks_per_dim );
+        owned_cell_info_test_3d( partitioner );
+    }
+    if ( ranks_per_dim[0] != ranks_per_dim[2] )
+    {
+        std::swap( ranks_per_dim[0], ranks_per_dim[2] );
+        ManualBlockPartitioner<3> partitioner( ranks_per_dim );
+        owned_cell_info_test_3d( partitioner );
+    }
+    if ( ranks_per_dim[1] != ranks_per_dim[2] )
+    {
+        std::swap( ranks_per_dim[1], ranks_per_dim[2] );
+        ManualBlockPartitioner<3> partitioner( ranks_per_dim );
+        owned_cell_info_test_3d( partitioner );
+    }
+}
+
+void testBlockPartitioner2d()
+{
+    DimBlockPartitioner<2> partitioner;
+    owned_cell_info_test_2d( partitioner );
+}
+
+void testManualPartitioner2d()
+{
+    // Let MPI compute the partitioning for this test.
+    int comm_size;
+    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
+    std::array<int, 2> ranks_per_dim = { 0, 0 };
+    MPI_Dims_create( comm_size, 2, ranks_per_dim.data() );
+
+    {
+        ManualBlockPartitioner<2> partitioner( ranks_per_dim );
+        owned_cell_info_test_2d( partitioner );
+    }
+
+    if ( ranks_per_dim[0] != ranks_per_dim[1] )
+    {
+        std::swap( ranks_per_dim[0], ranks_per_dim[1] );
+        ManualBlockPartitioner<2> partitioner( ranks_per_dim );
+        owned_cell_info_test_2d( partitioner );
+    }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, partitioner_owned_cell_info_test_3d )
+{
+    testBlockPartitioner3d();
+    testManualPartitioner3d();
+}
+
+TEST( TEST_CATEGORY, partitioner_owned_cell_info_test_2d )
+{
+    testBlockPartitioner2d();
+    testManualPartitioner2d();
+}
+} // namespace Test

--- a/cajita/unit_test/tstSparseDimPartitioner.hpp
+++ b/cajita/unit_test/tstSparseDimPartitioner.hpp
@@ -112,9 +112,7 @@ void uniform_distribution_automatic_rank()
         auto gt_tile = rec_partitions[d][cart_rank[d] + 1] -
                        rec_partitions[d][cart_rank[d]];
         EXPECT_EQ( owned_tiles_per_dim[d], gt_tile );
-        EXPECT_EQ( owned_cells_per_dim[d], gt_tile * cell_per_tile_dim *
-                                               cell_per_tile_dim *
-                                               cell_per_tile_dim );
+        EXPECT_EQ( owned_cells_per_dim[d], gt_tile * cell_per_tile_dim );
         gt_imbalance_factor *= gt_tile;
     }
     gt_imbalance_factor /=
@@ -157,9 +155,7 @@ void uniform_distribution_automatic_rank()
         auto gt_tile = rec_partitions[d][cart_rank[d] + 1] -
                        rec_partitions[d][cart_rank[d]];
 
-        EXPECT_EQ( owned_cells_per_dim[d], gt_tile * cell_per_tile_dim *
-                                               cell_per_tile_dim *
-                                               cell_per_tile_dim );
+        EXPECT_EQ( owned_cells_per_dim[d], gt_tile * cell_per_tile_dim );
     }
 
     auto imbalance_factor = partitioner.computeImbalanceFactor( cart_comm );


### PR DESCRIPTION
In this pull request, we update parts of the implementation in `GlobalGrid` and `Partitioner`, such that the `GlobalGrid` can support the `SparseMesh` mesh type as well.


**Changes made in:**

1. `GlobalGrid` constructor: all partition related operations are moved to the Partitioner class series
2. Partitioner series:
    1. Base class `BlockPartitioner`: add a virtual interface `getOwnedCellInfo` which will take in the MPI cartesian communicator and an array to record the number of global cells in each dimension, and output the owned number of cells and the global cell offset of the current MPI rank.
    2. Overriders in derived classes: `ManualBlockPartitioner`, `DimBlockPartitioner` and `SparseDimPartitioner`
        1. In `DimBlockPartitioner` and the `SparseDimParititoner`, the `owned_num_cell` and the `global_cell_offset` are dynamically computed from the input `global_cells_per_dim`.
        2. In `SparseDimPartitioner`, the `owned_num_cell` and the `global_cell_offset` are dynamically computed from the rec_partitioner, while the input `global_cells_per_dim` is not used anywhere. Please note, the unit of partition information is a tile but not a cell. Therefore, another interface called `getOwnedTileInfo` is added to support the implementation of `getOwnedCellInfo`.
3. Unit tests in `tstGlobalGrid` for the sparse grid case.


**User Doc:**
1. Users should take responsibility to initialize the partitioner (for sparse grid case); the owned cell information is meaningless if the partitioner is not initialized.
2. For dynamic partitioners, users are responsible for updating their `global_grid` variable (`owned_cell_num` and `global_cell_offset`) by using interface `setNumCellAndOffset` defined in `GlobalGrid`.
3. For dynamic partitioners, users can retrieve the `owned_cell_num` and `global_cell_offset` by calling `getOwnedCellInfo` defined in partitioners after partitions being updated. (Please see the last few lines in unit test `3d_sparse_grid_test` in `tstGlobalGrid.hpp` )
