### PR TITLE
Fix unit test floating point equal

### DIFF
--- a/cajita/unit_test/tstArray2d.hpp
+++ b/cajita/unit_test/tstArray2d.hpp
@@ -259,7 +259,7 @@ void arrayOpTest()
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 2.0 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 2.0 );
 
     // Scale the entire array with a single value.
     ArrayOp::scale( *array, 0.5, Ghost() );
@@ -267,7 +267,7 @@ void arrayOpTest()
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 1.0 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 1.0 );
 
     // Scale each array component by a different value.
     std::vector<double> scales = { 2.3, 1.5, 8.9, -12.1 };
@@ -276,7 +276,7 @@ void arrayOpTest()
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), scales[l] );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), scales[l] );
 
     // Create another array and update.
     auto array_2 = createArray<double, TEST_DEVICE>( label, cell_layout );
@@ -286,7 +286,7 @@ void arrayOpTest()
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 3.0 * scales[l] + 1.0 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 3.0 * scales[l] + 1.0 );
 
     // Check the subarray.
     auto subarray = createSubarray( *array, 2, 4 );
@@ -301,7 +301,8 @@ void arrayOpTest()
     for ( long i = 0; i < sub_ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < sub_ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < sub_ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_subview( i, j, l ), 3.0 * scales[l + 2] + 1.0 );
+                EXPECT_DOUBLE_EQ( host_subview( i, j, l ),
+                                  3.0 * scales[l + 2] + 1.0 );
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     // Compute the dot product of the two arrays.
@@ -349,7 +350,7 @@ void arrayOpTest()
         for ( long j = owned_space.min( Dim::J ); j < owned_space.max( Dim::J );
               ++j )
             for ( long l = 0; l < owned_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 0.5 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 0.5 );
 
     // Now make a clone and copy.
     auto array_3 = ArrayOp::clone( *array );
@@ -360,7 +361,7 @@ void arrayOpTest()
         for ( long j = owned_space.min( Dim::J ); j < owned_space.max( Dim::J );
               ++j )
             for ( long l = 0; l < owned_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 0.5 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 0.5 );
 
     // Test the fused clone copy.
     auto array_4 = ArrayOp::cloneCopy( *array, Own() );
@@ -370,7 +371,7 @@ void arrayOpTest()
         for ( long j = owned_space.min( Dim::J ); j < owned_space.max( Dim::J );
               ++j )
             for ( long l = 0; l < owned_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ), 0.5 );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ), 0.5 );
 
     // Do a 3 vector update.
     ArrayOp::assign( *array, 1.0, Ghost() );
@@ -384,8 +385,8 @@ void arrayOpTest()
     for ( long i = 0; i < ghosted_space.extent( Dim::I ); ++i )
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long l = 0; l < ghosted_space.extent( 2 ); ++l )
-                EXPECT_EQ( host_view( i, j, l ),
-                           ( 3.0 + 1.0 + 6.0 ) * scales[l] );
+                EXPECT_DOUBLE_EQ( host_view( i, j, l ),
+                                  ( 3.0 + 1.0 + 6.0 ) * scales[l] );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstArray3d.hpp
+++ b/cajita/unit_test/tstArray3d.hpp
@@ -263,7 +263,7 @@ void arrayOpTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 2.0 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 2.0 );
 
     // Scale the entire array with a single value.
     ArrayOp::scale( *array, 0.5, Ghost() );
@@ -272,7 +272,7 @@ void arrayOpTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 1.0 );
 
     // Scale each array component by a different value.
     std::vector<double> scales = { 2.3, 1.5, 8.9, -12.1 };
@@ -282,7 +282,7 @@ void arrayOpTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), scales[l] );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), scales[l] );
 
     // Create another array and update.
     auto array_2 = createArray<double, TEST_DEVICE>( label, cell_layout );
@@ -293,7 +293,8 @@ void arrayOpTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 3.0 * scales[l] + 1.0 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ),
+                                      3.0 * scales[l] + 1.0 );
 
     // Check the subarray.
     auto subarray = createSubarray( *array, 2, 4 );
@@ -312,8 +313,8 @@ void arrayOpTest()
         for ( long j = 0; j < sub_ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < sub_ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < sub_ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_subview( i, j, k, l ),
-                               3.0 * scales[l + 2] + 1.0 );
+                    EXPECT_DOUBLE_EQ( host_subview( i, j, k, l ),
+                                      3.0 * scales[l + 2] + 1.0 );
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
     // Compute the dot product of the two arrays.
@@ -364,7 +365,7 @@ void arrayOpTest()
             for ( long k = owned_space.min( Dim::K );
                   k < owned_space.max( Dim::K ); ++k )
                 for ( long l = 0; l < owned_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 0.5 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 0.5 );
 
     // Now make a clone and copy.
     auto array_3 = ArrayOp::clone( *array );
@@ -377,7 +378,7 @@ void arrayOpTest()
             for ( long k = owned_space.min( Dim::K );
                   k < owned_space.max( Dim::K ); ++k )
                 for ( long l = 0; l < owned_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 0.5 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 0.5 );
 
     // Test the fused clone copy.
     auto array_4 = ArrayOp::cloneCopy( *array, Own() );
@@ -389,7 +390,7 @@ void arrayOpTest()
             for ( long k = owned_space.min( Dim::K );
                   k < owned_space.max( Dim::K ); ++k )
                 for ( long l = 0; l < owned_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 0.5 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 0.5 );
 
     // Do a 3 vector update.
     ArrayOp::assign( *array, 1.0, Ghost() );
@@ -404,8 +405,8 @@ void arrayOpTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ),
-                               ( 3.0 + 1.0 + 6.0 ) * scales[l] );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ),
+                                      ( 3.0 + 1.0 + 6.0 ) * scales[l] );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstBovWriter.hpp
+++ b/cajita/unit_test/tstBovWriter.hpp
@@ -145,7 +145,7 @@ void writeTest3d()
                     cell_data_file.seekg( cell_id * sizeof( double ) );
                     cell_data_file.read( (char*)&cell_value, sizeof( double ) );
 
