### PR TITLE
Cajita examples - Spline and Interpolation

### DIFF
--- a/example/cajita_tutorial/14_spline/CMakeLists.txt
+++ b/example/cajita_tutorial/14_spline/CMakeLists.txt
@@ -9,19 +9,6 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
-add_subdirectory(01_types)
-add_subdirectory(02_global_mesh)
-add_subdirectory(03_partitioner)
-add_subdirectory(04_global_grid)
-add_subdirectory(05_index_space)
-add_subdirectory(06_local_grid)
-add_subdirectory(07_local_mesh)
-add_subdirectory(08_array)
-if(Cabana_ENABLE_HEFFTE)
-    add_subdirectory(10_fft_heffte)
-endif()
-if(Cabana_ENABLE_ALL)
-  add_subdirectory(13_all_loadbalancer)
-endif()
-add_subdirectory(14_spline)
-add_subdirectory(15_interpolation)
+add_executable(Spline spline_example.cpp)
+target_link_libraries(Spline Cajita)
+add_test(NAME Cajita_tutorial_14 COMMAND ${NONMPI_PRECOMMAND} Spline)

--- a/example/cajita_tutorial/14_spline/spline_example.cpp
+++ b/example/cajita_tutorial/14_spline/spline_example.cpp
@@ -17,6 +17,9 @@
 //---------------------------------------------------------------------------//
 // Spline example.
 //---------------------------------------------------------------------------//
+
+using namespace Cajita;
+
 void splineExample()
 {
     /*
@@ -87,7 +90,9 @@ void splineExample()
         SplineWeightValues = w[d][num_knots]
         SplineWeightPhysicalGradients g[d][num_knots]
 
-      This design allows for customizing the relavant spline data for a
+      where d indexes NumSpaceDim, and num_knots is SplineOrder + 1
+
+      This design allows for customizing the relevant spline data for a
       particular application. If all Tags are omitted, all SplineDataMembers are
       included.
     */
@@ -118,9 +123,40 @@ void splineExample()
     }
     std::cout << std::endl;
 
+    // Only a subset of specific SplineDataMember tags may be used instead of
+    // the full set by default:
+    using DataTags = Cajita::SplineDataMemberTypes<
+        SplinePhysicalCellSize, SplineLogicalPosition, SplinePhysicalDistance,
+        SplineWeightValues>;
+
+    // This is may be useful in reducing memory
+    // spline data type
+    using SD_t =
+        SplineData<value_type, order, num_space, Cajita::Node, DataTags>;
+
+    // Check members.
+    static_assert( SD_t::has_physical_cell_size,
+                   "spline data missing physical cell size" );
+    static_assert( SD_t::has_logical_position,
+                   "spline data missing logical position" );
+    static_assert( SD_t::has_physical_distance,
+                   "spline data missing physical distance" );
+    static_assert( SD_t::has_weight_values,
+                   "spline data missing weight values" );
+
+    // For example, the following line gives a compile-time error since the
+    // SplineWeightPhysicalGradients data tag was not included static_assert(
+    // SD_t::has_weight_physical_gradients,
+    //                "spline data missing weight physical gradients" );
+
     /*
       We can also use the Spline<Order> interface directly to evaluate
       specific spline data given basic information about the local grid.
+
+      This approach is useful if one needs to write their own particle-grid
+      operators. However, the built-in Cajita particle-grid operators in
+      Cajita_Interpolation.hpp does not require the use of these interfaces
+      except to construct the SplineData as above.
     */
     double rdx = 1.0 / cell_size;
     double values[3]; // num_knots for a 2nd-order spline

