### PR TITLE
Deprecate Cajita backwards compatibility wrappers

### DIFF
--- a/benchmark/cajita/Cajita_HaloPerformance.cpp
+++ b/benchmark/cajita/Cajita_HaloPerformance.cpp
@@ -100,7 +100,7 @@ void performanceTest( std::ostream& stream,
             // create halo
             halo_create_timer.start( halo_width );
             auto halo =
-                createHalo( *array, Cajita::NodeHaloPattern<3>(), halo_width );
+                createHalo( Cajita::NodeHaloPattern<3>(), halo_width, *array );
             halo_create_timer.stop( halo_width );
 
             // gather

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -148,9 +148,7 @@ class FaceHaloPattern<2> : public HaloPattern<2>
 };
 
 //! Full 3d halo with all 26 adjacent blocks. Backwards compatibility wrapper.
-class FullHaloPattern : public NodeHaloPattern<3>
-{
-};
+class [[deprecated]] FullHaloPattern : public NodeHaloPattern<3>{};
 
 //---------------------------------------------------------------------------//
 // Scatter reduction.
@@ -960,7 +958,7 @@ auto createHalo( const Pattern& pattern, const int width,
 //! Array-like container adapter to hold layout and data information for
 //! creating halos.
 template <class Scalar, class MemorySpace, class ArrayLayout>
-struct LayoutAdapter
+struct [[deprecated]] LayoutAdapter
 {
     //! Scalar value type.
     using value_type = Scalar;
@@ -985,8 +983,8 @@ struct LayoutAdapter
 */
 template <class Scalar, class Device, class EntityType, class MeshType,
           class Pattern>
-auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
-                 const Pattern& pattern, const int width = -1 )
+[[deprecated]] auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
+                                const Pattern& pattern, const int width = -1 )
 {
     LayoutAdapter<Scalar, typename Device::memory_space,
                   ArrayLayout<EntityType, MeshType>>
@@ -1008,8 +1006,9 @@ auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
 */
 template <class Scalar, class EntityType, class MeshType, class Pattern,
           class... Params>
-auto createHalo( const Array<Scalar, EntityType, MeshType, Params...>& array,
-                 const Pattern& pattern, const int width = -1 )
+[[deprecated]] auto
+createHalo( const Array<Scalar, EntityType, MeshType, Params...>& array,
+            const Pattern& pattern, const int width = -1 )
 {
     LayoutAdapter<
         Scalar,

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -955,10 +955,15 @@ auto createHalo( const Pattern& pattern, const int width,
 //---------------------------------------------------------------------------//
 // Backwards-compatible single array creation functions.
 //---------------------------------------------------------------------------//
-//! Array-like container adapter to hold layout and data information for
-//! creating halos.
+/*!
+  Array-like container adapter to hold layout and data information for
+  creating halos.
+
+  NOTE: This struct is only used in deprecated functions, but does not include
+  a deprecation tag to avoid nested deprecation warnings.
+*/
 template <class Scalar, class MemorySpace, class ArrayLayout>
-struct [[deprecated]] LayoutAdapter
+struct LayoutAdapter
 {
     //! Scalar value type.
     using value_type = Scalar;

--- a/cajita/src/Cajita_ManualPartitioner.hpp
+++ b/cajita/src/Cajita_ManualPartitioner.hpp
@@ -28,17 +28,14 @@ namespace Cajita
 /*!
   \brief Backwards compatibility wrapper for 3D ManualBlockPartitioner
 */
-class ManualPartitioner : public ManualBlockPartitioner<3>
-{
-  public:
-    /*!
-      \brief Constructor
-      \param ranks_per_dim MPI ranks per dimension.
-    */
-    ManualPartitioner( const std::array<int, 3>& ranks_per_dim )
-        : ManualBlockPartitioner<3>( ranks_per_dim )
-    {
-    }
+class [[deprecated]] ManualPartitioner : public ManualBlockPartitioner<3>{
+    public :
+        /*!
+          \brief Constructor
+          \param ranks_per_dim MPI ranks per dimension.
+        */
+        ManualPartitioner( const std::array<int, 3>& ranks_per_dim ) :
+            ManualBlockPartitioner<3>( ranks_per_dim ){}
 };
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_ReferenceStructuredSolver.hpp
+++ b/cajita/src/Cajita_ReferenceStructuredSolver.hpp
@@ -910,19 +910,17 @@ class ReferenceConjugateGradient
         std::copy( neighbor_set.begin(), neighbor_set.end(),
                    halo_neighbors.begin() );
 
-        // Build the halo. We put 2 entries as each operator application will
-        // gather 2 vectors with fused kernels.
-        auto halo_layout = createArrayLayout( local_grid, 2, EntityType() );
-        HaloPattern<num_space_dim> pattern;
-        pattern.setNeighbors( halo_neighbors );
-        halo = createHalo<Scalar, DeviceType>( *halo_layout, pattern, width );
-
         // Create a new layout.
         auto matrix_layout =
             createArrayLayout( local_grid, stencil.size(), EntityType() );
 
         // Allocate the matrix.
         matrix = createArray<Scalar, DeviceType>( "matrix", matrix_layout );
+
+        // Build the halo.
+        HaloPattern<num_space_dim> pattern;
+        pattern.setNeighbors( halo_neighbors );
+        halo = createHalo( pattern, width, *matrix );
     }
 
   private:

--- a/cajita/src/Cajita_UniformDimPartitioner.hpp
+++ b/cajita/src/Cajita_UniformDimPartitioner.hpp
@@ -28,9 +28,7 @@ namespace Cajita
 /*!
   \brief Backwards compatibility wrapper for 3D DimBlockPartitioner
 */
-class UniformDimPartitioner : public DimBlockPartitioner<3>
-{
-};
+class [[deprecated]] UniformDimPartitioner : public DimBlockPartitioner<3>{};
 
 //---------------------------------------------------------------------------//
 

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -11,9 +11,9 @@
 
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_GlobalMesh.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_SparseDimPartitioner.hpp>
 #include <Cajita_Types.hpp>
-#include <Cajita_UniformDimPartitioner.hpp>
 
 #include <gtest/gtest.h>
 
@@ -30,7 +30,7 @@ namespace Test
 void gridTest3d( const std::array<bool, 3>& is_dim_periodic )
 {
     // Let MPI compute the partitioning for this test.
-    UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;

--- a/cajita/unit_test/tstHalo2d.hpp
+++ b/cajita/unit_test/tstHalo2d.hpp
@@ -183,7 +183,7 @@ void gatherScatterTest( const ManualBlockPartitioner<2>& partitioner,
         ArrayOp::assign( *array, 1.0, Own() );
 
         // Create a halo.
-        auto halo = createHalo( *array, NodeHaloPattern<2>(), halo_width );
+        auto halo = createHalo( NodeHaloPattern<2>(), halo_width, *array );
 
         // Gather into the ghosts.
         halo->gather( TEST_EXECSPACE(), *array );
@@ -345,7 +345,7 @@ void scatterReduceTest( const ReduceFunc& reduce )
     pattern.setNeighbors( neighbors );
 
     // Create a halo.
-    auto halo = createHalo( *array, pattern );
+    auto halo = createHalo( pattern, array_halo_width, *array );
 
     // Scatter.
     halo->scatter( TEST_EXECSPACE(), reduce, *array );

--- a/cajita/unit_test/tstHalo3d.hpp
+++ b/cajita/unit_test/tstHalo3d.hpp
@@ -206,7 +206,7 @@ void gatherScatterTest( const ManualBlockPartitioner<3>& partitioner,
         ArrayOp::assign( *array, 1.0, Own() );
 
         // Create a halo.
-        auto halo = createHalo( *array, FullHaloPattern(), halo_width );
+        auto halo = createHalo( NodeHaloPattern<3>(), halo_width, *array );
 
         // Gather into the ghosts.
         halo->gather( TEST_EXECSPACE(), *array );
@@ -292,10 +292,10 @@ void gatherScatterTest( const ManualBlockPartitioner<3>& partitioner,
         ArrayOp::assign( *edge_k_array, 1.0, Own() );
 
         // Create a multihalo.
-        auto halo =
-            createHalo( FullHaloPattern(), halo_width, *cell_array, *node_array,
-                        *face_i_array, *face_j_array, *face_k_array,
-                        *edge_i_array, *edge_j_array, *edge_k_array );
+        auto halo = createHalo( NodeHaloPattern<3>(), halo_width, *cell_array,
+                                *node_array, *face_i_array, *face_j_array,
+                                *face_k_array, *edge_i_array, *edge_j_array,
+                                *edge_k_array );
 
         // Gather into the ghosts.
         halo->gather( TEST_EXECSPACE(), *cell_array, *node_array, *face_i_array,
@@ -414,7 +414,7 @@ void scatterReduceTest( const ReduceFunc& reduce )
     pattern.setNeighbors( neighbors );
 
     // Create a halo.
-    auto halo = createHalo( *array, pattern );
+    auto halo = createHalo( pattern, array_halo_width, *array );
 
     // Scatter.
     halo->scatter( TEST_EXECSPACE(), reduce, *array );

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -84,7 +84,8 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
         } );
 
     // Gather to get the ghosted global indices.
-    auto halo = createHalo( *global_index_array, NodeHaloPattern<3>() );
+    auto halo =
+        createHalo( NodeHaloPattern<3>(), halo_width, *global_index_array );
     halo->gather( TEST_EXECSPACE(), *global_index_array );
 
     // Do a loop over ghosted local indices and fill with the index
@@ -178,7 +179,8 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
         } );
 
     // Gather to get the ghosted global indices.
-    auto halo = createHalo( *global_index_array, NodeHaloPattern<2>() );
+    auto halo =
+        createHalo( NodeHaloPattern<2>(), halo_width, *global_index_array );
     halo->gather( TEST_EXECSPACE(), *global_index_array );
 
     // Do a loop over ghosted local indices and fill with the index

--- a/cajita/unit_test/tstInterpolation2d.hpp
+++ b/cajita/unit_test/tstInterpolation2d.hpp
@@ -80,7 +80,8 @@ void interpolationTest()
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
     auto scalar_grid_field =
         createArray<double, TEST_DEVICE>( "scalar_grid_field", scalar_layout );
-    auto scalar_halo = createHalo( *scalar_grid_field, NodeHaloPattern<2>() );
+    auto scalar_halo =
+        createHalo( NodeHaloPattern<2>(), halo_width, *scalar_grid_field );
     auto scalar_grid_host =
         Kokkos::create_mirror_view( scalar_grid_field->view() );
 
@@ -88,7 +89,8 @@ void interpolationTest()
     auto vector_layout = createArrayLayout( local_grid, 2, Node() );
     auto vector_grid_field =
         createArray<double, TEST_DEVICE>( "vector_grid_field", vector_layout );
-    auto vector_halo = createHalo( *vector_grid_field, NodeHaloPattern<2>() );
+    auto vector_halo =
+        createHalo( NodeHaloPattern<2>(), halo_width, *vector_grid_field );
     auto vector_grid_host =
         Kokkos::create_mirror_view( vector_grid_field->view() );
 

--- a/cajita/unit_test/tstInterpolation3d.hpp
+++ b/cajita/unit_test/tstInterpolation3d.hpp
@@ -83,7 +83,8 @@ void interpolationTest()
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
     auto scalar_grid_field =
         createArray<double, TEST_DEVICE>( "scalar_grid_field", scalar_layout );
-    auto scalar_halo = createHalo( *scalar_grid_field, FullHaloPattern() );
+    auto scalar_halo =
+        createHalo( NodeHaloPattern<3>(), halo_width, *scalar_grid_field );
     auto scalar_grid_host =
         Kokkos::create_mirror_view( scalar_grid_field->view() );
 
@@ -91,7 +92,8 @@ void interpolationTest()
     auto vector_layout = createArrayLayout( local_grid, 3, Node() );
     auto vector_grid_field =
         createArray<double, TEST_DEVICE>( "vector_grid_field", vector_layout );
-    auto vector_halo = createHalo( *vector_grid_field, FullHaloPattern() );
+    auto vector_halo =
+        createHalo( NodeHaloPattern<3>(), halo_width, *vector_grid_field );
     auto vector_grid_host =
         Kokkos::create_mirror_view( vector_grid_field->view() );
 

--- a/cajita/unit_test/tstLocalGrid.hpp
+++ b/cajita/unit_test/tstLocalGrid.hpp
@@ -12,8 +12,8 @@
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_LocalGrid.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_Types.hpp>
-#include <Cajita_UniformDimPartitioner.hpp>
 
 #include <gtest/gtest.h>
 
@@ -31,7 +31,7 @@ namespace Test
 void periodicTest3d()
 {
     // Let MPI compute the partitioning for this test.
-    UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;
@@ -1839,7 +1839,7 @@ void notPeriodicTest3d()
     MPI_Comm_split( MPI_COMM_WORLD, comm_rank, 0, &serial_comm );
 
     // Let MPI compute the partitioning for this test.
-    UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;
@@ -3355,7 +3355,7 @@ void notPeriodicTest2d()
 void mutabilityTest()
 {
     // Let MPI compute the partitioning for this test.
-    UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;

--- a/cajita/unit_test/tstLocalMesh3d.hpp
+++ b/cajita/unit_test/tstLocalMesh3d.hpp
@@ -15,7 +15,7 @@
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
-#include <Cajita_ManualPartitioner.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_Types.hpp>
 
 #include <gtest/gtest.h>
@@ -524,7 +524,7 @@ void uniformTest3d( const std::array<int, 3>& ranks_per_dim,
         createUniformGlobalMesh( low_corner, high_corner, cell_size );
 
     // Create the global grid.
-    ManualPartitioner partitioner( ranks_per_dim );
+    ManualBlockPartitioner<3> partitioner( ranks_per_dim );
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -556,7 +556,7 @@ void nonUniformTest3d( const std::array<int, 3>& ranks_per_dim,
                                                    edges[Dim::K] );
 
     // Create the global grid.
-    ManualPartitioner partitioner( ranks_per_dim );
+    ManualBlockPartitioner<3> partitioner( ranks_per_dim );
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
                                          is_dim_periodic, partitioner );
 
@@ -606,7 +606,7 @@ void irregularTest3d( const std::array<int, 3>& ranks_per_dim )
 
     // Create the global grid.
     std::array<bool, 3> periodic = { true, true, true };
-    ManualPartitioner partitioner( ranks_per_dim );
+    ManualBlockPartitioner<3> partitioner( ranks_per_dim );
     auto global_grid =
         createGlobalGrid( MPI_COMM_WORLD, global_mesh, periodic, partitioner );
 

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -15,8 +15,8 @@
 #include <Cajita_IndexSpace.hpp>
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_Parallel.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_Types.hpp>
-#include <Cajita_UniformDimPartitioner.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -195,7 +195,7 @@ void parallelIndexSpaceTest()
 void parallelLocalGridTest()
 {
     // Let MPI compute the partitioning for this test.
-    UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;

--- a/cajita/unit_test/tstParticleGridDistributor2d.hpp
+++ b/cajita/unit_test/tstParticleGridDistributor2d.hpp
@@ -17,8 +17,8 @@
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
-#include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_ParticleGridDistributor.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_Types.hpp>
 
 #include <Kokkos_Core.hpp>

--- a/cajita/unit_test/tstParticleGridDistributor3d.hpp
+++ b/cajita/unit_test/tstParticleGridDistributor3d.hpp
@@ -17,8 +17,8 @@
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
-#include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_ParticleGridDistributor.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_Types.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -262,7 +262,7 @@ void localOnlyTest( const GridType global_grid, const double cell_size )
         }
 }
 
-auto createGrid( const Cajita::ManualPartitioner& partitioner,
+auto createGrid( const Cajita::ManualBlockPartitioner<3>& partitioner,
                  const std::array<bool, 3>& is_periodic,
                  const double cell_size )
 {
@@ -287,7 +287,7 @@ void testParticleGridMigrate( const bool periodic )
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
     std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
-    Cajita::ManualPartitioner partitioner( ranks_per_dim );
+    Cajita::ManualBlockPartitioner<3> partitioner( ranks_per_dim );
 
     // Every boundary is periodic
     std::array<bool, 3> is_periodic = { periodic, periodic, periodic };
@@ -314,19 +314,19 @@ void testParticleGridMigrate( const bool periodic )
     if ( ranks_per_dim[0] != ranks_per_dim[1] )
     {
         std::swap( ranks_per_dim[0], ranks_per_dim[1] );
-        partitioner = Cajita::ManualPartitioner( ranks_per_dim );
+        partitioner = Cajita::ManualBlockPartitioner<3>( ranks_per_dim );
         migrateTest( global_grid, cell_size, 2, 2, true, 0 );
     }
     if ( ranks_per_dim[0] != ranks_per_dim[2] )
     {
         std::swap( ranks_per_dim[0], ranks_per_dim[2] );
-        partitioner = Cajita::ManualPartitioner( ranks_per_dim );
+        partitioner = Cajita::ManualBlockPartitioner<3>( ranks_per_dim );
         migrateTest( global_grid, cell_size, 2, 2, true, 0 );
     }
     if ( ranks_per_dim[1] != ranks_per_dim[2] )
     {
         std::swap( ranks_per_dim[1], ranks_per_dim[2] );
-        partitioner = Cajita::ManualPartitioner( ranks_per_dim );
+        partitioner = Cajita::ManualBlockPartitioner<3>( ranks_per_dim );
         migrateTest( global_grid, cell_size, 2, 2, true, 0 );
     }
 }
@@ -347,7 +347,7 @@ TEST( TEST_CATEGORY, local_only_test )
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
     std::array<int, 3> ranks_per_dim = { 0, 0, 0 };
     MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
-    Cajita::ManualPartitioner partitioner( ranks_per_dim );
+    Cajita::ManualBlockPartitioner<3> partitioner( ranks_per_dim );
 
     // Every boundary is periodic
     std::array<bool, 3> is_periodic = { true, true, true };

--- a/cajita/unit_test/tstSiloParticleOutput.hpp
+++ b/cajita/unit_test/tstSiloParticleOutput.hpp
@@ -23,8 +23,8 @@
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
+#include <Cajita_Partitioner.hpp>
 #include <Cajita_SiloParticleOutput.hpp>
-#include <Cajita_UniformDimPartitioner.hpp>
 
 #include <Cabana_AoSoA.hpp>
 #include <Cabana_DeepCopy.hpp>
@@ -48,7 +48,7 @@ using namespace Cajita;
 void writeTest()
 {
     // Let MPI compute the partitioning for this test.
-    Cajita::UniformDimPartitioner partitioner;
+    DimBlockPartitioner<3> partitioner;
 
     // Create the global grid.
     double cell_size = 0.23;

--- a/example/cajita_tutorial/09_grid_parallel/grid_parallel_example.cpp
+++ b/example/cajita_tutorial/09_grid_parallel/grid_parallel_example.cpp
@@ -38,7 +38,7 @@ void gridParallelExample()
     using device_type = exec_space::device_type;
 
     // Let MPI compute the partitioning for this example.
-    Cajita::UniformDimPartitioner partitioner;
+    Cajita::DimBlockPartitioner<3> partitioner;
 
     // Create the global mesh.
     double cell_size = 0.23;

--- a/example/cajita_tutorial/12_halo/halo_example.cpp
+++ b/example/cajita_tutorial/12_halo/halo_example.cpp
@@ -132,7 +132,7 @@ void gridHaloExample()
            - Face pattern communicates with 6 MPI neighbors in 3D (4 in 2D)
         */
         auto halo =
-            createHalo( *array, Cajita::NodeHaloPattern<3>(), halo_width );
+            createHalo( Cajita::NodeHaloPattern<3>(), halo_width, *array );
 
         /*
           Gather into the ghosts. This performs the grid communication from the

--- a/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
+++ b/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
@@ -178,16 +178,16 @@ void interpolationExample()
 
     // Create a halo for scatter operations. This concept is discussed in more
     // detail in the Halo tutorial example.
-    auto scalar_halo =
-        Cajita::createHalo( *scalar_grid_field, Cajita::NodeHaloPattern<2>() );
+    auto scalar_halo = Cajita::createHalo( Cajita::NodeHaloPattern<2>(),
+                                           halo_width, *scalar_grid_field );
 
     // Create a vector field on the grid.
     auto vector_layout =
         Cajita::createArrayLayout( local_grid, 2, Cajita::Node() );
     auto vector_grid_field = Cajita::createArray<double, ExecutionSpace>(
         "vector_grid_field", vector_layout );
-    auto vector_halo =
-        Cajita::createHalo( *vector_grid_field, Cajita::NodeHaloPattern<2>() );
+    auto vector_halo = Cajita::createHalo( Cajita::NodeHaloPattern<2>(),
+                                           halo_width, *vector_grid_field );
 
     // Simple Kokkos::Views may be used to represent particle data.
     // Create a scalar point field.


### PR DESCRIPTION
Plan to remove halo and partitioner wrappers in the next release

Spacing is a little odd with the deprecation tags