### PR TITLE
Rename build rule `format -> cabana-format`

### DIFF
--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -376,7 +376,7 @@ jobs:
         if: ${{ matrix.distro == 'ubuntu:latest' }}
         working-directory: build
         run: |
-             make format
+             make cabana-format
              git diff --exit-code
       - name: Upload Report to codecov.io
         if: ${{ matrix.coverage == 'ON' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CabanaConfig.cmake" "${CMAKE_CURRENT_
 ##---------------------------------------------------------------------------##
 if(CLANG_FORMAT_FOUND)
   file(GLOB_RECURSE FORMAT_SOURCES core/*.cpp core/*.hpp cajita/*hpp cajita/*cpp example/*cpp example/*hpp cmake/*cpp cmake/*hpp benchmark/*cpp benchmark/*hpp)
-  add_custom_target(format
+  add_custom_target(cabana-format
     COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
     DEPENDS ${FORMAT_SOURCES})
 endif()


### PR DESCRIPTION
Fix #498 
Prefix the build rule for formatting the code with to avoid collisions