### PR TITLE
Fix mistake in comm benchmark inputs

### DIFF
--- a/benchmark/core/CMakeLists.txt
+++ b/benchmark/core/CMakeLists.txt
@@ -46,7 +46,7 @@ if(Kokkos_ENABLE_SERIAL OR Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_OPENMP OR Kokkos_
 
     if(Cabana_ENABLE_MPI)
       target_link_libraries(CommPerformance gtest)
-      add_test(NAME Cabana_Performance_Comm COMMAND ${NONMPI_PRECOMMAND} CommPerformance 1000 comm_output.txt)
+      add_test(NAME Cabana_Performance_Comm COMMAND ${NONMPI_PRECOMMAND} CommPerformance comm_output.txt)
     endif()
   endif()
 endif()

--- a/benchmark/core/Cabana_CommPerformance.cpp
+++ b/benchmark/core/Cabana_CommPerformance.cpp
@@ -382,7 +382,7 @@ int main( int argc, char* argv[] )
     Kokkos::initialize( argc, argv );
 
     // Check arguments.
-    if ( argc < 3 )
+    if ( argc < 2 )
         throw std::runtime_error( "Incorrect number of arguments. \n \
              First argument - file name for output \n \
              Optional second argument - run size (small or large) \n \


### PR DESCRIPTION
Mistake from when this benchmark needed particle count on the command line