### PR TITLE
update sparse paritioner

### DIFF
--- a/cajita/src/Cajita_SparseDimPartitioner.hpp
+++ b/cajita/src/Cajita_SparseDimPartitioner.hpp
@@ -73,8 +73,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
     /*!
       \brief Constructor - automatically compute ranks_per_dim from MPI
       communicator
-      \param comm MPI communicator to decide the rank nums in each
-      dimention
+      \param comm MPI communicator to decide the rank nums in each dimension
       \param max_workload_coeff threshold factor for re-partition
       \param workload_num total workload(particle/tile) number, used to compute
       workload_threshold
@@ -101,17 +100,20 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
     /*!
       \brief Constructor - user-defined ranks_per_dim
       communicator
+      \param comm MPI communicator to decide the rank nums in each dimension
       \param max_workload_coeff threshold factor for re-partition
       \param workload_num total workload(particle/tile) number, used to compute
       workload_threshold
       \param num_step_rebalance the simulation step number after which one
       should check if repartition is needed
-      \param ranks_per_dim 3D array, user-defined MPI ranks in per dimension
+      \param ranks_per_dim 3D array, user-defined MPI rank constrains in per
+      dimension
       \param global_cells_per_dim 3D array, global cells in each dimension
       \param max_optimize_iteration max iteration number to run the optimization
     */
     SparseDimPartitioner(
-        float max_workload_coeff, int workload_num, int num_step_rebalance,
+        MPI_Comm comm, float max_workload_coeff, int workload_num,
+        int num_step_rebalance,
         const std::array<int, num_space_dim>& ranks_per_dim,
         const std::array<int, num_space_dim>& global_cells_per_dim,
         int max_optimize_iteration = 10 )
@@ -123,6 +125,11 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
         allocate( global_cells_per_dim );
         std::copy( ranks_per_dim.begin(), ranks_per_dim.end(),
                    _ranks_per_dim.data() );