--- a/example/cajita_tutorial/14_spline/spline_example.cpp
+++ b/example/cajita_tutorial/14_spline/spline_example.cpp
@@ -1,0 +1,223 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <iostream>
+
+//---------------------------------------------------------------------------//
+// Global Mesh example.
+//---------------------------------------------------------------------------//
+void splineExample()
+{
+    /*
+      Cajita provides B-Spline related interfaces for uniform grids operations.
+      The spline orders are:
+        0 - nearest grid point interpolation
+        1 - linear
+        2 - quadratic
+        3 - cubic
+    */
+    std::cout << "Cajita Spline Example\n" << std::endl;
+
+    /*******************************************************************
+      First, we need some setup to facilitate the use of Cajita splines.
+      This includes the creation of a simple uniform mesh and a particle
+      position.
+    */
+
+    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
+
+    // Create a 3-dimensional global uniform mesh
+    // Global bounding box.
+    double cell_size = 0.05;
+    std::array<int, 3> global_num_cell = { 20, 20, 20 };
+    std::array<double, 3> global_low_corner = { 0, 0, 0 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+
+    // Create the global mesh
+    auto global_mesh = Cajita::createUniformGlobalMesh(
+        global_low_corner, global_high_corner, cell_size );
+
+    // Set up a uniform partitioner
+    Cajita::DimBlockPartitioner<3> partitioner;
+
+    int halo_cell_width = 1;
+
+    // Create the global grid.
+    auto global_grid = Cajita::createGlobalGrid(
+        MPI_COMM_WORLD, global_mesh, { false, false, false }, partitioner );
+
+    // Get the local grid.
+    auto local_grid = Cajita::createLocalGrid( global_grid, halo_cell_width );
+
+    // Get the local mesh for this rank.
+    auto local_mesh = Cajita::createLocalMesh<ExecutionSpace>( *local_grid );
+
+    // Create a particle position vector.
+    double xp[3] = { 0.5, 2, 1.5 };
+
+    /********************************************************************/
+
+    /*
+      There are two ways to use Cajita splines in practice.
+      In the first way, one constructs an object of type SplineData<Scalar,
+      Order, NumSpaceDim, class EntityType, class... Tags> where Scalar =
+      underlying scalar type Order = spline order NumSpaceDim = number of space
+      dimensions EntityType = geometric entity type over which the spline is
+      defined Tags = variadic list of desired SplineDataMember tags.
+
+        The available SplineDataMembers and their associated member names are
+          SplinePhysicalCellSize = dx[d]
+          SplineLogicalPosition = x[d]
+          SplinePhysicalDistance = d[d]
+          SplineWeightValues = w[d][num_knots]
+          SplineWeightPhysicalGradients g[d][num_knots]
+
+      By default, if <class... Tags> is omitted, all SplineDataMembers are
+      included. This design allows for customizing the relavant spline data for
+      a particular application.
+    */
+    using value_type = double;
+    constexpr int order = 2;     // quadratic B-spline
+    constexpr int num_space = 3; // 3-dimensional
+
+    // This spline data type will be defined on grid nodes.
+    using SD = Cajita::SplineData<value_type, order, num_space, Cajita::Node>;
+
+    SD sd_n; // Default construction
+    std::cout << "Spline order: " << SD::order << " (quadratic)" << std::endl;
+
+    // Evaluate the spline data given a point position and the local mesh
+    Cajita::evaluateSpline( local_mesh, xp, sd_n );
+
+    // The spline data by default contains all available SplineDataMembers,
+    // whose values were all updated from the previous call to evaluateSpline()
+
+    std::cout << "Spline weights:" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        std::cout << "  Dim " << d << ": ";
+        for ( int k = 0; k < SD::num_knot; ++k )
+        {
+            std::cout << sd_n.w[d][k] << " ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+
+    /*
+      We can also use the Spline<Order> interface directly to evaluate
+      specific spline data given basic information about the local grid.
+    */
+
+    double rdx = 1.0 / cell_size;
+    double values[3]; // num_knots for a 2nd-order spline
+    double x0[3];     // Logical position in primal grid
+
+    std::cout << "Spline weights (static interface):" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        // These interfaces are for a single dimension only.
+        x0[d] = Cajita::Spline<2>::mapToLogicalGrid( xp[d], rdx,
+                                                     global_low_corner[d] );
+        Cajita::Spline<2>::value( x0[d], values );
+        std::cout << "  Dim " << d << ": ";
+        for ( auto v : values )
+        {
+            std::cout << v << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    // The offsets are the fixed logical space offsets of the knots,
+    // which depends on the order of the spline.
+    // For the quadratic B-spline, there are 3 knots with offsets -1, 0, 1:
+    int offsets_quadratic[3];
+    std::cout << "Spline offsets (static interface) (quadratic):" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        Cajita::Spline<2>::offsets( offsets_quadratic );
+        std::cout << "  Dim " << d << ": ";
+        for ( auto o : offsets_quadratic )
+        {
+            std::cout << o << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    // For a cubic B-spline, there are 4 knots, with offsets -1, 0, 1, 2.
+    // However, this number is also available as a static constexpr member for
+    // declaring arrays at compile-time.
+    int offsets_cubic[Cajita::Spline<3>::num_knot];
+    std::cout << "Spline offsets (static interface) (cubic):" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        Cajita::Spline<3>::offsets( offsets_cubic );
+        std::cout << "  Dim " << d << ": ";
+        for ( auto o : offsets_cubic )
+        {
+            std::cout << o << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    // The stencil returns the entity indices for a given logical space position
+    int stencil[3];
+    std::cout << "Spline stencil (static interface):" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        Cajita::Spline<2>::stencil( x0[d], stencil );
+        std::cout << "  Dim " << d << ": ";
+        for ( auto si : stencil )
+        {
+            std::cout << si << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    // The knot basis gradient values in physical units for a given logical
+    // position.
+    double grad[3];
+    std::cout << "Spline gradient (static interface):" << std::endl;
+    for ( int d = 0; d < num_space; ++d )
+    {
+        Cajita::Spline<2>::gradient( x0[d], rdx, grad );
+        std::cout << "  Dim " << d << ": ";
+        for ( auto g : grad )
+        {
+            std::cout << g << " ";
+        }
+        std::cout << std::endl;
+    }
+}
+
+//---------------------------------------------------------------------------//
+// Main.
+//---------------------------------------------------------------------------//
+int main( int argc, char* argv[] )
+{
+    MPI_Init( &argc, &argv );
+
+    Kokkos::ScopeGuard scope_guard( argc, argv );
+
+    splineExample();
+
+    MPI_Finalize();
+
+    return 0;
+}
+
+//---------------------------------------------------------------------------//

--- a/example/cajita_tutorial/15_interpolation/CMakeLists.txt
+++ b/example/cajita_tutorial/15_interpolation/CMakeLists.txt
@@ -9,19 +9,6 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
-add_subdirectory(01_types)
-add_subdirectory(02_global_mesh)
-add_subdirectory(03_partitioner)
-add_subdirectory(04_global_grid)
-add_subdirectory(05_index_space)
-add_subdirectory(06_local_grid)
-add_subdirectory(07_local_mesh)
-add_subdirectory(08_array)
-if(Cabana_ENABLE_HEFFTE)
-    add_subdirectory(10_fft_heffte)
-endif()
-if(Cabana_ENABLE_ALL)
-  add_subdirectory(13_all_loadbalancer)
-endif()
-add_subdirectory(14_spline)
-add_subdirectory(15_interpolation)
+add_executable(Interpolation interpolation_example.cpp)
+target_link_libraries(Interpolation Cajita)
+add_test(NAME Cajita_tutorial_15 COMMAND ${NONMPI_PRECOMMAND} Interpolation)

--- a/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
+++ b/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
@@ -25,12 +25,11 @@ void interpolationExample()
     */
     std::cout << "Cajita Interpolation Example\n" << std::endl;
 
-    /*******************************************************************
+    /*
       First, we need some setup to demonstrate the use of Cajita interpolation.
-      This includes the creation of a simple uniform mesh and various
-      fields on particles and the mesh.
+      This includes the creation of a simple uniform mesh and various fields on
+      particles and the mesh.
     */
-
     using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
 
     // Create the global mesh.
@@ -70,7 +69,7 @@ void interpolationExample()
             points( pid, Cajita::Dim::J ) = x[Cajita::Dim::J];
         } );
 
-    // Here, we use Cajita functionality to create grid data fields.
+    // Next, we use Cajita functionality to create grid data fields.
     // Create a scalar field on the grid. See the Array tutorial example for
     // information on these functions.
     auto scalar_layout =
@@ -114,37 +113,22 @@ void interpolationExample()
         num_point );
     auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );
 
-    /*******************************************************************************
-     *
+    /***************************************************************************
+     * P2G
+     **************************************************************************/
+    /*
      * The Cajita::P2G namespace contains several methods for interpolating data
      * from particles to the grid. These interpolations are inherently scatter
      * operations for particle-based threading (a single particle maps to
      * several grid nodes), which requires an underlying Kokkos::ScatterView for
      * the data being interpolated. Of note, these methods perform
-     * interpolations for a single particle datum. They may
+     * interpolations for a single particle datum. They may ...
      *
-     * *****************************************************************************/
-
-    /*******************************************************************************
-     *
-     * In addition to P2G, The Cajita::G2P namespace contains several methods
-     * for interpolating data from the grid to particles. These interpolations
-     * are inherently gather operations for particle-based threading (multiple
-     * grid values are gathered to a single point).
-     *
-     * *****************************************************************************/
-
-    /*************************
      * Cajita also provides a convenience interface for defining field-based P2G
      * or G2P operators, by wrapping the single-particle interpolation methods
-     * above inside Kokkos-View based functors. These operators may be used in
-     * the provided generic global function evaluators Cajita::p2g() or
-     * Cajita::g2p().
-     * ************************/
+     * with loops over all particles inside: Cajita::p2g().
+     */
 
-    /*************************
-     * p2g()
-     * *************************/
     Kokkos::deep_copy( scalar_point_field, 3.5 );
     Kokkos::deep_copy( vector_point_field, 3.5 );
     Kokkos::deep_copy( tensor_point_field, 3.5 );
@@ -175,9 +159,18 @@ void interpolationExample()
     Cajita::p2g( tensor_div_p2g, points, num_point, Cajita::Spline<1>(),
                  *vector_halo, *vector_grid_field );
 
-    /***********************************
-     * g2p()
-     * **********************************/
+    /***************************************************************************
+     * G2P
+     **************************************************************************/
+    /*
+     * In addition to P2G, The Cajita::G2P namespace contains several methods
+     * for interpolating data from the grid to particles. These interpolations
+     * are inherently gather operations for particle-based threading (multiple
+     * grid values are gathered to a single point).
+     *
+     * Here we again focus on the Cajita::g2p() interface to interpolate from
+     * all grid points to particles.
+     */
 
     // Interpolate a scalar grid value to the points.
     Kokkos::deep_copy( scalar_point_field, 0.0 );
@@ -218,11 +211,11 @@ void interpolationExample()
 int main( int argc, char* argv[] )
 {
     MPI_Init( &argc, &argv );
+    {
+        Kokkos::ScopeGuard scope_guard( argc, argv );
 
-    Kokkos::ScopeGuard scope_guard( argc, argv );
-
-    interpolationExample();
-
+        interpolationExample();
+    }
     MPI_Finalize();
 
     return 0;

--- a/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
+++ b/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
@@ -1,0 +1,231 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <iostream>
+
+//---------------------------------------------------------------------------//
+// Interpolation example.
+//---------------------------------------------------------------------------//
+void interpolationExample()
+{
+    /*
+      Cajita provides various particle-to-grid (p2g) and grid-to-particle (g2p)
+      interpolation methods, based on the rank of the interpolated field.
+    */
+    std::cout << "Cajita Interpolation Example\n" << std::endl;
+
+    /*******************************************************************
+      First, we need some setup to demonstrate the use of Cajita interpolation.
+      This includes the creation of a simple uniform mesh and various
+      fields on particles and the mesh.
+    */
+
+    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
+
+    // Create the global mesh.
+    std::array<double, 2> low_corner = { -1.2, 0.1 };
+    std::array<double, 2> high_corner = { -0.2, 9.5 };
+    double cell_size = 0.1;
+    auto global_mesh =
+        Cajita::createUniformGlobalMesh( low_corner, high_corner, cell_size );
+
+    // Create the global grid.
+    Cajita::DimBlockPartitioner<2> partitioner;
+    std::array<bool, 2> is_dim_periodic = { true, true };
+    auto global_grid = Cajita::createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                                 is_dim_periodic, partitioner );
+
+    // Create a  grid local_grid.
+    int halo_width = 1;
+    auto local_grid = Cajita::createLocalGrid( global_grid, halo_width );
+    auto local_mesh = Cajita::createLocalMesh<ExecutionSpace>( *local_grid );
+
+    // Create a point in the center of every cell.
+    auto cell_space = local_grid->indexSpace( Cajita::Own(), Cajita::Cell(),
+                                              Cajita::Local() );
+    int num_point = cell_space.size();
+    Kokkos::View<double* [2], ExecutionSpace> points(
+        Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
+    Kokkos::parallel_for(
+        "fill_points", createExecutionPolicy( cell_space, ExecutionSpace() ),
+        KOKKOS_LAMBDA( const int i, const int j ) {
+            int pi = i - halo_width;
+            int pj = j - halo_width;
+            int pid = pi + cell_space.extent( Cajita::Dim::I ) * pj;
+            int idx[2] = { i, j };
+            double x[2];
+            local_mesh.coordinates( Cajita::Cell(), idx, x );
+            points( pid, Cajita::Dim::I ) = x[Cajita::Dim::I];
+            points( pid, Cajita::Dim::J ) = x[Cajita::Dim::J];
+        } );
+
+    // Here, we use Cajita functionality to create grid data fields.
+    // Create a scalar field on the grid. See the Array tutorial example for
+    // information on these functions.
+    auto scalar_layout =
+        Cajita::createArrayLayout( local_grid, 1, Cajita::Node() );
+    auto scalar_grid_field = Cajita::createArray<double, ExecutionSpace>(
+        "scalar_grid_field", scalar_layout );
+
+    // Create a halo for scatter operations. This concept is discussed in more
+    // detail in the Halo tutorial example.
+    auto scalar_halo =
+        Cajita::createHalo( *scalar_grid_field, Cajita::NodeHaloPattern<2>() );
+    auto scalar_grid_host =
+        Kokkos::create_mirror_view( scalar_grid_field->view() );
+
+    // Create a vector field on the grid.
+    auto vector_layout =
+        Cajita::createArrayLayout( local_grid, 2, Cajita::Node() );
+    auto vector_grid_field = Cajita::createArray<double, ExecutionSpace>(
+        "vector_grid_field", vector_layout );
+    auto vector_halo =
+        Cajita::createHalo( *vector_grid_field, Cajita::NodeHaloPattern<2>() );
+    auto vector_grid_host =
+        Kokkos::create_mirror_view( vector_grid_field->view() );
+
+    // Simple Kokkos::Views may be used to represent particle data.
+    // Create a scalar point field.
+    Kokkos::View<double*, ExecutionSpace> scalar_point_field(
+        Kokkos::ViewAllocateWithoutInitializing( "scalar_point_field" ),
+        num_point );
+    auto scalar_point_host = Kokkos::create_mirror_view( scalar_point_field );
+
+    // Create a vector point field.
+    Kokkos::View<double* [2], ExecutionSpace> vector_point_field(
+        Kokkos::ViewAllocateWithoutInitializing( "vector_point_field" ),
+        num_point );
+    auto vector_point_host = Kokkos::create_mirror_view( vector_point_field );
+
+    // Create a tensor point field.
+    Kokkos::View<double* [2][2], ExecutionSpace> tensor_point_field(
+        Kokkos::ViewAllocateWithoutInitializing( "tensor_point_field" ),
+        num_point );
+    auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );
+
+    /*******************************************************************************
+     *
+     * The Cajita::P2G namespace contains several methods for interpolating data
+     * from particles to the grid. These interpolations are inherently scatter
+     * operations for particle-based threading (a single particle maps to
+     * several grid nodes), which requires an underlying Kokkos::ScatterView for
+     * the data being interpolated. Of note, these methods perform
+     * interpolations for a single particle datum. They may
+     *
+     * *****************************************************************************/
+
+    /*******************************************************************************
+     *
+     * In addition to P2G, The Cajita::G2P namespace contains several methods
+     * for interpolating data from the grid to particles. These interpolations
+     * are inherently gather operations for particle-based threading (multiple
+     * grid values are gathered to a single point).
+     *
+     * *****************************************************************************/
+
+    /*************************
+     * Cajita also provides a convenience interface for defining field-based P2G
+     * or G2P operators, by wrapping the single-particle interpolation methods
+     * above inside Kokkos-View based functors. These operators may be used in
+     * the provided generic global function evaluators Cajita::p2g() or
+     * Cajita::g2p().
+     * ************************/
+
+    /*************************
+     * p2g()
+     * *************************/
+    Kokkos::deep_copy( scalar_point_field, 3.5 );
+    Kokkos::deep_copy( vector_point_field, 3.5 );
+    Kokkos::deep_copy( tensor_point_field, 3.5 );
+
+    // Interpolate a scalar point value to the grid.
+    Cajita::ArrayOp::assign( *scalar_grid_field, 0.0, Cajita::Ghost() );
+    auto scalar_p2g = Cajita::createScalarValueP2G( scalar_point_field, -0.5 );
+    Cajita::p2g( scalar_p2g, points, num_point, Cajita::Spline<1>(),
+                 *scalar_halo, *scalar_grid_field );
+
+    // Interpolate a vector point value to the grid.
+    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
+    auto vector_p2g = Cajita::createVectorValueP2G( vector_point_field, -0.5 );
+    Cajita::p2g( vector_p2g, points, num_point, Cajita::Spline<1>(),
+                 *vector_halo, *vector_grid_field );
+
+    // Interpolate a scalar point gradient value to the grid.
+    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
+    auto scalar_grad_p2g =
+        Cajita::createScalarGradientP2G( scalar_point_field, -0.5 );
+    Cajita::p2g( scalar_grad_p2g, points, num_point, Cajita::Spline<1>(),
+                 *vector_halo, *vector_grid_field );
+
+    // Interpolate a tensor point divergence value to the grid.
+    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
+    auto tensor_div_p2g =
+        Cajita::createTensorDivergenceP2G( tensor_point_field, -0.5 );
+    Cajita::p2g( tensor_div_p2g, points, num_point, Cajita::Spline<1>(),
+                 *vector_halo, *vector_grid_field );
+
+    /***********************************
+     * g2p()
+     * **********************************/
+
+    // Interpolate a scalar grid value to the points.
+    Kokkos::deep_copy( scalar_point_field, 0.0 );
+    auto scalar_value_g2p =
+        Cajita::createScalarValueG2P( scalar_point_field, -0.5 );
+    Cajita::g2p( *scalar_grid_field, *scalar_halo, points, num_point,
+                 Cajita::Spline<1>(), scalar_value_g2p );
+    Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+
+    // Interpolate a vector grid value to the points.
+    Kokkos::deep_copy( vector_point_field, 0.0 );
+    auto vector_value_g2p =
+        Cajita::createVectorValueG2P( vector_point_field, -0.5 );
+    Cajita::g2p( *vector_grid_field, *vector_halo, points, num_point,
+                 Cajita::Spline<1>(), vector_value_g2p );
+    Kokkos::deep_copy( vector_point_host, vector_point_field );
+
+    // Interpolate a scalar grid gradient to the points.
+    Kokkos::deep_copy( vector_point_field, 0.0 );
+    auto scalar_gradient_g2p =
+        Cajita::createScalarGradientG2P( vector_point_field, -0.5 );
+    Cajita::g2p( *scalar_grid_field, *scalar_halo, points, num_point,
+                 Cajita::Spline<1>(), scalar_gradient_g2p );
+    Kokkos::deep_copy( vector_point_host, vector_point_field );
+
+    // Interpolate a vector grid divergence to the points.
+    Kokkos::deep_copy( scalar_point_field, 0.0 );
+    auto vector_div_g2p =
+        Cajita::createVectorDivergenceG2P( scalar_point_field, -0.5 );
+    Cajita::g2p( *vector_grid_field, *vector_halo, points, num_point,
+                 Cajita::Spline<1>(), vector_div_g2p );
+    Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+}
+
+//---------------------------------------------------------------------------//
+// Main.
+//---------------------------------------------------------------------------//
+int main( int argc, char* argv[] )
+{
+    MPI_Init( &argc, &argv );
+
+    Kokkos::ScopeGuard scope_guard( argc, argv );
+
+    interpolationExample();
+
+    MPI_Finalize();
+
+    return 0;
+}
+
+//---------------------------------------------------------------------------//

--- a/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
+++ b/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
@@ -210,7 +210,6 @@ void interpolationExample()
         num_point );
     auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );
 
