### PR TITLE
Cleanup kokkos header includes

### DIFF
--- a/cmake/test_harness/TestCUDA_UVM_Category.hpp
+++ b/cmake/test_harness/TestCUDA_UVM_Category.hpp
@@ -12,10 +12,6 @@
 #ifndef CABANA_TEST_CUDAUVM_CATEGORY_HPP
 #define CABANA_TEST_CUDAUVM_CATEGORY_HPP
 
-#include <Kokkos_Cuda.hpp>
-
-#include <gtest/gtest.h>
-
 #define TEST_CATEGORY cuda_uvm
 #define TEST_EXECSPACE Kokkos::Cuda
 #define TEST_MEMSPACE Kokkos::CudaUVMSpace

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -21,7 +21,6 @@
 #include <impl/Cabana_TypeTraits.hpp>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_ExecPolicy.hpp>
 
 #include <exception>
 #include <type_traits>


### PR DESCRIPTION
I recently had to fix invalid use of Kokkos headers in another library and decided to scan our includes to be sure.
We are doing pretty good but here are a couple trivial things I noticed that we might want to change.