-                    EXPECT_FLOAT_EQ(
+                    EXPECT_DOUBLE_EQ(
                         cell_value,
                         1.0 + fabs( cos( pi2 * xarg ) * cos( pi2 * yarg ) *
                                     cos( pi2 * zarg ) ) );
@@ -177,20 +177,20 @@ void writeTest3d()
 
                     node_data_file.seekg( node_id * sizeof( double ) );
                     node_data_file.read( (char*)&node_value, sizeof( double ) );
-                    EXPECT_FLOAT_EQ( node_value,
-                                     1.0 + fabs( cos( pi2 * xarg ) ) );
+                    EXPECT_DOUBLE_EQ( node_value,
+                                      1.0 + fabs( cos( pi2 * xarg ) ) );
                     ++node_id;
 
                     node_data_file.seekg( node_id * sizeof( double ) );
                     node_data_file.read( (char*)&node_value, sizeof( double ) );
-                    EXPECT_FLOAT_EQ( node_value,
-                                     1.0 + fabs( cos( pi2 * yarg ) ) );
+                    EXPECT_DOUBLE_EQ( node_value,
+                                      1.0 + fabs( cos( pi2 * yarg ) ) );
                     ++node_id;
 
                     node_data_file.seekg( node_id * sizeof( double ) );
                     node_data_file.read( (char*)&node_value, sizeof( double ) );
-                    EXPECT_FLOAT_EQ( node_value,
-                                     1.0 + fabs( cos( pi2 * zarg ) ) );
+                    EXPECT_DOUBLE_EQ( node_value,
+                                      1.0 + fabs( cos( pi2 * zarg ) ) );
                     ++node_id;
                 }
 
@@ -302,8 +302,8 @@ void writeTest2d()
                 cell_data_file.seekg( cell_id * sizeof( double ) );
                 cell_data_file.read( (char*)&cell_value, sizeof( double ) );
 
-                EXPECT_FLOAT_EQ( cell_value, 1.0 + fabs( cos( pi2 * xarg ) *
-                                                         cos( pi2 * yarg ) ) );
+                EXPECT_DOUBLE_EQ( cell_value, 1.0 + fabs( cos( pi2 * xarg ) *
+                                                          cos( pi2 * yarg ) ) );
                 ++cell_id;
             }
 
@@ -328,12 +328,12 @@ void writeTest2d()
 
                 node_data_file.seekg( node_id * sizeof( double ) );
                 node_data_file.read( (char*)&node_value, sizeof( double ) );
-                EXPECT_FLOAT_EQ( node_value, 1.0 + fabs( cos( pi2 * xarg ) ) );
+                EXPECT_DOUBLE_EQ( node_value, 1.0 + fabs( cos( pi2 * xarg ) ) );
                 ++node_id;
 
                 node_data_file.seekg( node_id * sizeof( double ) );
                 node_data_file.read( (char*)&node_value, sizeof( double ) );
-                EXPECT_FLOAT_EQ( node_value, 1.0 + fabs( cos( pi2 * yarg ) ) );
+                EXPECT_DOUBLE_EQ( node_value, 1.0 + fabs( cos( pi2 * yarg ) ) );
                 ++node_id;
             }
 

--- a/cajita/unit_test/tstHalo2d.hpp
+++ b/cajita/unit_test/tstHalo2d.hpp
@@ -48,8 +48,6 @@ template <class Array>
 void checkGather( const std::array<bool, 2>& is_dim_periodic,
                   const int halo_width, const Array& array )
 {
-    // FIXME Change back to fine grained EXPECT_EQ when passing on all distros
-    int pass_gather_test = 1;
     auto owned_space = array.layout()->indexSpace( Own(), Local() );
     auto ghosted_space = array.layout()->indexSpace( Ghost(), Local() );
     auto host_view = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
@@ -85,29 +83,19 @@ void checkGather( const std::array<bool, 2>& is_dim_periodic,
                      in_boundary_max_halo( i, Dim::I ) ||
                      in_boundary_max_halo( j, Dim::J ) )
                 {
-                    if ( host_view( i, j, l ) != 0.0 )
-                    {
-                        pass_gather_test = 0;
-                    }
+                    EXPECT_DOUBLE_EQ( host_view( i, j, l ), 0.0 );
                 }
                 else if ( i < owned_space.min( Dim::I ) - halo_width ||
                           i >= owned_space.max( Dim::I ) + halo_width + pad_i ||
                           j < owned_space.min( Dim::J ) - halo_width ||
                           j >= owned_space.max( Dim::J ) + halo_width + pad_j )
                 {
-                    if ( host_view( i, j, l ) != 0.0 )
-                    {
-                        pass_gather_test = 0;
-                    }
+                    EXPECT_DOUBLE_EQ( host_view( i, j, l ), 0.0 );
                 }
                 else
                 {
-                    if ( host_view( i, j, l ) != 1.0 )
-                    {
-                        pass_gather_test = 0;
-                    }
+                    EXPECT_DOUBLE_EQ( host_view( i, j, l ), 1.0 );
                 }
-    EXPECT_EQ( pass_gather_test, 1 );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstHalo3d.hpp
+++ b/cajita/unit_test/tstHalo3d.hpp
@@ -54,8 +54,6 @@ template <class Array>
 void checkGather( const std::array<bool, 3>& is_dim_periodic,
                   const int halo_width, const Array& array )
 {
-    // FIXME Change back to fine grained EXPECT_EQ when passing on all distros
-    int pass_gather_test = 1;
     auto owned_space = array.layout()->indexSpace( Own(), Local() );
     auto ghosted_space = array.layout()->indexSpace( Ghost(), Local() );
     auto host_view = Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(),
@@ -95,10 +93,7 @@ void checkGather( const std::array<bool, 3>& is_dim_periodic,
                          in_boundary_max_halo( j, Dim::J ) ||
                          in_boundary_max_halo( k, Dim::K ) )
                     {
-                        if ( host_view( i, j, k, l ) != 0.0 )
-                        {
-                            pass_gather_test = 0;
-                        }
+                        EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 0.0 );
                     }
                     else if ( i < owned_space.min( Dim::I ) - halo_width ||
                               i >= owned_space.max( Dim::I ) + halo_width +
@@ -110,19 +105,12 @@ void checkGather( const std::array<bool, 3>& is_dim_periodic,
                               k >= owned_space.max( Dim::K ) + halo_width +
                                        pad_k )
                     {
-                        if ( host_view( i, j, k, l ) != 0.0 )
-                        {
-                            pass_gather_test = 0;
-                        }
+                        EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 0.0 );
                     }
                     else
                     {
-                        if ( host_view( i, j, k, l ) != 1.0 )
-                        {
-                            pass_gather_test = 0;
-                        }
+                        EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 1.0 );
                     }