-    std::cout << "Invididual grid points before interpolation: "
     /***************************************************************************
      * P2G
      **************************************************************************/
@@ -252,6 +251,9 @@ void interpolationExample()
      * perform interpolations of particle data of various ranks.
      * *************************************************************************/
 
+    std::cout << "P2G interpolations" << std::endl;
+    std::cout << "-----------------------------------------------" << std::endl;
+
     // Initialize the particle data fields.
     Kokkos::deep_copy( scalar_point_field, 3.5 );
     Kokkos::deep_copy( vector_point_field, 3.5 );
@@ -259,43 +261,72 @@ void interpolationExample()
 
     // Reset the grid to zero.
     Cajita::ArrayOp::assign( *scalar_grid_field, 0.0, Cajita::Ghost() );
+    auto scalar_view = scalar_grid_field->view();
+    std::cout << "Invididual grid point scalar value at (5, 5, 5):\n\tbefore "
+                 "p2g::value interpolation: "
+              << scalar_view( 5, 5, 5 );
+
     // Interpolate a scalar point value to the grid.
     auto scalar_p2g = Cajita::createScalarValueP2G( scalar_point_field, -0.5 );
     Cajita::p2g( scalar_p2g, points, num_point, Cajita::Spline<1>(),
                  *scalar_halo, *scalar_grid_field );
