### PR TITLE
Move random particle init to core

### DIFF
--- a/benchmark/Cabana_LinkedCellPerformance.cpp
+++ b/benchmark/Cabana_LinkedCellPerformance.cpp
@@ -46,23 +46,20 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
     using aosoa_type = Cabana::AoSoA<member_types, Device>;
-    using aosoa_host_type = Cabana::AoSoA<member_types, Kokkos::HostSpace>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
     for ( int p = 0; p < num_problem_size; ++p )
     {
         int num_p = problem_sizes[p];
-        aosoa_host_type create_aosoa( "host_aosoa", num_p );
 
         // Define problem grid.
         x_min[p] = 0.0;
         x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
-        auto x = Cabana::slice<0>( create_aosoa, "position" );
-        Cabana::Benchmark::createRandomNeighbors( x, x_min[p], x_max[p],
-                                                  min_dist );
-        Cabana::deep_copy( aosoas[p], create_aosoa );
+        auto x = Cabana::slice<0>( aosoas[p], "position" );
+        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
+                                                  x_max[p], min_dist );
     }
 
     // Loop over number of ratios (neighbors per particle).

--- a/benchmark/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/Cabana_NeighborArborXPerformance.cpp
@@ -53,23 +53,20 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
     using aosoa_type = Cabana::AoSoA<member_types, Device>;