-    EXPECT_EQ( pass_gather_test, 1 );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -107,8 +107,6 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
         } );
 
     // Compare the results.
-    // FIXME Change back to fine grained EXPECT_EQ when passing on all distros
-    int pass_index_conversion_test = 1;
     auto index_view_host =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), index_view );
     auto l2g_view_host =
@@ -119,9 +117,8 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
                 for ( int k = space.min( Dim::K ); k < space.max( Dim::K );
                       ++k )
                     for ( int d = 0; d < 3; ++d )
-                        if ( l2g_view_host( i, j, k, d ) !=
-                             index_view_host( i, j, k, d ) )
-                            pass_index_conversion_test = 0;
+                        EXPECT_EQ( l2g_view_host( i, j, k, d ),
+                                   index_view_host( i, j, k, d ) );
     };
     check_results( own_local_space );
     for ( int i = -1; i < 2; ++i )
@@ -130,7 +127,6 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
                 if ( local_grid->neighborRank( i, j, k ) >= 0 )
                     check_results( local_grid->sharedIndexSpace(
                         Ghost(), EntityType(), i, j, k ) );
-    EXPECT_EQ( pass_index_conversion_test, 1 );
 }
 
 //---------------------------------------------------------------------------//
@@ -204,8 +200,6 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
         } );
 
     // Compare the results.
-    // FIXME Change back to fine grained EXPECT_EQ when passing on all distros
-    int pass_index_conversion_test = 1;
     auto index_view_host =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), index_view );
     auto l2g_view_host =
@@ -214,9 +208,8 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
         for ( int i = space.min( Dim::I ); i < space.max( Dim::I ); ++i )
             for ( int j = space.min( Dim::J ); j < space.max( Dim::J ); ++j )
                 for ( int d = 0; d < 2; ++d )
-                    if ( l2g_view_host( i, j, d ) !=
-                         index_view_host( i, j, d ) )
-                        pass_index_conversion_test = 0;
+                    EXPECT_EQ( l2g_view_host( i, j, d ),
+                               index_view_host( i, j, d ) );
     };
     check_results( own_local_space );
     for ( int i = -1; i < 2; ++i )
@@ -224,7 +217,6 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
             if ( local_grid->neighborRank( i, j ) >= 0 )
                 check_results( local_grid->sharedIndexSpace(
                     Ghost(), EntityType(), i, j ) );
-    EXPECT_EQ( pass_index_conversion_test, 1 );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -284,9 +284,9 @@ void executionTest()
     for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
-            EXPECT_EQ( v1_mirror( i ), 1.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 1.0 );
         else
-            EXPECT_EQ( v1_mirror( i ), 0.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 0.0 );
     }
 
     // Rank-2
@@ -305,9 +305,9 @@ void executionTest()
         {
             if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
                  j < is2.max( 1 ) )
-                EXPECT_EQ( v2_mirror( i, j ), 1.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 1.0 );
             else
-                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 0.0 );
         }
 
     // Rank-3
@@ -330,9 +330,9 @@ void executionTest()
                 if ( is3.min( 0 ) <= i && i < is3.max( 0 ) &&
                      is3.min( 1 ) <= j && j < is3.max( 1 ) &&
                      is3.min( 2 ) <= k && k < is3.max( 2 ) )
-                    EXPECT_EQ( v3_mirror( i, j, k ), 1.0 );
+                    EXPECT_DOUBLE_EQ( v3_mirror( i, j, k ), 1.0 );
                 else
-                    EXPECT_EQ( v3_mirror( i, j, k ), 0.0 );
+                    EXPECT_DOUBLE_EQ( v3_mirror( i, j, k ), 0.0 );
             }
 
     // Rank-4
@@ -359,9 +359,9 @@ void executionTest()
                          is4.min( 1 ) <= j && j < is4.max( 1 ) &&
                          is4.min( 2 ) <= k && k < is4.max( 2 ) &&
                          is4.min( 3 ) <= l && l < is4.max( 3 ) )
-                        EXPECT_EQ( v4_mirror( i, j, k, l ), 1.0 );
+                        EXPECT_DOUBLE_EQ( v4_mirror( i, j, k, l ), 1.0 );
                     else
-                        EXPECT_EQ( v4_mirror( i, j, k, l ), 0.0 );
+                        EXPECT_DOUBLE_EQ( v4_mirror( i, j, k, l ), 0.0 );
                 }
 }
 
@@ -381,9 +381,9 @@ void subviewTest()
     for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.range( 0 ).first <= i && i < is1.range( 0 ).second )
-            EXPECT_EQ( v1_mirror( i ), 1.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 1.0 );
         else
-            EXPECT_EQ( v1_mirror( i ), 0.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 0.0 );
     }
 
     // Rank-2
@@ -401,9 +401,9 @@ void subviewTest()
         {
             if ( is2.range( 0 ).first <= i && i < is2.range( 0 ).second &&
                  is2.range( 1 ).first <= j && j < is2.range( 1 ).second )
-                EXPECT_EQ( v2_mirror( i, j ), 1.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 1.0 );
             else
-                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 0.0 );
         }
 
     // Rank-3
@@ -423,9 +423,9 @@ void subviewTest()
                 if ( is3.range( 0 ).first <= i && i < is3.range( 0 ).second &&
                      is3.range( 1 ).first <= j && j < is3.range( 1 ).second &&
                      is3.range( 2 ).first <= k && k < is3.range( 2 ).second )