-    auto scalar_view = scalar_grid_field->view();
+
     // Print out a random grid point.
-    std::cout << scalar_view( 5, 5, 5 );
+    std::cout << "\n\tafter p2g::value interpolation: "
+              << scalar_view( 5, 5, 5 ) << "\n\n";
 
     // Reset the grid to zero.
-    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
-    // Interpolate a vector point value to the grid.
-    auto vector_p2g = Cajita::createVectorValueP2G( vector_point_field, -0.5 );
-    Cajita::p2g( vector_p2g, points, num_point, Cajita::Spline<1>(),
-                 *vector_halo, *vector_grid_field );
     auto vector_view = vector_grid_field->view();
-    // Print out a random grid point.
-    std::cout << vector_grid_field->view()( 5, 5, 5 );
+    std::cout << "Invididual grid point vector value at (5, 5, 5):\n\tbefore "
+                 "p2g::gradient interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 )
+              << ">";
 
-    // Reset the grid to zero.
-    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
     // Interpolate a scalar point gradient value to the grid.
     auto scalar_grad_p2g =
         Cajita::createScalarGradientP2G( scalar_point_field, -0.5 );
     Cajita::p2g( scalar_grad_p2g, points, num_point, Cajita::Spline<1>(),
                  *vector_halo, *vector_grid_field );
