### PR TITLE
Added string label argument to silo particle writer to support multiple particle groups.

### DIFF
--- a/cajita/src/Cajita_SiloParticleOutput.hpp
+++ b/cajita/src/Cajita_SiloParticleOutput.hpp
@@ -37,6 +37,7 @@ namespace SiloParticleOutput
 {
 /*!
   \brief Write particle output in Silo format using mesh information.
+  \param label Particles label.
   \param global_grid Cajita global grid.
   \param time_step_index Current simulation step index.
   \param time Current simulation time.
@@ -44,7 +45,7 @@ namespace SiloParticleOutput
   \param fields Variadic list of particle property fields.
 */
 template <class GlobalGridType, class CoordSliceType, class... FieldSliceTypes>
-void writeTimeStep( const GlobalGridType& global_grid,
+void writeTimeStep( const std::string& label, const GlobalGridType& global_grid,
                     const int time_step_index, const double time,
                     const CoordSliceType& coords, FieldSliceTypes&&... fields )
 {
@@ -58,7 +59,7 @@ void writeTimeStep( const GlobalGridType& global_grid,
             num_group = global_grid.dimNumBlock( d );
 
     Cabana::Experimental::SiloParticleOutput::writeTimeStep(
-        global_grid.comm(), num_group, time_step_index, time, coords,
+        label, global_grid.comm(), num_group, time_step_index, time, coords,
         fields... );
 }
 } // namespace SiloParticleOutput

--- a/cajita/unit_test/tstSiloParticleOutput.hpp
+++ b/cajita/unit_test/tstSiloParticleOutput.hpp
@@ -124,7 +124,7 @@ void writeTest()
     double time = 7.64;
     double step = 892;
     Cajita::Experimental::SiloParticleOutput::writeTimeStep(
-        *global_grid, step, time, coords, ids, matrix, vec );
+        "particles", *global_grid, step, time, coords, ids, matrix, vec );
 
     // Move the particles and write again.
     double time_step_size = 0.32;
@@ -135,7 +135,7 @@ void writeTest()
             coords_mirror( p, d ) += 1.32;
     Cabana::deep_copy( coords, coords_mirror );
     Cajita::Experimental::SiloParticleOutput::writeTimeStep(
-        *global_grid, step, time, coords, ids, matrix, vec );
+        "particles", *global_grid, step, time, coords, ids, matrix, vec );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_SiloParticleOutput.hpp
+++ b/core/src/Cabana_SiloParticleOutput.hpp
@@ -383,6 +383,7 @@ void writeMultiMesh( PMPIO_baton_t* baton, DBfile* silo_file,
 //---------------------------------------------------------------------------//
 /*!
   \brief Write particle output in Silo format.
+  \param prefix Filename prefix.
   \param comm MPI communicator.
   \param num_group Number of files to create in parallel.
   \param time_step_index Current simulation step index.
@@ -391,9 +392,10 @@ void writeMultiMesh( PMPIO_baton_t* baton, DBfile* silo_file,
   \param fields Variadic list of particle property fields.
 */
 template <class CoordSliceType, class... FieldSliceTypes>
-void writeTimeStep( MPI_Comm comm, const int num_group,
-                    const int time_step_index, const double time,
-                    const CoordSliceType& coords, FieldSliceTypes&&... fields )
+void writeTimeStep( const std::string& prefix, MPI_Comm comm,
+                    const int num_group, const int time_step_index,
+                    const double time, const CoordSliceType& coords,
+                    FieldSliceTypes&&... fields )
 {
     // Create the parallel baton.
     int mpi_tag = 1948;
@@ -409,11 +411,10 @@ void writeTimeStep( MPI_Comm comm, const int num_group,
 
     // Group 0 writes a master file for the time step.
     if ( 0 == group_rank )
-        file_name << "particles_" << time_step_index << ".silo";
-
+        file_name << prefix << "_" << time_step_index << ".silo";
     // The other groups write auxiliary files.
     else
-        file_name << "particles_" << time_step_index << "_group_" << group_rank
+        file_name << prefix << "_" << time_step_index << "_group_" << group_rank
                   << ".silo";
 
     // Compose a directory name.


### PR DESCRIPTION
This PR changes the `Cajita::Experimental::SiloParticleOutput::writeTimeStep` and `Cabana::Experimental::SiloParticleOutput::writeTimeStep` to require a string label as first parameter, in order to support writing different particle groups.