-                    EXPECT_EQ( v3_mirror( i, j, k ), 1.0 );
+                    EXPECT_DOUBLE_EQ( v3_mirror( i, j, k ), 1.0 );
                 else
-                    EXPECT_EQ( v3_mirror( i, j, k ), 0.0 );
+                    EXPECT_DOUBLE_EQ( v3_mirror( i, j, k ), 0.0 );
             }
 
     // Rank-4
@@ -453,9 +453,9 @@ void subviewTest()
                          k < is4.range( 2 ).second &&
                          is4.range( 3 ).first <= l &&
                          l < is4.range( 3 ).second )
-                        EXPECT_EQ( v4_mirror( i, j, k, l ), 1.0 );
+                        EXPECT_DOUBLE_EQ( v4_mirror( i, j, k, l ), 1.0 );
                     else
-                        EXPECT_EQ( v4_mirror( i, j, k, l ), 0.0 );
+                        EXPECT_DOUBLE_EQ( v4_mirror( i, j, k, l ), 0.0 );
                 }
 }
 

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -106,9 +106,9 @@ void parallelIndexSpaceTest()
     for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
-            EXPECT_EQ( v1_mirror( i ), 1.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 1.0 );
         else
-            EXPECT_EQ( v1_mirror( i ), 0.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 0.0 );
     }
 
     // check reduction.
@@ -127,9 +127,9 @@ void parallelIndexSpaceTest()
     for ( int i = 0; i < size_i; ++i )
     {
         if ( is1.min( 0 ) <= i && i < is1.max( 0 ) )
-            EXPECT_EQ( v1_mirror( i ), 2.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 2.0 );
         else
-            EXPECT_EQ( v1_mirror( i ), 0.0 );
+            EXPECT_DOUBLE_EQ( v1_mirror( i ), 0.0 );
     }
 
     // check reduction.
@@ -154,9 +154,9 @@ void parallelIndexSpaceTest()
         {
             if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
                  j < is2.max( 1 ) )
-                EXPECT_EQ( v2_mirror( i, j ), 1.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 1.0 );
             else
-                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 0.0 );
         }
 
     // check reduction.
@@ -179,9 +179,9 @@ void parallelIndexSpaceTest()
         {
             if ( is2.min( 0 ) <= i && i < is2.max( 0 ) && is2.min( 1 ) <= j &&
                  j < is2.max( 1 ) )
-                EXPECT_EQ( v2_mirror( i, j ), 2.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 2.0 );
             else
-                EXPECT_EQ( v2_mirror( i, j ), 0.0 );
+                EXPECT_DOUBLE_EQ( v2_mirror( i, j ), 0.0 );
         }
 
     // check reduction.
@@ -239,7 +239,7 @@ void parallelLocalGridTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 1.0 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 1.0 );
 
     // check reduction.
     double sum = 0.0;
@@ -262,7 +262,7 @@ void parallelLocalGridTest()
         for ( long j = 0; j < ghosted_space.extent( Dim::J ); ++j )
             for ( long k = 0; k < ghosted_space.extent( Dim::K ); ++k )
                 for ( long l = 0; l < ghosted_space.extent( 3 ); ++l )
-                    EXPECT_EQ( host_view( i, j, k, l ), 2.0 );
+                    EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), 2.0 );
 
     // check reduction.
     double sum_tag = 0.0;
@@ -301,15 +301,15 @@ void parallelMultiSpaceTest()
             long idx[2] = { i, j };
             if ( is2_1.inRange( idx ) )
             {
-                EXPECT_EQ( 1.0, host_data_2d( i, j ) );
+                EXPECT_DOUBLE_EQ( 1.0, host_data_2d( i, j ) );
             }
             else if ( is2_2.inRange( idx ) )
             {
-                EXPECT_EQ( 2.0, host_data_2d( i, j ) );
+                EXPECT_DOUBLE_EQ( 2.0, host_data_2d( i, j ) );
             }
             else
             {
-                EXPECT_EQ( 0.0, host_data_2d( i, j ) );
+                EXPECT_DOUBLE_EQ( 0.0, host_data_2d( i, j ) );
             }
         }
 
@@ -341,15 +341,15 @@ void parallelMultiSpaceTest()
                 long idx[3] = { i, j, k };
                 if ( is3_1.inRange( idx ) )
                 {
-                    EXPECT_EQ( 1.0, host_data_3d( i, j, k ) );
+                    EXPECT_DOUBLE_EQ( 1.0, host_data_3d( i, j, k ) );
                 }
                 else if ( is3_2.inRange( idx ) )
                 {
-                    EXPECT_EQ( 2.0, host_data_3d( i, j, k ) );
+                    EXPECT_DOUBLE_EQ( 2.0, host_data_3d( i, j, k ) );
                 }
                 else
                 {
-                    EXPECT_EQ( 0.0, host_data_3d( i, j, k ) );
+                    EXPECT_DOUBLE_EQ( 0.0, host_data_3d( i, j, k ) );
                 }
             }
 
@@ -383,15 +383,15 @@ void parallelMultiSpaceTest()
                     long idx[4] = { i, j, k, l };
                     if ( is4_1.inRange( idx ) )
                     {
-                        EXPECT_EQ( 1.0, host_data_4d( i, j, k, l ) );
+                        EXPECT_DOUBLE_EQ( 1.0, host_data_4d( i, j, k, l ) );
                     }
                     else if ( is4_2.inRange( idx ) )
                     {
-                        EXPECT_EQ( 2.0, host_data_4d( i, j, k, l ) );
+                        EXPECT_DOUBLE_EQ( 2.0, host_data_4d( i, j, k, l ) );
                     }
                     else
                     {
-                        EXPECT_EQ( 0.0, host_data_4d( i, j, k, l ) );
+                        EXPECT_DOUBLE_EQ( 0.0, host_data_4d( i, j, k, l ) );
                     }
                 }
 }

--- a/cajita/unit_test/tstSplines.hpp
+++ b/cajita/unit_test/tstSplines.hpp
@@ -36,7 +36,7 @@ TEST( cajita_splines, zero_spline_test )
     double sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = 2.1789;
     x0 = Spline<0>::mapToLogicalGrid( xp, rdx, low_x );