+
     // Print out a random grid point.
-    std::cout << vector_view( 5, 5, 5 );
+    std::cout << "\n\tafter p2g::gradient interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 ) << ">"
+              << "\n\n";
 
     // Reset the grid to zero.
     Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
+    std::cout << "Invididual grid point vector value at (5, 5, 5):\n\tbefore "
+                 "p2g::divergence interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 )
+              << ">";
+
     // Interpolate a tensor point divergence value to the grid.
     auto tensor_div_p2g =
         Cajita::createTensorDivergenceP2G( tensor_point_field, -0.5 );
     Cajita::p2g( tensor_div_p2g, points, num_point, Cajita::Spline<1>(),
                  *vector_halo, *vector_grid_field );
+
     // Print out a random grid point.
-    std::cout << vector_view( 5, 5, 5 );
+    std::cout << "\n\tafter p2g::divergence interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 ) << ">"
+              << "\n\n";
+
+    // Reset the grid to zero.
+    Cajita::ArrayOp::assign( *vector_grid_field, 0.0, Cajita::Ghost() );
+    std::cout << "Invididual grid point vector value at (5, 5, 5):\n\tbefore "
+                 "p2g::value interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 )
+              << ">";
+
+    // Interpolate a vector point value to the grid.
+    auto vector_p2g = Cajita::createVectorValueP2G( vector_point_field, -0.5 );
+    Cajita::p2g( vector_p2g, points, num_point, Cajita::Spline<1>(),
+                 *vector_halo, *vector_grid_field );
+
+    // Print out a random grid point.
+    std::cout << "\n\tafter p2g::value interpolation: <";
+    std::cout << vector_view( 5, 5, 0 ) << ", " << vector_view( 5, 5, 1 ) << ">"
+              << "\n\n";
 
     /***************************************************************************
      * User-defined thread-level functors may be used instead of
@@ -307,7 +338,7 @@ void interpolationExample()
      * The P2GExampleFunctor is initialized with both a scalar
      * point field and a vector point field.
      *
-     * Whereas this example still passes the user-defined functor
+     * Although this example still passes the user-defined functor
      * to Cajita::p2g(), more advanced usages with kernel fusion
      * and multiple aggregated fields will be considered in another
      * example.
@@ -341,45 +372,74 @@ void interpolationExample()
      * grid data of various ranks.
      * *************************************************************************/
 
