### PR TITLE
Allow any integer type for LocalMesh coordinates

### DIFF
--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -172,9 +172,10 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block, which correlates directly to local index spaces associated with
     //! the block.
-    KOKKOS_INLINE_FUNCTION
-    void coordinates( Cell, const int index[num_space_dim],
-                      Scalar x[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION void coordinates( Cell,
+                                             const Integer index[num_space_dim],
+                                             Scalar x[num_space_dim] ) const
     {
         for ( std::size_t d = 0; d < num_space_dim; ++d )
             x[d] = _ghost_low_corner[d] +
@@ -185,9 +186,10 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block, which correlates directly to local index spaces associated with
     //! the block.
-    KOKKOS_INLINE_FUNCTION
-    void coordinates( Node, const int index[num_space_dim],
-                      Scalar x[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION void coordinates( Node,
+                                             const Integer index[num_space_dim],
+                                             Scalar x[num_space_dim] ) const
     {
         for ( std::size_t d = 0; d < num_space_dim; ++d )
             x[d] = _ghost_low_corner[d] + Scalar( index[d] ) * _cell_size[d];
@@ -197,9 +199,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block, which correlates directly to local index spaces associated with
     //! the block.
-    template <int Dir>
+    template <int Dir, class Integer>
     KOKKOS_INLINE_FUNCTION void coordinates( Face<Dir>,
-                                             const int index[num_space_dim],
+                                             const Integer index[num_space_dim],
                                              Scalar x[num_space_dim] ) const
     {
         static_assert( Dir < num_space_dim, "Face dimension out of bounds" );
@@ -216,9 +218,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block, which correlates directly to local index spaces associated with
     //! the block.
-    template <int Dir, std::size_t NSD = num_space_dim>
+    template <int Dir, class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, void>
-    coordinates( Edge<Dir>, const int index[3], Scalar x[3] ) const
+    coordinates( Edge<Dir>, const Integer index[3], Scalar x[3] ) const
     {
         for ( std::size_t d = 0; d < 3; ++d )
             if ( Dir == d )
@@ -233,16 +235,20 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block and correlates directly to local index spaces associated with the
     //! block.
-    KOKKOS_INLINE_FUNCTION
-    Scalar measure( Node, const int[num_space_dim] ) const { return 0.0; }
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION Scalar measure( Node,
+                                           const Integer[num_space_dim] ) const
+    {
+        return 0.0;
+    }
 
     //! Get the measure of an Edge at the given index.
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block and correlates directly to local index spaces associated with the
     //! block.
-    template <int Dir, std::size_t NSD = num_space_dim>
+    template <int Dir, class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Scalar>
-    measure( Edge<Dir>, const int[3] ) const
+    measure( Edge<Dir>, const Integer[3] ) const
     {
         return _cell_size[Dir];
     }
@@ -251,9 +257,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block and correlates directly to local index spaces associated with the
     //! block.
-    template <int Dir>
+    template <int Dir, class Integer>
     KOKKOS_INLINE_FUNCTION Scalar measure( Face<Dir>,
-                                           const int[num_space_dim] ) const
+                                           const Integer[num_space_dim] ) const
     {
         static_assert( Dir < num_space_dim, "Face dimension out of bounds" );
         return _face_area[Dir];
@@ -263,8 +269,9 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Local indexing is relative to the ghosted decomposition of the mesh
     //! block and correlates directly to local index spaces associated with the
     //! block.
-    KOKKOS_INLINE_FUNCTION
-    Scalar measure( Cell, const int[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION Scalar measure( Cell,
+                                           const Integer[num_space_dim] ) const
     {
         return _cell_volume;
     }
@@ -576,9 +583,10 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       local index spaces associated with the block.
       \param x Calculated Cell position
     */
-    KOKKOS_INLINE_FUNCTION
-    void coordinates( Cell, const int index[num_space_dim],
-                      Scalar x[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION void coordinates( Cell,
+                                             const Integer index[num_space_dim],
+                                             Scalar x[num_space_dim] ) const
     {
         for ( std::size_t d = 0; d < num_space_dim; ++d )
             x[d] = ( _local_edges[d]( index[d] + 1 ) +
@@ -592,9 +600,10 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       ghosted decomposition of the mesh block.
       \param x Calculated Node position
     */
-    KOKKOS_INLINE_FUNCTION
-    void coordinates( Node, const int index[num_space_dim],
-                      Scalar x[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION void coordinates( Node,
+                                             const Integer index[num_space_dim],
+                                             Scalar x[num_space_dim] ) const
     {
         for ( std::size_t d = 0; d < num_space_dim; ++d )
             x[d] = _local_edges[d]( index[d] );
@@ -606,9 +615,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       ghosted decomposition of the mesh block.
       \param x Calculated Face position
     */
-    template <int Dir>
+    template <int Dir, class Integer>
     KOKKOS_INLINE_FUNCTION void coordinates( Face<Dir>,
-                                             const int index[num_space_dim],
+                                             const Integer index[num_space_dim],
                                              Scalar x[num_space_dim] ) const
     {
         static_assert( Dir < num_space_dim, "Face dimension out of bounds" );
@@ -628,9 +637,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       ghosted decomposition of the mesh block.
       \param x Calculated Edge position
     */
-    template <int Dir, std::size_t NSD = num_space_dim>
+    template <int Dir, class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, void>
-    coordinates( Edge<Dir>, const int index[3], Scalar x[3] ) const
+    coordinates( Edge<Dir>, const Integer index[3], Scalar x[3] ) const
     {
         for ( std::size_t d = 0; d < 3; ++d )
             if ( Dir == d )
@@ -644,17 +653,21 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
     /*!
       Get the measure of a Node.
     */
-    KOKKOS_INLINE_FUNCTION
-    Scalar measure( Node, const int[num_space_dim] ) const { return 0.0; }
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION Scalar measure( Node,
+                                           const Integer[num_space_dim] ) const
+    {
+        return 0.0;
+    }
 
     /*!
       Get the measure of a 3d Edge given the local index.
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <int Dir, std::size_t NSD = num_space_dim>
+    template <int Dir, class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Scalar>
-    measure( Edge<Dir>, const int index[3] ) const
+    measure( Edge<Dir>, const Integer index[3] ) const
     {
         return _local_edges[Dir][index[Dir] + 1] -
                _local_edges[Dir][index[Dir]];
@@ -665,9 +678,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <std::size_t NSD = num_space_dim>
+    template <class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Scalar>
-    measure( Face<Dim::I>, const int index[3] ) const
+    measure( Face<Dim::I>, const Integer index[3] ) const
     {
         return measure( Edge<Dim::J>(), index ) *
                measure( Edge<Dim::K>(), index );
@@ -678,9 +691,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <std::size_t NSD = num_space_dim>
+    template <class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Scalar>
-    measure( Face<Dim::J>, const int index[3] ) const
+    measure( Face<Dim::J>, const Integer index[3] ) const
     {
         return measure( Edge<Dim::I>(), index ) *
                measure( Edge<Dim::K>(), index );
@@ -691,9 +704,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <std::size_t NSD = num_space_dim>
+    template <class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Scalar>
-    measure( Face<Dim::K>, const int index[3] ) const
+    measure( Face<Dim::K>, const Integer index[3] ) const
     {
         return measure( Edge<Dim::I>(), index ) *
                measure( Edge<Dim::J>(), index );
@@ -704,9 +717,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <std::size_t NSD = num_space_dim>
+    template <class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, Scalar>
-    measure( Face<Dim::I>, const int index[2] ) const
+    measure( Face<Dim::I>, const Integer index[2] ) const
     {
         return _local_edges[Dim::J][index[Dim::J] + 1] -
                _local_edges[Dim::J][index[Dim::J]];
@@ -717,9 +730,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    template <std::size_t NSD = num_space_dim>
+    template <class Integer, std::size_t NSD = num_space_dim>
     KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, Scalar>
-    measure( Face<Dim::J>, const int index[2] ) const
+    measure( Face<Dim::J>, const Integer index[2] ) const
     {
         return _local_edges[Dim::I][index[Dim::I] + 1] -
                _local_edges[Dim::I][index[Dim::I]];
@@ -730,8 +743,9 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
       \param index %Array of local indices relative to the
       ghosted decomposition of the mesh block
     */
-    KOKKOS_INLINE_FUNCTION
-    Scalar measure( Cell, const int index[num_space_dim] ) const
+    template <class Integer>
+    KOKKOS_INLINE_FUNCTION Scalar
+    measure( Cell, const Integer index[num_space_dim] ) const
     {
         Scalar m = 1.0;
         for ( std::size_t d = 0; d < num_space_dim; ++d )

--- a/cajita/unit_test/tstLocalMesh2d.hpp
+++ b/cajita/unit_test/tstLocalMesh2d.hpp
@@ -245,6 +245,50 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
                 EXPECT_FLOAT_EQ( measure_m( i, j ), cell_size );
             }
     }
+
+    // Extra check for using local mesh functions with shared index space.
+    auto shared_cell_space =
+        local_grid.sharedIndexSpace( Cajita::Own(), Cajita::Cell(), 0, 1 );
+    std::cout << shared_cell_space.extent( 0 ) << " "
+              << shared_cell_space.extent( 1 ) << std::endl;
+    {
+        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
+        std::cout << loc_x.extent( 0 ) << " " << loc_x.extent( 1 ) << std::endl;
+        Kokkos::parallel_for(
+            "get_cell_coord",
+            createExecutionPolicy( shared_cell_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j ) {
+                Kokkos::Array<double, 2> loc;
+                // Passing this index to the local mesh is the relevant check.
+                auto idx = shared_cell_space.min();
+                local_mesh.coordinates( Cell(), idx.data(), loc.data() );
+                loc_x( i, j ) = loc[Dim::I];
+                loc_y( i, j ) = loc[Dim::J];
+                measure( i, j ) = local_mesh.measure( Cell(), idx.data() );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        for ( int i = 0; i < shared_cell_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < shared_cell_space.extent( Dim::J ); ++j )
+            {
+                int i_shared = shared_cell_space.min( Dim::I ) + i;
+                int j_shared = shared_cell_space.min( Dim::J ) + j;
+
+                // This is specific to the neighbor chosen above at (0,1).
+                EXPECT_FLOAT_EQ( loc_x_m( i_shared, j_shared ),
+                                 own_lc_m( Dim::I ) + cell_size * 0.5 );
+                EXPECT_FLOAT_EQ( loc_y_m( i_shared, j_shared ),
+                                 own_hc_m( Dim::J ) - cell_size * 0.5 );
+                EXPECT_FLOAT_EQ( measure_m( i_shared, j_shared ),
+                                 cell_size * cell_size );
+            }
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstLocalMesh3d.hpp
+++ b/cajita/unit_test/tstLocalMesh3d.hpp
@@ -461,6 +461,55 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
                     EXPECT_FLOAT_EQ( measure_m( i, j, k ), cell_size );
                 }
     }
+
+    // Extra check for using local mesh functions with shared index space.
+    auto shared_cell_space =
+        local_grid.sharedIndexSpace( Cajita::Own(), Cajita::Cell(), 0, 1, 0 );
+    {
+        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
+        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", cell_space );
+        Kokkos::parallel_for(
+            "get_cell_coord",
+            createExecutionPolicy( shared_cell_space, TEST_EXECSPACE() ),
+            KOKKOS_LAMBDA( const int i, const int j, const int k ) {
+                Kokkos::Array<double, 3> loc;
+                auto idx = shared_cell_space.min();
+                // Passing this index to the local mesh is the relevant check.
+                local_mesh.coordinates( Cell(), idx.data(), loc.data() );
+                loc_x( i, j, k ) = loc[Dim::I];
+                loc_y( i, j, k ) = loc[Dim::J];
+                loc_z( i, j, k ) = loc[Dim::K];
+                measure( i, j, k ) = local_mesh.measure( Cell(), idx.data() );
+            } );
+        auto measure_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), measure );
+        auto loc_x_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_x );
+        auto loc_y_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_y );
+        auto loc_z_m =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), loc_z );
+        for ( int i = 0; i < shared_cell_space.extent( Dim::I ); ++i )
+            for ( int j = 0; j < shared_cell_space.extent( Dim::J ); ++j )
+                for ( int k = 0; k < shared_cell_space.extent( Dim::K ); ++k )
+                {
+                    int i_shared = shared_cell_space.min( Dim::I ) + i;
+                    int j_shared = shared_cell_space.min( Dim::J ) + j;
+                    int k_shared = shared_cell_space.min( Dim::K ) + k;
+
+                    // This is specific to the neighbor at (0,1,0).
+                    EXPECT_FLOAT_EQ( loc_x_m( i_shared, j_shared, k_shared ),
+                                     own_lc_m( Dim::I ) + cell_size * 0.5 );
+                    EXPECT_FLOAT_EQ( loc_y_m( i_shared, j_shared, k_shared ),
+                                     own_hc_m( Dim::J ) - cell_size * 0.5 );
+                    EXPECT_FLOAT_EQ( loc_z_m( i_shared, j_shared, k_shared ),
+                                     own_lc_m( Dim::K ) + cell_size * 0.5 );
+                    EXPECT_FLOAT_EQ( measure_m( i_shared, j_shared, k_shared ),
+                                     cell_size * cell_size * cell_size );
+                }
+    }
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
It is not currently possible to use get `coordinates` with a `sharedIndexSpace` because it returns `long` instead of `int`

Needed for the grid halo for peridynamics (eventually MD as well)