@@ -44,7 +44,7 @@ TEST( cajita_splines, zero_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = low_x + 5 * dx;
     x0 = Spline<0>::mapToLogicalGrid( xp, rdx, low_x );
@@ -52,7 +52,7 @@ TEST( cajita_splines, zero_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     // Check the stencil by putting a point in the center of a dual cell (on a
     // node).
@@ -73,12 +73,12 @@ TEST( cajita_splines, zero_spline_test )
     field[0] = grid_func( low_x + node_id * dx );
     Spline<0>::value( x0, values );
     double field_xp = field[0] * values[0];
-    EXPECT_FLOAT_EQ( field_xp, field[0] );
+    EXPECT_DOUBLE_EQ( field_xp, field[0] );
 
     // Check the derivative of a function.
     Spline<0>::gradient( x0, rdx, values );
     double field_grad = field[0] * values[0];
-    EXPECT_FLOAT_EQ( field_grad, 0.0 );
+    EXPECT_DOUBLE_EQ( field_grad, 0.0 );
 }
 
 TEST( cajita_splines, linear_spline_test )
@@ -95,7 +95,7 @@ TEST( cajita_splines, linear_spline_test )
     double sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = 2.1789;
     x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
@@ -103,7 +103,7 @@ TEST( cajita_splines, linear_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = low_x + 5 * dx;
     x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
@@ -111,7 +111,7 @@ TEST( cajita_splines, linear_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     // Check the stencil by putting a point in the center of a primal cell.
     int cell_id = 4;
@@ -157,7 +157,7 @@ TEST( cajita_splines, quadratic_spline_test )
     double sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = 2.1789;
     x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
@@ -165,7 +165,7 @@ TEST( cajita_splines, quadratic_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = low_x + 5 * dx;
     x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
@@ -173,7 +173,7 @@ TEST( cajita_splines, quadratic_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     // Check the stencil by putting a point in the center of a dual cell (on a
     // node).
@@ -201,14 +201,14 @@ TEST( cajita_splines, quadratic_spline_test )
     Spline<2>::value( x0, values );
     double field_xp =
         field[0] * values[0] + field[1] * values[1] + field[2] * values[2];
-    EXPECT_FLOAT_EQ( field_xp, grid_func( xp ) );
+    EXPECT_DOUBLE_EQ( field_xp, grid_func( xp ) );
 
     // Check the derivative of a function.
     Spline<2>::gradient( x0, rdx, values );
     double field_grad =
         field[0] * values[0] + field[1] * values[1] + field[2] * values[2];
     auto grid_deriv = [=]( const double ) { return 4.32; };
-    EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
+    EXPECT_DOUBLE_EQ( field_grad, grid_deriv( xp ) );
 }
 
 TEST( cajita_splines, cubic_spline_test )
@@ -225,7 +225,7 @@ TEST( cajita_splines, cubic_spline_test )
     double sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = 2.1789;
     x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
@@ -233,7 +233,7 @@ TEST( cajita_splines, cubic_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     xp = low_x + 5 * dx;
     x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
@@ -241,7 +241,7 @@ TEST( cajita_splines, cubic_spline_test )
     sum = 0.0;
     for ( auto x : values )
         sum += x;
-    EXPECT_FLOAT_EQ( sum, 1.0 );
+    EXPECT_DOUBLE_EQ( sum, 1.0 );
 
     // Check the stencil by putting a point in the center of a primal cell.
     int cell_id = 4;
@@ -271,14 +271,14 @@ TEST( cajita_splines, cubic_spline_test )
     Spline<3>::value( x0, values );
     double field_xp = field[0] * values[0] + field[1] * values[1] +
                       field[2] * values[2] + field[3] * values[3];
-    EXPECT_FLOAT_EQ( field_xp, grid_func( xp ) );
+    EXPECT_DOUBLE_EQ( field_xp, grid_func( xp ) );
 
     // Check the derivative of a function.
     Spline<3>::gradient( x0, rdx, values );
     double field_grad = field[0] * values[0] + field[1] * values[1] +
                         field[2] * values[2] + field[3] * values[3];
     auto grid_deriv = [=]( const double ) { return 4.32; };
-    EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
+    EXPECT_DOUBLE_EQ( field_grad, grid_deriv( xp ) );
 }
 
 } // end namespace Test

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -41,19 +41,20 @@ void checkDataMembers( aosoa_type aosoa, const float fval, const double dval,
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
                 for ( int k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( slice_0( idx, i, j, k ), fval * ( i + j + k ) );
+                    EXPECT_FLOAT_EQ( slice_0( idx, i, j, k ),
+                                     fval * ( i + j + k ) );
 
         // Member 1.
         EXPECT_EQ( slice_1( idx ), ival );
 
         // Member 2.
         for ( int i = 0; i < dim_1; ++i )
-            EXPECT_EQ( slice_2( idx, i ), dval * i );
+            EXPECT_DOUBLE_EQ( slice_2( idx, i ), dval * i );
 
         // Member 3.
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
-                EXPECT_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
+                EXPECT_DOUBLE_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
     }
 }
 
@@ -325,16 +326,16 @@ void testRawData()
         int s = Cabana::Impl::Index<16>::s( idx );
         int a = Cabana::Impl::Index<16>::a( idx );
 
-        EXPECT_EQ( mirror_slice_0( idx ), ( s + a ) * 1.0 );
+        EXPECT_FLOAT_EQ( mirror_slice_0( idx ), ( s + a ) * 1.0 );
         EXPECT_EQ( mirror_slice_1( idx ), int( ( s + a ) * 2 ) );
         EXPECT_EQ( mirror_slice_3( idx ), int( ( s + a ) * 4 ) );
-        EXPECT_EQ( mirror_slice_4( idx ), ( s + a ) * 5.0 );
+        EXPECT_DOUBLE_EQ( mirror_slice_4( idx ), ( s + a ) * 5.0 );
 
         // Member 2 has some extra dimensions so check those too.
         for ( int j = 0; j < dim_1; ++j )
             for ( int k = 0; k < dim_2; ++k )
-                EXPECT_EQ( mirror_slice_2( idx, j, k ),
-                           ( s + a + j + k ) * 3.0 );
+                EXPECT_DOUBLE_EQ( mirror_slice_2( idx, j, k ),
+                                  ( s + a + j + k ) * 3.0 );
     }
 }
 

--- a/core/unit_test/tstDeepCopy.hpp
+++ b/core/unit_test/tstDeepCopy.hpp
@@ -39,19 +39,20 @@ void checkDataMembers( aosoa_type aosoa, const float fval, const double dval,
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
                 for ( int k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( slice_0( idx, i, j, k ), fval * ( i + j + k ) );
+                    EXPECT_FLOAT_EQ( slice_0( idx, i, j, k ),
+                                     fval * ( i + j + k ) );
 
         // Member 1.
         EXPECT_EQ( slice_1( idx ), ival );
 
         // Member 2.
         for ( int i = 0; i < dim_1; ++i )
-            EXPECT_EQ( slice_2( idx, i ), dval * i );
+            EXPECT_DOUBLE_EQ( slice_2( idx, i ), dval * i );
 
         // Member 3.
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
-                EXPECT_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
+                EXPECT_DOUBLE_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
     }
 }
 

--- a/core/unit_test/tstDistributor.hpp
+++ b/core/unit_test/tstDistributor.hpp
@@ -89,9 +89,10 @@ void test1( const bool use_topology )
     for ( int i = 0; i < num_data; ++i )
     {
         EXPECT_EQ( slice_int_dst_host( i ), my_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_dst_host( i, 0 ), my_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_dst_host( i, 1 ),
-                   my_rank + host_steering( i ) + 0.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_dst_host( i, 0 ),
+                          my_rank + host_steering( i ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_dst_host( i, 1 ),
+                          my_rank + host_steering( i ) + 0.5 );
     }
 }
 
@@ -161,8 +162,10 @@ void test2( const bool use_topology )
     for ( int i = 0; i < num_data / 2; ++i )
     {
         EXPECT_EQ( slice_int_host( i ), my_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + host_steering( i ) + 0.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ),
+                          my_rank + host_steering( i ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ),
+                          my_rank + host_steering( i ) + 0.5 );
     }
 }
 