-    using aosoa_host_type = Cabana::AoSoA<member_types, Kokkos::HostSpace>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
     for ( int p = 0; p < num_problem_size; ++p )
     {
         int num_p = problem_sizes[p];
-        aosoa_host_type create_aosoa( "host_aosoa", num_p );
 
         // Define problem grid.
         x_min[p] = 0.0;
         x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
-        auto x_host = Cabana::slice<0>( create_aosoa, "position" );
-        Cabana::Benchmark::createRandomNeighbors( x_host, x_min[p], x_max[p],
-                                                  min_dist );
-        Cabana::deep_copy( aosoas[p], create_aosoa );
+        auto x = Cabana::slice<0>( aosoas[p], "position" );
+        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
+                                                  x_max[p], min_dist );
 
         if ( sort )
         {

--- a/benchmark/Cabana_NeighborVerletPerformance.cpp
+++ b/benchmark/Cabana_NeighborVerletPerformance.cpp
@@ -59,23 +59,20 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
     using aosoa_type = Cabana::AoSoA<member_types, Device>;
-    using aosoa_host_type = Cabana::AoSoA<member_types, Kokkos::HostSpace>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
     for ( int p = 0; p < num_problem_size; ++p )
     {
         int num_p = problem_sizes[p];
-        aosoa_host_type create_aosoa( "host_aosoa", num_p );
 
         // Define problem grid.
         x_min[p] = 0.0;
         x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
-        auto x_host = Cabana::slice<0>( create_aosoa, "position" );
-        Cabana::Benchmark::createRandomNeighbors( x_host, x_min[p], x_max[p],
-                                                  min_dist );
-        Cabana::deep_copy( aosoas[p], create_aosoa );
+        auto x = Cabana::slice<0>( aosoas[p], "position" );
+        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
+                                                  x_max[p], min_dist );
 
         if ( sort )
         {
@@ -87,7 +84,6 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };
-            auto x = Cabana::slice<0>( aosoas[p], "position" );
             Cabana::LinkedCellList<Device> linked_cell_list(
                 x, sort_delta, grid_min, grid_max );
             Cabana::permute( linked_cell_list, aosoas[p] );

--- a/benchmark/Cajita_SparseMapPerformance.cpp
+++ b/benchmark/Cajita_SparseMapPerformance.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include "Cabana_BenchmarkUtils.hpp"
+#include "Cabana_ParticleInit.hpp"
 
 #include <Cajita_SparseIndexSpace.hpp>
 
@@ -45,20 +46,16 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     int num_cells_per_dim_size = num_cells_per_dim.size();
 
     // Create random sets of particle positions.
-    using data_layout = typename exec_space::array_layout;
-    using position_type_host =
-        Kokkos::View<float* [3], data_layout, Kokkos::HostSpace>;
     using position_type = Kokkos::View<float* [3], memory_space>;
     std::vector<position_type> positions( num_problem_size );
     for ( int p = 0; p < num_problem_size; ++p )
     {
-        position_type_host pos(
+        positions[p] = position_type(
             Kokkos::ViewAllocateWithoutInitializing( "positions" ),
             problem_sizes[p] );
-        Cabana::Benchmark::createRandomParticles( pos, global_low_corner[0],
-                                                  global_high_corner[0] );
-        positions[p] =
-            Kokkos::create_mirror_view_and_copy( memory_space(), pos );
+        Cabana::createRandomParticles( positions[p], problem_sizes[p],
+                                       global_low_corner[0],
+                                       global_high_corner[0] );
     }
     // Number of runs in the test loops.
     int num_run = 10;

--- a/benchmark/Cajita_SparsePartitionerPerformance.cpp
+++ b/benchmark/Cajita_SparsePartitionerPerformance.cpp
@@ -10,6 +10,7 @@
  ****************************************************************************/
 
 #include "Cabana_BenchmarkUtils.hpp"
+#include "Cabana_ParticleInit.hpp"
 
 #include <Cajita_SparseDimPartitioner.hpp>
 #include <Cajita_SparseIndexSpace.hpp>
@@ -85,7 +86,6 @@ void performanceTest( ParticleWorkloadTag, std::ostream& stream, MPI_Comm comm,
                       std::vector<int> problem_sizes,
                       std::vector<int> num_cells_per_dim )
 {
-    using exec_space = typename Device::execution_space;
     using memory_space = typename Device::memory_space;
 
     // Get comm rank;
@@ -121,20 +121,16 @@ void performanceTest( ParticleWorkloadTag, std::ostream& stream, MPI_Comm comm,
                       ( problem_sizes.back() % comm_size < comm_rank ? 1 : 0 );
 
     // Create random sets of particle positions.
-    using data_layout = typename exec_space::array_layout;
-    using position_type_host =
-        Kokkos::View<float* [3], data_layout, Kokkos::HostSpace>;
     using position_type = Kokkos::View<float* [3], memory_space>;
     std::vector<position_type> positions( num_problem_size );
     for ( int p = 0; p < num_problem_size; ++p )
     {
-        position_type_host pos(
+        positions[p] = position_type(
             Kokkos::ViewAllocateWithoutInitializing( "positions" ),
             problem_sizes[p] );
-        Cabana::Benchmark::createRandomParticles( pos, global_low_corner[0],
-                                                  global_high_corner[0] );
-        positions[p] =
-            Kokkos::create_mirror_view_and_copy( memory_space(), pos );
+        Cabana::createRandomParticles( positions[p], problem_sizes[p],
+                                       global_low_corner[0],
+                                       global_high_corner[0] );
     }
 
     for ( int c = 0; c < num_cells_per_dim_size; ++c )

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADERS_PUBLIC
   Cabana_NeighborList.hpp
   Cabana_Parallel.hpp
   Cabana_ParameterPack.hpp
+  Cabana_ParticleInit.hpp
   Cabana_Slice.hpp
   Cabana_SoA.hpp
   Cabana_Sort.hpp

--- a/core/src/Cabana_Core.hpp
+++ b/core/src/Cabana_Core.hpp
@@ -25,6 +25,7 @@
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_Parallel.hpp>
 #include <Cabana_ParameterPack.hpp>
+#include <Cabana_ParticleInit.hpp>
 #include <Cabana_Slice.hpp>
 #include <Cabana_SoA.hpp>
 #include <Cabana_Sort.hpp>

--- a/core/src/Cabana_ParticleInit.hpp
+++ b/core/src/Cabana_ParticleInit.hpp
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+/*!
+  \file Cabana_ParticleInit.hpp
+  \brief Particle creation utilities.
+*/
+#ifndef CABANA_PARTICLEINIT_HPP
+#define CABANA_PARTICLEINIT_HPP
+
+#include <Kokkos_Random.hpp>
+
+#include <random>
+#include <type_traits>
+
+namespace Cabana
+{
+
+//! Generate random particles with minimum distance between neighbors. This
+// approximates many physical scenarios, e.g. atomic simulations. Kokkos
+// device version.
+template <class PositionType>
+void createRandomParticlesMinDistance( PositionType& positions,
+                                       const std::size_t num_particles,
+                                       const double box_min,
+                                       const double box_max,
+                                       const double min_dist )
+{
+    using exec_space = typename PositionType::execution_space;
+
+    double min_dist_sqr = min_dist * min_dist;
+
+    using PoolType = Kokkos::Random_XorShift64_Pool<exec_space>;
+    using RandomType = Kokkos::Random_XorShift64<exec_space>;
+    PoolType pool( 342343901 );
+    auto random_coord_op = KOKKOS_LAMBDA( const int p )
+    {
+        auto gen = pool.get_state();
+
+        // Create particles. Only add particles that are outside a minimum
+        // distance from other particles.
+        bool found_neighbor = true;
+
+        // Keep trying new random coordinates until we insert one that is
+        // not within the minimum distance of any other particle.
+        while ( found_neighbor )
+        {
+            found_neighbor = false;
+
+            for ( int d = 0; d < 3; ++d )
+                positions( p, d ) = Kokkos::rand<RandomType, double>::draw(
+                    gen, box_min, box_max );
+
+            for ( int n = 0; n < p; n++ )
+            {
+                double dx = positions( n, 0 ) - positions( p, 0 );
+                double dy = positions( n, 1 ) - positions( p, 1 );
+                double dz = positions( n, 2 ) - positions( p, 2 );
+                double dist = dx * dx + dy * dy + dz * dz;
+                if ( dist < min_dist_sqr )
+                {
+                    found_neighbor = true;
+                    break;
+                }
+            }
+            pool.free_state( gen );
+        }
+    };
+    Kokkos::RangePolicy<exec_space> exec_policy( 0, num_particles );
+    Kokkos::parallel_for( exec_policy, random_coord_op );
+    Kokkos::fence();
+}
+
+//! Generate random particles with minimum distance between neighbors. This
+// approximates many physical scenarios, e.g. atomic simulations. Non-Kokkos
+// host version.
+template <class PositionType>
+void createRandomParticlesMinDistanceHost( PositionType& positions,
+                                           const std::size_t num_particles,
+                                           const double box_min,
+                                           const double box_max,
+                                           const double min_dist )
+{
+    using memory_space = typename PositionType::memory_space;
+    static_assert( std::is_same<memory_space, Kokkos::HostSpace>::value,
+                   "Must use host space." );
+
+    double min_dist_sqr = min_dist * min_dist;
+    std::default_random_engine rand_gen;
+    std::uniform_real_distribution<double> rand_dist( box_min, box_max );
+
+    // Seed the distribution with a particle at the origin.
+    positions( 0, 0 ) = ( box_max - box_min ) / 2.0;
+    positions( 0, 1 ) = ( box_max - box_min ) / 2.0;
+    positions( 0, 2 ) = ( box_max - box_min ) / 2.0;
+
+    // Create particles. Only add particles that are outside a minimum
+    // distance from other particles.
+    for ( std::size_t p = 0; p < num_particles; ++p )
+    {
+        bool found_neighbor = true;
+
+        // Keep trying new random coordinates until we insert one that is
+        // not within the minimum distance of any other particle.
+        while ( found_neighbor )
+        {
+            found_neighbor = false;
+
+            // Create particle coordinates.
+            positions( p, 0 ) = rand_dist( rand_gen );
+            positions( p, 1 ) = rand_dist( rand_gen );
+            positions( p, 2 ) = rand_dist( rand_gen );
+
+            for ( std::size_t n = 0; n < p; n++ )
+            {
+                double dx = positions( n, 0 ) - positions( p, 0 );
+                double dy = positions( n, 1 ) - positions( p, 1 );
+                double dz = positions( n, 2 ) - positions( p, 2 );
+                double dist = dx * dx + dy * dy + dz * dz;
+                if ( dist < min_dist_sqr )
+                {
+                    found_neighbor = true;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+//! Generate random particles. Kokkos device version.
+template <class PositionType>
+void createRandomParticles( PositionType& positions,
+                            const std::size_t num_particles,
+                            const double box_min, const double box_max )
+{
+    using exec_space = typename PositionType::execution_space;
+
+    using PoolType = Kokkos::Random_XorShift64_Pool<exec_space>;
+    using RandomType = Kokkos::Random_XorShift64<exec_space>;
+    PoolType pool( 342343901 );
+    auto random_coord_op = KOKKOS_LAMBDA( const int p )
+    {
+        auto gen = pool.get_state();
+        for ( int d = 0; d < 3; ++d )
+            positions( p, d ) =
+                Kokkos::rand<RandomType, double>::draw( gen, box_min, box_max );
+        pool.free_state( gen );
+    };
+    Kokkos::RangePolicy<exec_space> exec_policy( 0, num_particles );
+    Kokkos::parallel_for( exec_policy, random_coord_op );
+    Kokkos::fence();
+}
+
+//---------------------------------------------------------------------------//
+//! Generate random particles. Non-Kokkos host version.
+template <typename PositionType>
+void createRandomParticlesHost( PositionType& positions,
+                                const std::size_t num_particles,
+                                const double box_min, const double box_max )
+{
+    using memory_space = typename PositionType::memory_space;
+    static_assert( std::is_same<memory_space, Kokkos::HostSpace>::value,
+                   "Must use host space." );
+
+    using value_type = typename PositionType::value_type;
+
+    // compute position range
+    value_type box_range = box_max - box_min;
+
+    // compute generator range
+    std::minstd_rand0 generator( 3439203991 );
+    value_type generator_range =
+        static_cast<value_type>( generator.max() - generator.min() );
+
+    // generate random particles
+    for ( std::size_t n = 0; n < num_particles; ++n )
+        for ( std::size_t d = 0; d < 3; ++d )
+            positions( n, d ) =
+                ( static_cast<value_type>( ( generator() - generator.min() ) ) *
+                  box_range / generator_range ) +
+                box_min;
+}
+
+} // namespace Cabana
+
+#endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SERIAL_TESTS
   NeighborList
   Parallel
   ParameterPack
+  ParticleInit
   Slice
   Sort
   Tuple

--- a/core/unit_test/neighbor_unit_test.hpp
+++ b/core/unit_test/neighbor_unit_test.hpp
@@ -13,13 +13,12 @@
 #include <Cabana_DeepCopy.hpp>
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_Parallel.hpp>
+#include <Cabana_ParticleInit.hpp>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_Random.hpp>
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <vector>
 
 namespace Test
@@ -68,46 +67,6 @@ copyListToHost( const ListType& list, const int num_particle, const int max_n )
         } );
     Kokkos::fence();
     return createTestListHostCopy( list_copy );
-}
-
-//---------------------------------------------------------------------------//
-// Create particles.
-Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE>
-createParticles( const int num_particle, const double box_min,
-                 const double box_max )
-{
-#ifdef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    using RandomMemSpace = Kokkos::HostSpace;
-    using RandomExecSpace = Kokkos::DefaultHostExecutionSpace;
-#else
-    using RandomMemSpace = TEST_MEMSPACE;
-    using RandomExecSpace = TEST_EXECSPACE;
-#endif
-
-    using DataTypes = Cabana::MemberTypes<double[3]>;
-    using AoSoA_t_r = Cabana::AoSoA<DataTypes, RandomMemSpace>;
-    AoSoA_t_r aosoa_random( "random", num_particle );
-
-    auto position = Cabana::slice<0>( aosoa_random );
-    using PoolType = Kokkos::Random_XorShift64_Pool<RandomExecSpace>;
-    using RandomType = Kokkos::Random_XorShift64<RandomExecSpace>;
-    PoolType pool( 342343901 );
-    auto random_coord_op = KOKKOS_LAMBDA( const int p )
-    {
-        auto gen = pool.get_state();
-        for ( int d = 0; d < 3; ++d )
-            position( p, d ) =
-                Kokkos::rand<RandomType, double>::draw( gen, box_min, box_max );
-        pool.free_state( gen );
-    };
-    Kokkos::RangePolicy<RandomExecSpace> exec_policy( 0, num_particle );
-    Kokkos::parallel_for( exec_policy, random_coord_op );
-    Kokkos::fence();
-
-    using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE>;
-    AoSoA_t aosoa( "aosoa", num_particle );
-    Cabana::deep_copy( aosoa, aosoa_random );
-    return aosoa;
 }
 
 //---------------------------------------------------------------------------//
@@ -986,18 +945,35 @@ struct NeighborListTestData
     double grid_min[3] = { box_min, box_min, box_min };
     double grid_max[3] = { box_max, box_max, box_max };
 
-    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE> aosoa;
+    using DataTypes = Cabana::MemberTypes<double[3]>;
+    using AoSoA_t = Cabana::AoSoA<DataTypes, TEST_MEMSPACE>;
+    AoSoA_t aosoa;
+
     TestNeighborList<typename TEST_EXECSPACE::array_layout, Kokkos::HostSpace>
         N2_list_copy;
 
     NeighborListTestData()
     {
         // Create the AoSoA and fill with random particle positions.
-        aosoa = createParticles( num_particle, box_min, box_max );
+        aosoa = AoSoA_t( "random", num_particle );
+
+#ifdef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+        using AoSoA_copy = Cabana::AoSoA<DataTypes, Kokkos::HostSpace>;
+        AoSoA_copy aosoa_copy( "aosoa", num_particle );
+        auto positions = Cabana::slice<0>( aosoa_copy );
+#else
+        auto positions = Cabana::slice<0>( aosoa );
+#endif
+
+        Cabana::createRandomParticles( positions, positions.size(), box_min,
+                                       box_max );
+
+#ifdef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+        Cabana::deep_copy( aosoa, aosoa_copy );
+#endif
 
         // Create a full N^2 neighbor list to check against.
-        auto N2_list =
-            computeFullNeighborList( Cabana::slice<0>( aosoa ), test_radius );
+        auto N2_list = computeFullNeighborList( positions, test_radius );
         N2_list_copy = createTestListHostCopy( N2_list );
     }
 };

--- a/core/unit_test/tstParticleInit.hpp
+++ b/core/unit_test/tstParticleInit.hpp
@@ -74,23 +74,6 @@ void testRandomCreationMinDistance()
     checkRandomDistances( min_dist, host_positions );
 }
 
-void testRandomCreationMinDistanceHost()
-{
-    int num_particle = 2000;
-    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, Kokkos::HostSpace> host_aosoa(
-        "random", num_particle );
-    auto host_positions = Cabana::slice<0>( host_aosoa );
-
-    double min_dist = 0.47;
-    double box_min = -9.5;
-    double box_max = 7.6;
-    Cabana::createRandomParticlesMinDistanceHost(
-        host_positions, host_positions.size(), box_min, box_max, min_dist );
-
-    checkRandomParticles( num_particle, box_min, box_max, host_positions );
-    checkRandomDistances( min_dist, host_positions );
-}
-
 void testRandomCreation()
 {
     int num_particle = 200;
@@ -109,25 +92,8 @@ void testRandomCreation()
     checkRandomParticles( num_particle, box_min, box_max, host_positions );
 }
 
-void testRandomCreationHost()
-{
-    int num_particle = 200;
-    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, Kokkos::HostSpace> host_aosoa(
-        "random", num_particle );
-    auto host_positions = Cabana::slice<0>( host_aosoa );
-
-    double box_min = -9.5;
-    double box_max = 7.6;
-    Cabana::createRandomParticles( host_positions, host_positions.size(),
-                                   box_min, box_max );
-
-    checkRandomParticles( num_particle, box_min, box_max, host_positions );
-}
-
 TEST( TEST_CATEGORY, random_particle_creation_test )
 {
     testRandomCreationMinDistance();
-    testRandomCreationMinDistanceHost();
     testRandomCreation();
-    testRandomCreationHost();
 }

--- a/core/unit_test/tstParticleInit.hpp
+++ b/core/unit_test/tstParticleInit.hpp
@@ -1,0 +1,133 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cabana_AoSoA.hpp>
+#include <Cabana_DeepCopy.hpp>
+#include <Cabana_ParticleInit.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <gtest/gtest.h>
+
+template <class PositionType>
+void checkRandomParticles( const int num_particle, const double box_min,
+                           const double box_max,
+                           const PositionType host_positions )
+{
+    // Check that we got as many particles as we should have.
+    EXPECT_EQ( host_positions.size(), num_particle );
+
+    // Check that all of the particles are in the domain.
+    for ( int p = 0; p < num_particle; ++p )
+        for ( int d = 0; d < 3; ++d )
+        {
+            EXPECT_GE( host_positions( p, d ), box_min );
+            EXPECT_LE( host_positions( p, d ), box_max );
+        }
+}
+
+template <class PositionType>
+void checkRandomDistances( const int min_distance,
+                           const PositionType host_positions )
+{
+    std::size_t num_particle = host_positions.size();
+
+    // Check that none of the particles are are too close.
+    for ( std::size_t i = 0; i < num_particle; ++i )
+        for ( std::size_t j = 0; j < num_particle; ++j )
+        {
+            double dsqr = 0.0;
+            for ( int d = 0; d < 3; ++d )
+            {
+                double diff = host_positions( i, d ) - host_positions( j, d );
+                dsqr += diff * diff;
+            }
+            EXPECT_GE( dsqr, min_distance );
+        }
+}
+
+void testRandomCreationMinDistance()
+{
+    int num_particle = 200;
+    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE> aosoa(
+        "random", num_particle );
+    auto positions = Cabana::slice<0>( aosoa );
+
+    double min_dist = 0.47;
+    double box_min = -9.5;
+    double box_max = 7.6;
+    Cabana::createRandomParticlesMinDistance( positions, positions.size(),
+                                              box_min, box_max, min_dist );
+    auto host_aosoa =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto host_positions = Cabana::slice<0>( host_aosoa );
+
+    checkRandomParticles( num_particle, box_min, box_max, host_positions );
+    checkRandomDistances( min_dist, host_positions );
+}
+
+void testRandomCreationMinDistanceHost()
+{
+    int num_particle = 2000;
+    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, Kokkos::HostSpace> host_aosoa(
+        "random", num_particle );
+    auto host_positions = Cabana::slice<0>( host_aosoa );
+
+    double min_dist = 0.47;
+    double box_min = -9.5;
+    double box_max = 7.6;
+    Cabana::createRandomParticlesMinDistanceHost(
+        host_positions, host_positions.size(), box_min, box_max, min_dist );
+
+    checkRandomParticles( num_particle, box_min, box_max, host_positions );
+    checkRandomDistances( min_dist, host_positions );
+}
+
+void testRandomCreation()
+{
+    int num_particle = 200;
+    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, TEST_MEMSPACE> aosoa(
+        "random", num_particle );
+    auto positions = Cabana::slice<0>( aosoa );
+
+    double box_min = -9.5;
+    double box_max = 7.6;
+    Cabana::createRandomParticles( positions, positions.size(), box_min,
+                                   box_max );
+    auto host_aosoa =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto host_positions = Cabana::slice<0>( host_aosoa );
+
+    checkRandomParticles( num_particle, box_min, box_max, host_positions );
+}
+
+void testRandomCreationHost()
+{
+    int num_particle = 200;
+    Cabana::AoSoA<Cabana::MemberTypes<double[3]>, Kokkos::HostSpace> host_aosoa(
+        "random", num_particle );
+    auto host_positions = Cabana::slice<0>( host_aosoa );
+
+    double box_min = -9.5;
+    double box_max = 7.6;
+    Cabana::createRandomParticles( host_positions, host_positions.size(),
+                                   box_min, box_max );
+
+    checkRandomParticles( num_particle, box_min, box_max, host_positions );
+}
+
+TEST( TEST_CATEGORY, random_particle_creation_test )
+{
+    testRandomCreationMinDistance();
+    testRandomCreationMinDistanceHost();
+    testRandomCreation();
+    testRandomCreationHost();
+}


### PR DESCRIPTION
Combine random particle generation from benchmarks and tests into core library.

Should speed up benchmarks init (previously done on the host), but currently not bin-accelerated (could use the LinkedCellList)