+    std::cout << "G2P interpolations" << std::endl;
+    std::cout << "-----------------------------------------------" << std::endl;
+
     // Interpolate a scalar grid value to the points.
     Kokkos::deep_copy( scalar_point_field, 0.0 );
+    std::cout << "Individual particle point scalar value at (127):\n\tbefore "
+                 "g2p::value interpolation: ";
+    std::cout << scalar_point_host( 127 );
+
     auto scalar_value_g2p =
         Cajita::createScalarValueG2P( scalar_point_field, -0.5 );
     Cajita::g2p( *scalar_grid_field, *scalar_halo, points, num_point,
                  Cajita::Spline<1>(), scalar_value_g2p );
     Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+
     // Print out a random particle.
-    std::cout << scalar_point_field( 127 );
+    std::cout << "\n\tafter g2p::value interpolation: "
+              << scalar_point_host( 127 ) << "\n\n";
 
     // Interpolate a vector grid value to the points.
     Kokkos::deep_copy( vector_point_field, 0.0 );
+    std::cout << "Individual particle point vector value at (127):\n\tbefore "
+                 "g2p::value interpolation: ";
+    std::cout << "<" << vector_point_host( 127, 0 ) << ", "
+              << vector_point_host( 127, 1 ) << ">";
+
     auto vector_value_g2p =
         Cajita::createVectorValueG2P( vector_point_field, -0.5 );
     Cajita::g2p( *vector_grid_field, *vector_halo, points, num_point,
                  Cajita::Spline<1>(), vector_value_g2p );
     Kokkos::deep_copy( vector_point_host, vector_point_field );