@@ -251,10 +254,10 @@ void test3( const bool use_topology )
     for ( int i = 0; i < num_data; ++i )
     {
         EXPECT_EQ( slice_int_dst_host( i ), inverse_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_dst_host( i, 0 ),
-                   inverse_rank + host_steering( i ) );
-        EXPECT_EQ( slice_dbl_dst_host( i, 1 ),
-                   inverse_rank + host_steering( i ) + 0.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_dst_host( i, 0 ),
+                          inverse_rank + host_steering( i ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_dst_host( i, 1 ),
+                          inverse_rank + host_steering( i ) + 0.5 );
     }
 }
 
@@ -329,12 +332,12 @@ void test4( const bool use_topology )
 
     // self sends
     EXPECT_EQ( slice_int_dst_host( 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_dst_host( 0, 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_dst_host( 0, 1 ), my_rank + 0.5 );
+    EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 0, 0 ), my_rank );
+    EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 0, 1 ), my_rank + 0.5 );
 
     EXPECT_EQ( slice_int_dst_host( 1 ), my_rank );
-    EXPECT_EQ( slice_dbl_dst_host( 1, 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_dst_host( 1, 1 ), my_rank + 0.5 );
+    EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 1, 0 ), my_rank );
+    EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 1, 1 ), my_rank + 0.5 );
 
     // others
     for ( int i = 1; i < my_size; ++i )
@@ -342,22 +345,22 @@ void test4( const bool use_topology )
         if ( i == my_rank )
         {
             EXPECT_EQ( slice_int_dst_host( 2 * i ), 0 );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i, 0 ), 0 );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i, 1 ), 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i, 0 ), 0 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i, 1 ), 0.5 );
 
             EXPECT_EQ( slice_int_dst_host( 2 * i + 1 ), 0 );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i + 1, 0 ), 0 );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i + 1, 1 ), 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i + 1, 0 ), 0 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i + 1, 1 ), 0.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_dst_host( 2 * i ), i );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i, 0 ), i );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i, 1 ), i + 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i, 0 ), i );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i, 1 ), i + 0.5 );
 
             EXPECT_EQ( slice_int_dst_host( 2 * i + 1 ), i );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i + 1, 0 ), i );
-            EXPECT_EQ( slice_dbl_dst_host( 2 * i + 1, 1 ), i + 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i + 1, 0 ), i );
+            EXPECT_DOUBLE_EQ( slice_dbl_dst_host( 2 * i + 1, 1 ), i + 0.5 );
         }
     }
 }
@@ -435,8 +438,8 @@ void test5( const bool use_topology )
 
     // self sends
     EXPECT_EQ( slice_int_host( 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_host( 0, 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_host( 0, 1 ), my_rank + 0.5 );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 0 ), my_rank );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 1 ), my_rank + 0.5 );
 
     // others
     for ( int i = 1; i < my_size; ++i )
@@ -444,14 +447,14 @@ void test5( const bool use_topology )
         if ( i == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 0 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 0 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 0 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 0.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), i );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), i );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), i + 0.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), i );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), i + 0.5 );
         }
     }
 }
@@ -532,9 +535,10 @@ void test6( const bool use_topology )
     for ( std::size_t i = 0; i < distributor->totalNumImport(); ++i )
     {
         EXPECT_EQ( slice_int_host( i ), distributor->neighborRank( i ) );
-        EXPECT_EQ( slice_dbl_host( i, 0 ), distributor->neighborRank( i ) );
-        EXPECT_EQ( slice_dbl_host( i, 1 ),
-                   distributor->neighborRank( i ) + 0.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ),
+                          distributor->neighborRank( i ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ),
+                          distributor->neighborRank( i ) + 0.5 );
     }
 }
 
