### PR TITLE
Add local mesh default constructor

### DIFF
--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -50,6 +50,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Kokkos execution space.
     using execution_space = typename Device::execution_space;
 
+    //! Default constructor.
+    LocalMesh() = default;
+
     //! Constructor.
     LocalMesh( const LocalGrid<UniformMesh<Scalar, num_space_dim>>& local_grid )
     {


### PR DESCRIPTION
Useful in Picasso for storing the mesh on the device for boundary condition checks