### PR TITLE
Do not use `Kokkos::Impl::{Cuda,HIP}Traits::WarpSize`

### DIFF
--- a/core/src/impl/Cabana_PerformanceTraits.hpp
+++ b/core/src/impl/Cabana_PerformanceTraits.hpp
@@ -71,7 +71,7 @@ template <>
 class PerformanceTraits<Kokkos::Cuda>
 {
   public:
-    static constexpr int vector_length = Kokkos::Impl::CudaTraits::WarpSize;
+    static constexpr int vector_length = 32; // warp size
 };
 #endif
 
@@ -81,8 +81,7 @@ template <>
 class PerformanceTraits<Kokkos::Experimental::HIP>
 {
   public:
-    static constexpr int vector_length =
-        Kokkos::Experimental::Impl::HIPTraits::WarpSize;
+    static constexpr int vector_length = 64; // wavefront size
 };
 #endif
 


### PR DESCRIPTION
Partial fix for #474 
Inline the definition instead of using Kokkos internals.
The warp size is 32 for all existing compute capability (see [CUDA toolkit documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications))
The wavefront size is 64 on AMD GPUs (see [AMD GPU Hardware Basics](https://www.olcf.ornl.gov/wp-content/uploads/2019/10/ORNL_Application_Readiness_Workshop-AMD_GPU_Basics.pdf))