@@ -608,8 +612,8 @@ void test7( const bool use_topology )
     auto slice_dbl_host = Cabana::slice<1>( data_host );
     Cabana::deep_copy( data_host, data );
     EXPECT_EQ( slice_int_host( 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_host( 0, 0 ), my_rank );
-    EXPECT_EQ( slice_dbl_host( 0, 1 ), my_rank + 0.5 );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 0 ), my_rank );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 1 ), my_rank + 0.5 );
 }
 
 //---------------------------------------------------------------------------//
@@ -691,8 +695,8 @@ void test8( const bool use_topology )
     for ( unsigned i = 0; i < data.size(); ++i )
     {
         EXPECT_EQ( slice_int_host( i ), my_rank );
-        EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank );
-        EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + 1 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), my_rank );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), my_rank + 1 );
     }
 }
 

--- a/core/unit_test/tstHalo.hpp
+++ b/core/unit_test/tstHalo.hpp
@@ -105,12 +105,12 @@ void test1( const bool use_topology )
     for ( int i = 0; i < my_size; ++i )
     {
         EXPECT_EQ( slice_int_host( 2 * i ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
 
         EXPECT_EQ( slice_int_host( 2 * i + 1 ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 0 ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 1 ), my_rank + 1.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 0 ), my_rank + 1 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 1 ), my_rank + 1.5 );
     }
 
     // Check that we got one element from everyone.
@@ -121,20 +121,20 @@ void test1( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 1.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
         }
     }
 
@@ -149,12 +149,13 @@ void test1( const bool use_topology )
     for ( int i = 0; i < my_size; ++i )
     {
         EXPECT_EQ( slice_int_host( 2 * i ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
 
         EXPECT_EQ( slice_int_host( 2 * i + 1 ), 2 * ( my_rank + 1 ) );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 0 ), 2 * ( my_rank + 1 ) );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 1 ), 2 * ( my_rank + 1.5 ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 0 ), 2 * ( my_rank + 1 ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 1 ),
+                          2 * ( my_rank + 1.5 ) );
     }
 
     // Check that the ghost data didn't change.
@@ -165,20 +166,20 @@ void test1( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 1.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
         }
     }
 
@@ -191,12 +192,13 @@ void test1( const bool use_topology )
     for ( int i = 0; i < my_size; ++i )
     {
         EXPECT_EQ( slice_int_host( 2 * i ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
-        EXPECT_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 0 ), my_rank + 1 );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i, 1 ), my_rank + 1.5 );
 
         EXPECT_EQ( slice_int_host( 2 * i + 1 ), 2 * ( my_rank + 1 ) );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 0 ), 2 * ( my_rank + 1 ) );
-        EXPECT_EQ( slice_dbl_host( 2 * i + 1, 1 ), 2 * ( my_rank + 1.5 ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 0 ), 2 * ( my_rank + 1 ) );
+        EXPECT_DOUBLE_EQ( slice_dbl_host( 2 * i + 1, 1 ),
+                          2 * ( my_rank + 1.5 ) );
     }
 
     // Check that the ghost data was updated.
@@ -207,20 +209,20 @@ void test1( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), 2 * ( my_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 2 * ( my_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 2 * ( my_rank + 1.5 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 2 * ( my_rank + 1 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 2 * ( my_rank + 1.5 ) );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 2 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 2 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 3 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 2 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 3 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), 2 * ( send_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 2 * ( send_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 2 * ( send_rank + 1.5 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 2 * ( send_rank + 1 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 2 * ( send_rank + 1.5 ) );
         }
     }
 }
@@ -300,8 +302,8 @@ void test2( const bool use_topology )
 
     // check that the local data didn't change.
     EXPECT_EQ( slice_int_host( 0 ), my_rank + 1 );
-    EXPECT_EQ( slice_dbl_host( 0, 0 ), my_rank + 1 );
-    EXPECT_EQ( slice_dbl_host( 0, 1 ), my_rank + 1.5 );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 0 ), my_rank + 1 );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 1 ), my_rank + 1.5 );
 
     // Check that we got one element from everyone.
     for ( int i = num_local; i < num_local + my_size; ++i )
@@ -311,20 +313,20 @@ void test2( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 1.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
         }
     }
 
@@ -336,8 +338,10 @@ void test2( const bool use_topology )
     // Check that the local data was updated. Every ghost was sent to all of
     // the ranks so the result should be multiplied by the number of ranks.
     EXPECT_EQ( slice_int_host( 0 ), ( my_size + 1 ) * ( my_rank + 1 ) );
-    EXPECT_EQ( slice_dbl_host( 0, 0 ), ( my_size + 1 ) * ( my_rank + 1 ) );
-    EXPECT_EQ( slice_dbl_host( 0, 1 ), ( my_size + 1 ) * ( my_rank + 1.5 ) );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 0 ),
+                      ( my_size + 1 ) * ( my_rank + 1 ) );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 1 ),
+                      ( my_size + 1 ) * ( my_rank + 1.5 ) );
 
     // Check that the ghost data didn't change.
     for ( int i = num_local; i < num_local + my_size; ++i )
@@ -347,20 +351,20 @@ void test2( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), my_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), my_rank + 1.5 );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), 1.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), send_rank + 1 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), send_rank + 1.5 );
         }
     }
 
@@ -371,8 +375,10 @@ void test2( const bool use_topology )
 
     // Check that the local data remained unchanged.
     EXPECT_EQ( slice_int_host( 0 ), ( my_size + 1 ) * ( my_rank + 1 ) );
-    EXPECT_EQ( slice_dbl_host( 0, 0 ), ( my_size + 1 ) * ( my_rank + 1 ) );
-    EXPECT_EQ( slice_dbl_host( 0, 1 ), ( my_size + 1 ) * ( my_rank + 1.5 ) );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 0 ),
+                      ( my_size + 1 ) * ( my_rank + 1 ) );
+    EXPECT_DOUBLE_EQ( slice_dbl_host( 0, 1 ),
+                      ( my_size + 1 ) * ( my_rank + 1.5 ) );
 
     // Check that the ghost data was updated.
     for ( int i = num_local; i < num_local + my_size; ++i )