+
+        // init MPI topology
+        int comm_size;
+        MPI_Comm_size( comm, &comm_size );
+        MPI_Dims_create( comm_size, num_space_dim, _ranks_per_dim.data() );
     }
 
     /*!
@@ -367,6 +374,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                          cell_bits_per_tile_dim;
                 Kokkos::atomic_increment( &workload( ti + 1, tj + 1, tz + 1 ) );
             } );
+        Kokkos::fence();
     }
 
     /*!
@@ -393,6 +401,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                         &workload( ti + 1, tj + 1, tk + 1 ) );
                 }
             } );
+        Kokkos::fence();
     }
 
     /*!
@@ -411,6 +420,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
         // workload matrix, save the results in _workload_prefix_sum
         MPI_Allreduce( workload.data(), prefix_sum.data(), total_size, MPI_INT,
                        MPI_SUM, comm );
+        MPI_Barrier( comm );
 
         // compute the prefix sum (in three dimensions)
         // prefix sum in the dimension 0
@@ -432,6 +442,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                             prefix_sum( i, j, k ) = update;
                         }
                     } );
+        Kokkos::fence();
 
         // prefix sum in the dimension 1
         for ( int i = 0;
@@ -452,6 +463,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                             prefix_sum( i, j, k ) = update;
                         }
                     } );
+        Kokkos::fence();
 
         // prefix sum in the dimension 2
         for ( int i = 0;
@@ -472,6 +484,7 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                             prefix_sum( i, j, k ) = update;
                         }
                     } );
+        Kokkos::fence();
     }
 
     /*!
@@ -490,11 +503,31 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                            const CellUnit dx, MPI_Comm comm )
     {
         computeLocalWorkLoad( view, particle_num, global_lower_corner, dx );
+        MPI_Barrier( comm );
+
         computeFullPrefixSum( comm );
-        bool is_changed = false;
+        MPI_Barrier( comm );
+
+        // each iteration covers partitioner optization in all three dimensions
+        // (with a random dim sequence)
         for ( int i = 0; i < _max_optimize_iteration; ++i )
         {
-            optimizePartition( is_changed, std::rand() % num_space_dim );
+            bool is_changed = false; // record changes in current iteration
+            bool dim_covered[3] = { false, false, false };
+            for ( int d = 0; d < 3; ++d )
+            {
+                int random_dim_id = std::rand() % num_space_dim;
+                while ( dim_covered[random_dim_id] )
+                    random_dim_id = std::rand() % num_space_dim;
+
+                bool is_dim_changed = false; // record changes in current dim
+                optimizePartition( is_dim_changed, random_dim_id );
+
+                // update control info
+                is_changed = is_changed || is_dim_changed;
+                dim_covered[random_dim_id] = true;
+            }
+            // return if the current partition is optimal
             if ( !is_changed )
                 return i;
         }
@@ -511,11 +544,29 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
     int optimizePartition( const SparseMapType& sparseMap, MPI_Comm comm )
     {
         computeLocalWorkLoad( sparseMap );
+        MPI_Barrier( comm );
+
         computeFullPrefixSum( comm );
-        bool is_changed = false;
+        MPI_Barrier( comm );
+
         for ( int i = 0; i < _max_optimize_iteration; ++i )
         {
-            optimizePartition( is_changed, std::rand() % num_space_dim );
+            bool is_changed = false; // record changes in current iteration
+            bool dim_covered[3] = { false, false, false };
+            for ( int d = 0; d < 3; ++d )
+            {
+                int random_dim_id = std::rand() % num_space_dim;
+                while ( dim_covered[random_dim_id] )
+                    random_dim_id = std::rand() % num_space_dim;
+
+                bool is_dim_changed = false; // record changes in current dim
+                optimizePartition( is_dim_changed, random_dim_id );
+
+                // update control info
+                is_changed = is_changed || is_dim_changed;
+                dim_covered[random_dim_id] = true;
+            }
+            // return if the current partition is optimal
             if ( !is_changed )
                 return i;
         }
@@ -569,9 +620,13 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                                               dj, j, dk, k ) /
                         rank;
                 } );
+            Kokkos::fence();
 
             // point_i: current partition position
             int point_i = 1;
+            // equal_start_point: register the beginning pos of potentially
+            // equivalent partitions
+            int equal_start_point = 1;
             // last_point: the opimized position for the lask partition
             int last_point = 0;
             // current_workload: the workload between [last_point, point_i)
@@ -593,6 +648,8 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                             current_workload( jnk ) = compute_sub_workload(
                                 di, last_point, point_i, dj, j, dk, k );
                         } );
+                    Kokkos::fence();
+
                     // compute the (w_jk^ave - w_jk^{last_point:point_i})
                     Kokkos::parallel_for(
                         "compute_diff",
@@ -601,9 +658,14 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                         KOKKOS_LAMBDA( uint32_t jnk ) {
                             auto wl =
                                 current_workload( jnk ) - ave_workload( jnk );
-                            wl *= wl;
+                            // compute absolute diff (rather than squares to
+                            // avoid potential overflow)
+                            // TODO: update when Kokkos::abs() available
+                            wl = wl > 0 ? wl : -wl;
                             current_workload( jnk ) = wl;
                         } );
+                    Kokkos::fence();
+
                     // compute the sum of the difference in all rank_j*rank_k
                     // regions
                     int diff;
@@ -615,24 +677,35 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
                             update += current_workload( idx );
                         },
                         diff );
+                    Kokkos::fence();
+
                     // record the new optimal position
                     if ( diff <= last_diff )
                     {
+                        // register starting points of potentially equivalent
+                        // partitions
+                        if ( diff != last_diff )
+                            equal_start_point = point_i;
+
                         // check if point_i reach the total_tile_num
                         if ( point_i == rec_mirror( rank, di ) )
                         {
                             rec_mirror( current_rank, di ) = point_i;
                             break;
                         }
+
                         last_diff = diff;
                         point_i++;
                     }
                     else
                     {
-                        // final optimal position
-                        if ( rec_mirror( current_rank, di ) != point_i - 1 )
+                        // final optimal position - middle position of all
+                        // potentially equivalent partitions
+                        if ( rec_mirror( current_rank, di ) !=
+                             ( point_i - 1 + equal_start_point ) / 2 )
                         {
-                            rec_mirror( current_rank, di ) = point_i - 1;
+                            rec_mirror( current_rank, di ) =
+                                ( point_i - 1 + equal_start_point ) / 2;
                             is_changed = true;
                         }
                         last_point = point_i - 1;

--- a/cajita/unit_test/tstSparseDimPartitioner.hpp
+++ b/cajita/unit_test/tstSparseDimPartitioner.hpp
@@ -144,6 +144,7 @@ void uniform_distribution_automatic_rank()
                     sis.insertCell( i, j, k );
                 }
         } );
+    Kokkos::fence();
 
     // compute workload and do partition optimization
     partitioner.optimizePartition( sis, MPI_COMM_WORLD );
@@ -421,6 +422,7 @@ void random_distribution_automatic_rank( int occupy_num_per_rank,
                 sis.insertTile( tiles_view( id, 0 ), tiles_view( id, 1 ),
                                 tiles_view( id, 2 ) );
             } );
+        Kokkos::fence();
 
         // compute workload from a sparseMap and do partition optimization
         partitioner.optimizePartition( sis, MPI_COMM_WORLD );


### PR DESCRIPTION
**Bug fix**
1. Added many missing `Kokkos::fence()` - fixes HIP failures with newer Kokkos versions

**Major updates:**
1. the main `optimizePartition` function
- previous implementation: randomly choose one dimension to optimize in each iteration;
- potential problems: if two consecutive choices are the same, the optimization will return with the other two dimensions unoptimized.
- the update: cover all dimensions (with a random permutation) in each optimization iteration. 
2. `optimizePartition` for each dimension - choice of optimal position
- previous implementation: use the left-most optimal position when there are multiple optimal solutions
- potential problems: in general real simulations, we won't optimize the partition in every time step. Suppose we use the left-most optimal position, and the object moves towards the left; Then, in the next few steps, when there is no partition optimization performed, we need to do lots of particle communication through this new-updated partition.
- the update: if there are multiple optimal solutions, say [a,b], we will use (a+b)/2 as the optimal choices.
3. `optimizaPartition` for each dimension - compute_diff 
- previous implementation: use wl^2 as the workload difference
- potential problems: may overflow when using particle number as workload unit (especially when we have 1B particles in real simulations)
- the update: use absolute value |wl| instead

**Minor updates:**
1. Constructor: init MPI topology from user's constrains