-    // Print out a random particle.
-    std::cout << vector_point_field( 127, 0 );
+    std::cout << "\n\tafter g2p::value interpolation: ";
+    std::cout << "<" << vector_point_host( 127, 0 ) << ", "
+              << vector_point_host( 127, 1 ) << ">"
+              << "\n\n";
 
     // Interpolate a scalar grid gradient to the points.
     Kokkos::deep_copy( vector_point_field, 0.0 );
+    std::cout << "Individual particle point vector value at (127):\n\tbefore "
+                 "g2p::gradient interpolation: ";
+    std::cout << "<" << vector_point_host( 127, 0 ) << ", "
+              << vector_point_host( 127, 1 ) << ">";
+
     auto scalar_gradient_g2p =
         Cajita::createScalarGradientG2P( vector_point_field, -0.5 );
     Cajita::g2p( *scalar_grid_field, *scalar_halo, points, num_point,
                  Cajita::Spline<1>(), scalar_gradient_g2p );
     Kokkos::deep_copy( vector_point_host, vector_point_field );
-    // Print out a random particle.
-    std::cout << vector_point_field( 127, 0 );
+    std::cout << "\n\tafter g2p::gradient interpolation: ";
+    std::cout << "<" << vector_point_host( 127, 0 ) << ", "
+              << vector_point_host( 127, 1 ) << ">"
+              << "\n\n";
 
     // Interpolate a vector grid divergence to the points.
     Kokkos::deep_copy( scalar_point_field, 0.0 );
+    std::cout << "Individual particle point scalar value at (127):\n\tbefore "
+                 "g2p::divergence interpolation: ";
+    std::cout << scalar_point_host( 127 );
+
     auto vector_div_g2p =
         Cajita::createVectorDivergenceG2P( scalar_point_field, -0.5 );
     Cajita::g2p( *vector_grid_field, *vector_halo, points, num_point,
                  Cajita::Spline<1>(), vector_div_g2p );
     Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+
     // Print out a random particle.
-    std::cout << vector_point_field( 127, 0 );
+    std::cout << "\n\tafter g2p::divergence interpolation: "
+              << scalar_point_host( 127 ) << "\n\n";
 
     /***************************************************************************
      * User-defined thread-level functors can again be used instead, just as


### PR DESCRIPTION
This adds examples for using `Cajita::Spline<>` and the interpolation functions in `Cajita::P2G` and `Cajita::G2P`.

Part of #352 