@@ -382,25 +388,25 @@ void test2( const bool use_topology )
         if ( send_rank == 0 )
         {
             EXPECT_EQ( slice_int_host( i ), ( my_size + 1 ) * ( my_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 0 ),
-                       ( my_size + 1 ) * ( my_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 1 ),
-                       ( my_size + 1 ) * ( my_rank + 1.5 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ),
+                              ( my_size + 1 ) * ( my_rank + 1 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ),
+                              ( my_size + 1 ) * ( my_rank + 1.5 ) );
         }
         else if ( send_rank == my_rank )
         {
             EXPECT_EQ( slice_int_host( i ), ( my_size + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 0 ), ( my_size + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 1 ), ( my_size + 1 ) * 1.5 );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ), ( my_size + 1 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ), ( my_size + 1 ) * 1.5 );
         }
         else
         {
             EXPECT_EQ( slice_int_host( i ),
                        ( my_size + 1 ) * ( send_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 0 ),
-                       ( my_size + 1 ) * ( send_rank + 1 ) );
-            EXPECT_EQ( slice_dbl_host( i, 1 ),
-                       ( my_size + 1 ) * ( send_rank + 1.5 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 0 ),
+                              ( my_size + 1 ) * ( send_rank + 1 ) );
+            EXPECT_DOUBLE_EQ( slice_dbl_host( i, 1 ),
+                              ( my_size + 1 ) * ( send_rank + 1.5 ) );
         }
     }
 }

--- a/core/unit_test/tstParallel.hpp
+++ b/core/unit_test/tstParallel.hpp
@@ -40,19 +40,20 @@ void checkDataMembers( aosoa_type aosoa, int begin, int end, const float fval,
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
                 for ( int k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( slice_0( idx, i, j, k ), fval * ( i + j + k ) );
+                    EXPECT_FLOAT_EQ( slice_0( idx, i, j, k ),
+                                     fval * ( i + j + k ) );
 
         // Member 1.
         EXPECT_EQ( slice_1( idx ), ival );
 
         // Member 2.
         for ( int i = 0; i < dim_1; ++i )
-            EXPECT_EQ( slice_2( idx, i ), dval * i );
+            EXPECT_DOUBLE_EQ( slice_2( idx, i ), dval * i );
 
         // Member 3.
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
-                EXPECT_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
+                EXPECT_DOUBLE_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
     }
 }
 

--- a/core/unit_test/tstParameterPack.hpp
+++ b/core/unit_test/tstParameterPack.hpp
@@ -45,7 +45,7 @@ void captureTest()
     auto int_host =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), int_view );
 
-    EXPECT_EQ( dbl_host( 0 ), 3.14 );
+    EXPECT_DOUBLE_EQ( dbl_host( 0 ), 3.14 );
     EXPECT_EQ( int_host( 0, 0 ), 12 );
 }
 

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -75,19 +75,20 @@ void checkDataMembers( aosoa_type aosoa, const float fval, const double dval,
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
                 for ( int k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( slice_0( idx, i, j, k ), fval * ( i + j + k ) );
+                    EXPECT_FLOAT_EQ( slice_0( idx, i, j, k ),
+                                     fval * ( i + j + k ) );
 
         // Member 1.
         EXPECT_EQ( slice_1( idx ), ival );
 
         // Member 2.
         for ( int i = 0; i < dim_1; ++i )
-            EXPECT_EQ( slice_2( idx, i ), dval * i );
+            EXPECT_DOUBLE_EQ( slice_2( idx, i ), dval * i );
 
         // Member 3.
         for ( int i = 0; i < dim_1; ++i )
             for ( int j = 0; j < dim_2; ++j )
-                EXPECT_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
+                EXPECT_DOUBLE_EQ( slice_3( idx, i, j ), dval * ( i + j ) );
     }
 }
 

--- a/core/unit_test/tstSoA.cpp
+++ b/core/unit_test/tstSoA.cpp
@@ -64,8 +64,8 @@ void testSoA()
     Cabana::get<5>( soa, 2, 1, 1, 1 ) = v2;
 
     // Check the data.
-    EXPECT_EQ( Cabana::get<0>( soa, 3 ), v1 );
-    EXPECT_EQ( Cabana::get<5>( soa, 2, 1, 1, 1 ), v2 );
+    EXPECT_DOUBLE_EQ( Cabana::get<0>( soa, 3 ), v1 );
+    EXPECT_FLOAT_EQ( Cabana::get<5>( soa, 2, 1, 1, 1 ), v2 );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstTuple.hpp
+++ b/core/unit_test/tstTuple.hpp
@@ -34,21 +34,23 @@ void checkDataMembers( view_type view, const float fval, const double dval,
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
                 for ( std::size_t k = 0; k < dim_3; ++k )
-                    EXPECT_EQ( Cabana::get<0>( mirror_view( idx ), i, j, k ),
-                               fval * ( i + j + k ) );
+                    EXPECT_FLOAT_EQ(
+                        Cabana::get<0>( mirror_view( idx ), i, j, k ),
+                        fval * ( i + j + k ) );
 
         // Member 1.
         EXPECT_EQ( Cabana::get<1>( mirror_view( idx ) ), ival );
 
         // Member 2.
         for ( std::size_t i = 0; i < dim_1; ++i )
-            EXPECT_EQ( Cabana::get<2>( mirror_view( idx ), i ), dval * i );
+            EXPECT_DOUBLE_EQ( Cabana::get<2>( mirror_view( idx ), i ),
+                              dval * i );
 
         // Member 3.
         for ( std::size_t i = 0; i < dim_1; ++i )
             for ( std::size_t j = 0; j < dim_2; ++j )
-                EXPECT_EQ( Cabana::get<3>( mirror_view( idx ), i, j ),
-                           dval * ( i + j ) );
+                EXPECT_DOUBLE_EQ( Cabana::get<3>( mirror_view( idx ), i, j ),
+                                  dval * ( i + j ) );
     }
 }
 


### PR DESCRIPTION
Fixes #398 by switching `Array` from `EXPECT_EQ` to `EXPECT_DOUBLE_EQ`

- Converts a lot of other checks to the correct type, but leaves some double checks as `EXPECT_FLOAT_EQ` for a lower error threshold (failures otherwise, e.g. in the neighbor list tests)
- Removes workarounds for previous long logs from isolated CI failures