### PR TITLE
Sparse Local Grid and Tile Index Space

### DIFF
--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -202,6 +202,31 @@ createGlobalGrid( MPI_Comm comm,
                                                    partitioner );
 }
 
+/*!
+  \brief Create a sparse global grid.
+  \param comm The communicator over which to define the grid.
+  \param global_mesh The global mesh data.
+  \param periodic Whether each logical dimension is periodic.
+  \param partitioner The grid partitioner.
+*/
+template <class Scalar, std::size_t NumSpaceDim>
+std::shared_ptr<GlobalGrid<SparseMesh<Scalar, NumSpaceDim>>> createGlobalGrid(
+    MPI_Comm comm,
+    const std::shared_ptr<GlobalMesh<SparseMesh<Scalar, NumSpaceDim>>>&
+        global_mesh,
+    const std::array<bool, SparseMesh<Scalar, NumSpaceDim>::num_space_dim>&
+        periodic,
+    const BlockPartitioner<SparseMesh<Scalar, NumSpaceDim>::num_space_dim>&
+        partitioner )
+{
+    for ( long unsigned int d = 0; d < NumSpaceDim; ++d )
+        if ( periodic[d] )
+            std::runtime_error(
+                "Sparse grid doesn't support periodic BC so far!" );
+    return std::make_shared<GlobalGrid<SparseMesh<Scalar, NumSpaceDim>>>(
+        comm, global_mesh, periodic, partitioner );
+}
+
 //---------------------------------------------------------------------------//
 
 } // end namespace Cajita

--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -150,11 +150,11 @@ class IndexSpace
         return result;
     }
 
-  private:
-    // Minimum index bounds.
+  protected:
+    //! Minimum index bounds.
     Kokkos::Array<long, Rank> _min;
 
-    // Maximum index bounds.
+    //! Maximum index bounds.
     Kokkos::Array<long, Rank> _max;
 };
 

--- a/cajita/src/Cajita_SparseLocalGrid.hpp
+++ b/cajita/src/Cajita_SparseLocalGrid.hpp
@@ -1,0 +1,298 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+/*!
+  \file Cajita_SparseLocalGrid.hpp
+  \brief Sparse Local grid and related implementations
+*/
+#ifndef CAJITA_LOCALGRID_SPARSE_HPP
+#define CAJITA_LOCALGRID_SPARSE_HPP
+
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_IndexSpace.hpp>
+#include <Cajita_SparseIndexSpace.hpp>
+#include <Cajita_Types.hpp>
+
+#include <array>
+#include <vector>
+
+namespace Cajita
+{
+namespace Experimental
+{
+//---------------------------------------------------------------------------//
+template <class MeshType>
+class LocalGrid;
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Local logical grid specialized for sparse grid.
+  \tparam MeshType Mesh type: SparseMesh
+  \tparam NumSpaceDim Space Dimension, needed by SparseMesh's template
+*/
+template <class Scalar, std::size_t NumSpaceDim>
+class LocalGrid<SparseMesh<Scalar, NumSpaceDim>>
+{
+  public:
+    //! Mesh type.
+    using mesh_type = SparseMesh<Scalar, NumSpaceDim>;
+
+    //! Spatial dimension.
+    static constexpr std::size_t num_space_dim = mesh_type::num_space_dim;
+
+    /*!
+      \brief Constructor.
+      \param global_grid The global grid from which the local grid will be
+      constructed.
+      \param halo_cell_width The number of halo cells surrounding the locally
+      owned cells.
+      \param cell_num_per_tile_dim The number of local cells in each tile in
+      each dimension.
+    */
+    LocalGrid( const std::shared_ptr<GlobalGrid<mesh_type>>& global_grid,
+               const int halo_cell_width, const long cell_num_per_tile_dim );
+
+    //! \brief Get the global grid that owns the local grid.
+    const GlobalGrid<mesh_type>& globalGrid() const;
+    //! \brief Get a mutable version of the global grid that own the local grid
+    GlobalGrid<mesh_type>& globalGrid();
+
+    //! \brief Get the number of cells in the halo.
+    int haloCellWidth() const;
+
+    //! \brief Get the number of tiles in the halo.
+    int haloTileWidth() const;
+
+    //! \brief Get the total number of local cells per dimension (owned + halo).
+    //! \param d Spatial dimension.
+    int totalNumCell( const int d ) const;
+
+    //! \brief Get the total number of local cells (owned + halo) on this MPI
+    //! rank
+    int totalNumCell() const;
+
+    /*!
+      \brief Get the global index of a neighbor given neighbor rank offsets
+      relative to this local grid.
+
+      \param off_ijk %Array of neighbor offset indices.
+
+      If the neighbor rank is out of bounds return -1. Note that in the case of
+      periodic boundaries out of bounds indices are allowed as the indices will
+      be wrapped around the periodic boundary.
+    */
+    int neighborRank( const std::array<int, num_space_dim>& off_ijk ) const;
+
+    /*!
+      \brief Get the global index of a neighbor given neighbor rank offsets
+      relative to this local grid.
+
+      \param off_i, off_j, off_k Neighbor offset index in a given dimension.
+
+      If the neighbor rank is out of bounds return -1. Note that in the case of
+      periodic boundaries out of bounds indices are allowed as the indices will
+      be wrapped around the periodic boundary.
+    */
+    int neighborRank( const int off_i, const int off_j, const int off_k ) const;
+
+    /*!
+     \brief Given a decomposition type, entity type, and index type, get the
+     contiguous set of indices that span the space of those entities in the
+     local domain (return the general cell index space)
+
+     \param t1 Decomposition type: Own or Ghost
+     \param t2 Entity type: Cell, Node, Edge, or Face
+     \param t3 Index type: Local or Global
+   */
+    template <class DecompositionTag, class EntityType, class IndexType>
+    IndexSpace<num_space_dim> indexSpace( DecompositionTag t1, EntityType t2,
+                                          IndexType t3 ) const;
+
+    /*!
+      \brief Given the relative offsets of a neighbor rank, get the set of
+      global entity indices shared with that neighbor in the given
+      decomposition.
+
+      \param t1 Decomposition type: Own or Ghost
+      \param t2 Entity: Cell or Node; TODO: Edge or Face
+      \param off_ijk Array of neighbor offset indices.
+      \param halo_width Optional depth of shared indices within the halo. Must
+      be less than or equal to the halo width of the local grid. Default is to
+      use the halo width of the local grid.
+    */
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag,
+              class EntityType>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpace( DecompositionTag t1, EntityType t2,
+                          const std::array<int, num_space_dim>& off_ijk,
+                          const int halo_width = -1 ) const;
+
+    /*!
+      \brief Given the relative offsets of a neighbor rank, get the set of
+      global entity indices shared with that neighbor in the given
+      decomposition.
+
+      \tparam DecompositionTag Decomposition type: Own or Ghost
+      \tparam EntityType Entity: Cell, Node, Edge, or Face
+
+      \param t1 Decomposition type: Own or Ghost
+      \param t2 Entity: Cell or Node; TODO: Edge or Face
+      \param off_i, off_j, off_k Neighbor offset index in a given dimension.
+      \param halo_width Optional depth of shared indices within the halo. Must
+      be less than or equal to the halo width of the local grid. Default is to
+      use the halo width of the local grid.
+    */
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag,
+              class EntityType, std::size_t NSD = num_space_dim>
+    std::enable_if_t<3 == NSD, TileIndexSpace<3, cellBitsPerTileDim>>
+    sharedTileIndexSpace( DecompositionTag t1, EntityType t2, const int off_i,
+                          const int off_j, const int off_k,
+                          const int halo_width = -1 ) const;
+
+  private:
+    // Node related index space implementations
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Node,
+                                              IndexType t3 ) const;
+
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Node,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+
+    // Cell related index space implementations
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Cell,
+                                              IndexType t3 ) const;
+
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Cell,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+
+    // Face related index space implementations
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Face<Dim::I>,
+                                              IndexType t3 ) const;
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Face<Dim::J>,
+                                              IndexType t3 ) const;
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Face<Dim::K>,
+                                              IndexType t3 ) const;
+
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Face<Dim::I>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Face<Dim::J>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Face<Dim::K>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    // Edge related index space implementations1
+
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Edge<Dim::I>,
+                                              IndexType t3 ) const;
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Edge<Dim::J>,
+                                              IndexType t3 ) const;
+    template <class DecompositionTag, class IndexType>
+    IndexSpace<num_space_dim> indexSpaceImpl( DecompositionTag t1, Edge<Dim::K>,
+                                              IndexType t3 ) const;
+
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Edge<Dim::I>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Edge<Dim::J>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( DecompositionTag t1, Edge<Dim::K>,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+
+    // More genearl implementations for node and cell center indices
+    // Note: In Sparse grid, each cell considers the left-most node and its cell
+    // center as belongings, i.e., Node and Cell share the same element-to-cell
+    // mapping, thus sharse the same interface.
+    IndexSpace<num_space_dim> indexSpaceImpl( Own, Local ) const;
+    IndexSpace<num_space_dim> indexSpaceImpl( Ghost, Local ) const;
+    IndexSpace<num_space_dim> indexSpaceImpl( Own, Global ) const;
+
+    template <unsigned long long cellBitsPerTileDim>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( Own,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+    template <unsigned long long cellBitsPerTileDim>
+    TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+    sharedTileIndexSpaceImpl( Ghost,
+                              const std::array<int, num_space_dim>& off_ijk,
+                              const int halo_width ) const;
+
+  private:
+    std::shared_ptr<GlobalGrid<mesh_type>> _global_grid;
+    int _halo_cell_width;
+    const long _cell_num_per_tile_dim;
+
+}; // end LocalGrid<SparseMesh<Scalar, NumSpaceDim>>
+
+//---------------------------------------------------------------------------//
+// Creation function.
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a local grid.
+  \param global_grid The global grid from which the local grid will be
+  constructed.
+  \param halo_cell_width The number of halo cells surrounding the locally
+  owned cells.
+  \param cell_num_per_tile_dim The number of local cells in each tile in each
+  dimension.
+*/
+template <class MeshType>
+std::shared_ptr<LocalGrid<MeshType>>
+createSparseLocalGrid( const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
+                       const int halo_cell_width,
+                       const int cell_num_per_tile_dim )
+{
+    static_assert( isSparseMesh<MeshType>::value,
+                   "createSparseLocalGrid supports only SparseMesh" );
+    return std::make_shared<LocalGrid<MeshType>>( global_grid, halo_cell_width,
+                                                  cell_num_per_tile_dim );
+}
+
+} // namespace Experimental
+//---------------------------------------------------------------------------//
+} // namespace Cajita
+
+//---------------------------------------------------------------------------//
+// Template implementations
+//---------------------------------------------------------------------------//
+
+#include <Cajita_SparseLocalGrid_impl.hpp>
+
+//---------------------------------------------------------------------------//
+#endif // end CAJITA_LOCALGRID_SPARSE_HPP

--- a/cajita/src/Cajita_SparseLocalGrid_impl.hpp
+++ b/cajita/src/Cajita_SparseLocalGrid_impl.hpp
@@ -1,0 +1,573 @@
+/****************************************************************************
+ * Copyright (c) 2018-2021 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_LOCALGRID_SPARSE_IMPL_HPP
+#define CAJITA_LOCALGRID_SPARSE_IMPL_HPP
+
+#include <type_traits>
+namespace Cajita
+{
+namespace Experimental
+{
+//---------------------------------------------------------------------------//
+// Constructor
+template <class Scalar, std::size_t NumSpaceDim>
+LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::LocalGrid(
+    const std::shared_ptr<GlobalGrid<mesh_type>>& global_grid,
+    const int halo_cell_width, const long cell_num_per_tile_dim )
+    : _global_grid( global_grid )
+    , _cell_num_per_tile_dim( cell_num_per_tile_dim )
+{
+    static_assert( 3 == num_space_dim, "SparseMesh supports only 3D" );
+    // ensure integer number of halo tiles
+    _halo_cell_width =
+        static_cast<int>( ( halo_cell_width + cell_num_per_tile_dim - 1 ) /
+                          cell_num_per_tile_dim ) *
+        cell_num_per_tile_dim;
+}
+
+//---------------------------------------------------------------------------//
+// Get the global grid that owns the local grid.
+template <class Scalar, std::size_t NumSpaceDim>
+const GlobalGrid<SparseMesh<Scalar, NumSpaceDim>>&
+LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::globalGrid() const
+{
+    return *_global_grid;
+}
+
+//---------------------------------------------------------------------------//
+// Get a mutable version of the global grid that own the local grid.
+template <class Scalar, std::size_t NumSpaceDim>
+GlobalGrid<SparseMesh<Scalar, NumSpaceDim>>&
+LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::globalGrid()
+{
+    return *_global_grid;
+}
+
+//---------------------------------------------------------------------------//
+// Get the halo size. (unit in cell)
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::haloCellWidth() const
+{
+    return _halo_cell_width;
+}
+
+//---------------------------------------------------------------------------//
+// Get the halo size. (unit in tile)
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::haloTileWidth() const
+{
+    return _halo_cell_width / _cell_num_per_tile_dim;
+}
+
+//---------------------------------------------------------------------------//
+// Get the total number of local cells in a given dimension (owned + halo).
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::totalNumCell(
+    const int d ) const
+{
+    return _global_grid->ownedNumCell( d ) + 2 * _halo_cell_width;
+}
+
+//---------------------------------------------------------------------------//
+// Get the total number of local cells in current rank (owned + halo).
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::totalNumCell() const
+{
+    int total_num_cell = 1;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        total_num_cell *= totalNumCell( static_cast<int>( d ) );
+
+    return total_num_cell;
+}
+
+//---------------------------------------------------------------------------//
+// Given the relative offsets of a neighbor rank relative to this local grid's
+// indices get the of the neighbor.
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::neighborRank(
+    const std::array<int, num_space_dim>& off_ijk ) const
+{
+    std::array<int, num_space_dim> nijk;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        nijk[d] = _global_grid->dimBlockId( d ) + off_ijk[d];
+    return _global_grid->blockRank( nijk );
+}
+
+template <class Scalar, std::size_t NumSpaceDim>
+int LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::neighborRank(
+    const int off_i, const int off_j, const int off_k ) const
+{
+    std::array<int, num_space_dim> off_ijk = { off_i, off_j, off_k };
+    return neighborRank( off_ijk );
+}
+
+//! \cond Impl
+//---------------------------------------------------------------------------//
+// Get the index space for a  given combination of decomposition, entity, and
+// index types.
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class EntityType, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpace(
+    DecompositionTag t1, EntityType t2, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    return indexSpaceImpl( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+// Given the relative offsets of a neighbor rank relative to this local
+// grid's indices get the set of local entity indices shared with that
+// neighbor in the given decomposition. Optionally provide a halo width
+// for the shared space. This halo width must be less than or equal to the
+// halo width of the local grid. The default behavior is to use the halo
+// width of the local grid.
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag,
+          class EntityType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpace(
+    DecompositionTag t1, EntityType t2,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    static constexpr unsigned long long cell_num_per_tile_dim =
+        1 << cellBitsPerTileDim;
+
+    int hw = ( -1 == halo_width ) ? _halo_cell_width : halo_width;
+    hw = static_cast<int>( ( hw + cell_num_per_tile_dim - 1 ) /
+                           cell_num_per_tile_dim ) *
+         cell_num_per_tile_dim;
+
+    // Check that the offsets are valid.
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        if ( off_ijk[d] < -1 || 1 < off_ijk[d] )
+            throw std::logic_error( "Neighbor indices out of bounds" );
+
+    // Check that the requested halo width is valid.
+    if ( hw > _halo_cell_width )
+        throw std::logic_error(
+            "Requested halo width larger than local grid halo" );
+
+    // Check to see if this is a valid neighbor. If not, return a shared space
+    // of size 0.
+    if ( neighborRank( off_ijk ) < 0 )
+    {
+        std::array<long, num_space_dim> zero_size;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            zero_size[d] = 0;
+        return TileIndexSpace<num_space_dim, cellBitsPerTileDim>( zero_size,
+                                                                  zero_size );
+    }
+
+    // Call the underlying implementation.
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, t2, off_ijk, hw );
+}
+
+//---------------------------------------------------------------------------//
+// Get the global shared tile index space according to input tags
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag,
+          class EntityType, std::size_t NSD>
+std::enable_if_t<3 == NSD, TileIndexSpace<3, cellBitsPerTileDim>>
+LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpace(
+    DecompositionTag t1, EntityType t2, const int off_i, const int off_j,
+    const int off_k, const int halo_width ) const
+{
+    std::array<int, 3> off_ijk = { off_i, off_j, off_k };
+    return sharedTileIndexSpace<cellBitsPerTileDim>( t1, t2, off_ijk,
+                                                     halo_width );
+}
+
+//---------------------------------------------------------------------------//
+//----------------------------- Node/Cell -----------------------------------//
+//---------------------------------------------------------------------------//
+// Get the local index space of the owned nodes or cell centers (unit in cell)
+template <class Scalar, std::size_t NumSpaceDim>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl( Own,
+                                                                 Local ) const
+    -> IndexSpace<num_space_dim>
+{
+    // Compute the lower bound.
+    std::array<long, num_space_dim> min;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        min[d] = _halo_cell_width;
+
+    // Compute the upper bound.
+    std::array<long, num_space_dim> max;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        max[d] = min[d] + _global_grid->ownedNumCell( d );
+
+    return IndexSpace<num_space_dim>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+// Get the local index space of the owned and ghosted nodes or cell centers
+// (unit in cell)
+template <class Scalar, std::size_t NumSpaceDim>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl( Ghost,
+                                                                 Local ) const
+    -> IndexSpace<num_space_dim>
+{
+    // Compute the size.
+    std::array<long, num_space_dim> size;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        size[d] = totalNumCell( d );
+    }
+
+    return IndexSpace<num_space_dim>( size );
+}
+
+//---------------------------------------------------------------------------//
+// Get the local index space of the owned nodes or cell centers (unit in cell)
+template <class Scalar, std::size_t NumSpaceDim>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl( Own,
+                                                                 Global ) const
+    -> IndexSpace<num_space_dim>
+{
+    // Compute the lower bound.
+    std::array<long, num_space_dim> min;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        min[d] = _global_grid->globalOffset( d );
+
+    // Compute the upper bound.
+    std::array<long, num_space_dim> max;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+        max[d] = min[d] + _global_grid->ownedNumCell( d );
+
+    return IndexSpace<num_space_dim>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+// Given a relative set of indices of a neighbor, get the set of global
+// tile indices we own that we share with that neighbor to use as ghosts.
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    Own, const std::array<int, num_space_dim>& off_ijk,
+    const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    auto owned_cell_space = indexSpaceImpl( Own(), Node(), Global() );
+    // Compute the lower bound.
+    std::array<long, num_space_dim> min;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == off_ijk[d] )
+            min[d] = owned_cell_space.min( d ) >> cellBitsPerTileDim;
+
+        // Middle neighbor.
+        else if ( 0 == off_ijk[d] )
+            min[d] = owned_cell_space.min( d ) >> cellBitsPerTileDim;
+
+        // Upper neighbor.
+        else if ( 1 == off_ijk[d] )
+            min[d] = ( owned_cell_space.max( d ) - halo_width ) >>
+                     cellBitsPerTileDim;
+        else
+            throw std::runtime_error( "Neighbor offset must be 1, 0, or -1" );
+    }
+
+    // Compute the upper bound.
+    std::array<long, num_space_dim> max;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == off_ijk[d] )
+            max[d] = ( owned_cell_space.min( d ) + halo_width ) >>
+                     cellBitsPerTileDim;
+
+        // Middle neighbor.
+        else if ( 0 == off_ijk[d] )
+            max[d] = owned_cell_space.max( d ) >> cellBitsPerTileDim;
+
+        // Upper neighbor.
+        else if ( 1 == off_ijk[d] )
+            max[d] = owned_cell_space.max( d ) >> cellBitsPerTileDim;
+        else
+            throw std::runtime_error( "Neighbor offset must be 1, 0, or -1" );
+    }
+
+    return TileIndexSpace<num_space_dim, cellBitsPerTileDim>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+// Given a relative set of indices of a neighbor, get set of global tile
+// indices owned by that neighbor that are shared with us to use as ghosts.
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    Ghost, const std::array<int, num_space_dim>& off_ijk,
+    const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    // Get the owned local index space.
+    auto owned_cell_space = indexSpaceImpl( Own(), Node(), Global() );
+
+    // Compute the lower bound.
+    std::array<long, num_space_dim> min;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == off_ijk[d] )
+            min[d] = ( owned_cell_space.min( d ) - halo_width ) >>
+                     cellBitsPerTileDim;
+
+        // Middle neighbor
+        else if ( 0 == off_ijk[d] )
+            min[d] = owned_cell_space.min( d ) >> cellBitsPerTileDim;
+
+        // Upper neighbor.
+        else if ( 1 == off_ijk[d] )
+            min[d] = owned_cell_space.max( d ) >> cellBitsPerTileDim;
+        else
+            throw std::runtime_error( "Neighbor offset must be 1, 0, or -1" );
+    }
+
+    // Compute the upper bound.
+    std::array<long, num_space_dim> max;
+    for ( std::size_t d = 0; d < num_space_dim; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == off_ijk[d] )
+            max[d] = owned_cell_space.min( d ) >> cellBitsPerTileDim;
+
+        // Middle neighbor
+        else if ( 0 == off_ijk[d] )
+            max[d] = owned_cell_space.max( d ) >> cellBitsPerTileDim;
+
+        // Upper neighbor.
+        else if ( 1 == off_ijk[d] )
+            max[d] = ( owned_cell_space.max( d ) + halo_width ) >>
+                     cellBitsPerTileDim;
+        else
+            throw std::runtime_error( "Neighbor offset must be 1, 0, or -1" );
+    }
+
+    return TileIndexSpace<num_space_dim, cellBitsPerTileDim>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+//-------------------------------- Node -------------------------------------//
+//---------------------------------------------------------------------------//
+// Implementations for node indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Node, IndexType t3 ) const -> IndexSpace<num_space_dim>
+{
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementation for node-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Node, const std::array<int, num_space_dim>& off_ijk,
+    const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+//---------------------------------------------------------------------------//
+//-------------------------------- Cell -------------------------------------//
+//---------------------------------------------------------------------------//
+// Implementations for cell indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Cell, IndexType t3 ) const -> IndexSpace<num_space_dim>
+{
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementation for cell-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Cell, const std::array<int, num_space_dim>& off_ijk,
+    const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+//---------------------------------------------------------------------------//
+//-------------------------------- Face -------------------------------------//
+//---------------------------------------------------------------------------//
+// Implementations for Face<Dim::I> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Face<Dim::I>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementations for Face<Dim::J> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Face<Dim::J>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementations for Face<Dim::K> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Face<Dim::K>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementation for face<Dim::I>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Face<Dim::I>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+// Implementation for face<Dim::J>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Face<Dim::J>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+// Implementation for face<Dim::K>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Face<Dim::K>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Face entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+//---------------------------------------------------------------------------//
+//-------------------------------- Edge -------------------------------------//
+//---------------------------------------------------------------------------//
+// Implementations for edge<Dim::I> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::I>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementations for edge<Dim::J> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::J>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementations for edge<Dim::K> indices
+template <class Scalar, std::size_t NumSpaceDim>
+template <class DecompositionTag, class IndexType>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::indexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::K>, IndexType t3 ) const
+    -> IndexSpace<num_space_dim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return indexSpaceImpl( t1, t3 );
+}
+
+// Implementation for Edge<Dim::I>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::I>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+// Implementation for Edge<Dim::I>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::J>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+
+// Implementation for Edge<Dim::I>-related shared index space
+template <class Scalar, std::size_t NumSpaceDim>
+template <unsigned long long cellBitsPerTileDim, class DecompositionTag>
+auto LocalGrid<SparseMesh<Scalar, NumSpaceDim>>::sharedTileIndexSpaceImpl(
+    DecompositionTag t1, Edge<Dim::K>,
+    const std::array<int, num_space_dim>& off_ijk, const int halo_width ) const
+    -> TileIndexSpace<num_space_dim, cellBitsPerTileDim>
+{
+    std::runtime_error(
+        "Sparse grid implementation doesn't support Edge entities so far" );
+    return sharedTileIndexSpaceImpl<cellBitsPerTileDim>( t1, off_ijk,
+                                                         halo_width );
+}
+//! \endcond
+
+//---------------------------------------------------------------------------//
+} // namespace Experimental
+} // namespace Cajita
+
+#endif // end CAJITA_LOCALGRID_SPARSE_IMPL_HPP

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SERIAL_TESTS
 set(MPI_TESTS
   GlobalGrid
   LocalGrid
+  SparseLocalGrid
   IndexConversion
   LocalMesh3d
   LocalMesh2d

--- a/cajita/unit_test/tstSparseLocalGrid.hpp
+++ b/cajita/unit_test/tstSparseLocalGrid.hpp
@@ -1,0 +1,482 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_SparseDimPartitioner.hpp>
+#include <Cajita_SparseLocalGrid.hpp>
+#include <Cajita_Types.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+#include <array>
+#include <numeric>
+
+using namespace Cajita;
+using namespace Cajita::Experimental;
+
+namespace Test
+{
+template <typename EntityType>
+void sparseLocalGridTest( EntityType t2 )
+{
+    // Create the global mesh.
+    double cell_size = 0.23;
+    std::array<int, 3> global_num_cell = { 16, 32, 64 };
+    int cell_num_per_tile_dim = 4;
+    std::array<int, 3> global_num_tile = { 16 / cell_num_per_tile_dim,
+                                           32 / cell_num_per_tile_dim,
+                                           64 / cell_num_per_tile_dim };
+    std::array<double, 3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double, 3> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh_ptr = Cajita::createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    // Create and initialize sparse partitioner
+    std::array<bool, 3> periodic = { false, false, false };
+    SparseDimPartitioner<TEST_DEVICE, 4> partitioner(
+        MPI_COMM_WORLD, 1.5, 16 * 32, 100, global_num_cell, 10 );
+    auto ranks_per_dim =
+        partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
+    std::array<std::vector<int>, 3> rec_partitions;
+    for ( int d = 0; d < 3; ++d )
+    {
+        int ele = global_num_tile[d] / ranks_per_dim[d];
+        int part = 0;
+        for ( int i = 0; i < ranks_per_dim[d]; ++i )
+        {
+            rec_partitions[d].push_back( part );
+            part += ele;
+        }
+        rec_partitions[d].push_back( global_num_tile[d] );
+    }
+    partitioner.initializeRecPartition( rec_partitions[0], rec_partitions[1],
+                                        rec_partitions[2] );
+
+    // Create global grid
+    auto global_grid_ptr = Cajita::createGlobalGrid(
+        MPI_COMM_WORLD, global_mesh_ptr, periodic, partitioner );
+
+    // Create a local grid.
+    int halo_width = 3;
+    auto local_grid_ptr = Cajita::Experimental::createSparseLocalGrid(
+        global_grid_ptr, halo_width, cell_num_per_tile_dim );
+
+    // Check sizes - constructor should correct the halo_width to
+    // k*cell_num_per_tile_dim
+    EXPECT_EQ( local_grid_ptr->haloCellWidth(), 4 );
+    EXPECT_EQ( local_grid_ptr->haloTileWidth(), 1 );
+    halo_width = 4;
+
+    // Get the local number of cells.
+    auto owned_cell_space_local =
+        local_grid_ptr->indexSpace( Own(), t2, Local() );
+    std::vector<int> local_num_cells( 3 );
+    for ( int d = 0; d < 3; ++d )
+        local_num_cells[d] = owned_cell_space_local.extent( d );
+
+    // Compute a global set of local cell size arrays.
+    auto grid_comm = global_grid_ptr->comm();
+    std::vector<int> cart_dims( 3 );
+    std::vector<int> cart_period( 3 );
+    std::vector<int> cart_rank( 3 );
+    MPI_Cart_get( grid_comm, 3, cart_dims.data(), cart_period.data(),
+                  cart_rank.data() );
+
+    std::vector<int> local_num_cell_i( cart_dims[Dim::I], 0 );
+    std::vector<int> local_num_cell_j( cart_dims[Dim::J], 0 );
+    std::vector<int> local_num_cell_k( cart_dims[Dim::K], 0 );
+
+    local_num_cell_i[cart_rank[Dim::I]] = local_num_cells[Dim::I];
+    local_num_cell_j[cart_rank[Dim::J]] = local_num_cells[Dim::J];
+    local_num_cell_k[cart_rank[Dim::K]] = local_num_cells[Dim::K];
+
+    MPI_Allreduce( MPI_IN_PLACE, local_num_cell_i.data(), cart_dims[Dim::I],
+                   MPI_INT, MPI_MAX, grid_comm );
+    MPI_Allreduce( MPI_IN_PLACE, local_num_cell_j.data(), cart_dims[Dim::J],
+                   MPI_INT, MPI_MAX, grid_comm );
+    MPI_Allreduce( MPI_IN_PLACE, local_num_cell_k.data(), cart_dims[Dim::K],
+                   MPI_INT, MPI_MAX, grid_comm );
+
+    // Check the neighbor rank
+    for ( int i = -1; i < 2; ++i )
+        for ( int j = -1; j < 2; ++j )
+            for ( int k = -1; k < 2; ++k )
+            {
+                std::vector<int> nr = { cart_rank[Dim::I] + i,
+                                        cart_rank[Dim::J] + j,
+                                        cart_rank[Dim::K] + k };
+                if ( nr[Dim::I] < 0 || nr[Dim::I] >= cart_dims[Dim::I] ||
+                     nr[Dim::J] < 0 || nr[Dim::J] >= cart_dims[Dim::J] ||
+                     nr[Dim::K] < 0 || nr[Dim::K] >= cart_dims[Dim::K] )
+                    continue;
+                int nrank;
+                MPI_Cart_rank( grid_comm, nr.data(), &nrank );
+                EXPECT_EQ( local_grid_ptr->neighborRank( i, j, k ), nrank );
+            }
+
+    // Check to make sure we got the right number of total cells in each
+    // dimension.
+    EXPECT_EQ( global_num_cell[Dim::I],
+               std::accumulate( local_num_cell_i.begin(),
+                                local_num_cell_i.end(), 0 ) );
+    EXPECT_EQ( global_num_cell[Dim::J],
+               std::accumulate( local_num_cell_j.begin(),
+                                local_num_cell_j.end(), 0 ) );
+    EXPECT_EQ( global_num_cell[Dim::K],
+               std::accumulate( local_num_cell_k.begin(),
+                                local_num_cell_k.end(), 0 ) );
+
+    // Check the local cell bounds.
+    EXPECT_EQ( owned_cell_space_local.min( Dim::I ), halo_width );
+    EXPECT_EQ( owned_cell_space_local.max( Dim::I ),
+               local_num_cells[Dim::I] + halo_width );
+    EXPECT_EQ( owned_cell_space_local.min( Dim::J ), halo_width );
+    EXPECT_EQ( owned_cell_space_local.max( Dim::J ),
+               local_num_cells[Dim::J] + halo_width );
+    EXPECT_EQ( owned_cell_space_local.min( Dim::K ), halo_width );
+    EXPECT_EQ( owned_cell_space_local.max( Dim::K ),
+               local_num_cells[Dim::K] + halo_width );
+
+    // Check the global owned cell bounds.
+    auto global_owned_cell_space =
+        local_grid_ptr->indexSpace( Own(), t2, Global() );
+    EXPECT_EQ( global_owned_cell_space.min( Dim::I ),
+               global_grid_ptr->globalOffset( Dim::I ) );
+    EXPECT_EQ( global_owned_cell_space.max( Dim::I ),
+               global_grid_ptr->globalOffset( Dim::I ) +
+                   local_num_cells[Dim::I] );
+    EXPECT_EQ( global_owned_cell_space.min( Dim::J ),
+               global_grid_ptr->globalOffset( Dim::J ) );
+    EXPECT_EQ( global_owned_cell_space.max( Dim::J ),
+               global_grid_ptr->globalOffset( Dim::J ) +
+                   local_num_cells[Dim::J] );
+    EXPECT_EQ( global_owned_cell_space.min( Dim::K ),
+               global_grid_ptr->globalOffset( Dim::K ) );
+    EXPECT_EQ( global_owned_cell_space.max( Dim::K ),
+               global_grid_ptr->globalOffset( Dim::K ) +
+                   local_num_cells[Dim::K] );
+
+    // Check the ghosted cell bounds.
+    auto ghosted_cell_space =
+        local_grid_ptr->indexSpace( Ghost(), t2, Local() );
+    for ( int d = 0; d < 3; ++d )
+    {
+        EXPECT_EQ( ghosted_cell_space.extent( d ),
+                   owned_cell_space_local.extent( d ) + 2 * halo_width );
+    }
+
+    // Check the cells we own that we will share with our neighbors. Cover
+    // enough of the neighbors that we know the bounds are correct in each
+    // dimension. The three variations here cover all of the cases.
+    auto owned_cell_space = local_grid_ptr->indexSpace( Own(), t2, Global() );
+    if ( cart_rank[Dim::I] > 0 )
+    {
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, -1, 0, 0 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) + halo_width );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::J] > 0 )
+    {
+
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, 0, -1, 0 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) + halo_width );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::K] > 0 )
+    {
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, 0, 0, -1 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) + halo_width );
+    }
+
+    if ( cart_rank[Dim::I] + 1 < cart_dims[Dim::I] )
+    {
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, 1, 0, 0 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) - halo_width );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::J] + 1 < cart_dims[Dim::J] )
+    {
+
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, 0, 1, 0 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) - halo_width );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::K] + 1 < cart_dims[Dim::K] )
+    {
+        auto owned_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Own(), t2, 0, 0, 1 );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( owned_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) - halo_width );
+        EXPECT_EQ( owned_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+
+    // Check the tiles are ghosts that our neighbors own. Cover enough of the
+    // neighbors that we know the bounds are correct in each dimension. The
+    // three variations here cover all of the cases.
+    if ( cart_rank[Dim::I] > 0 )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, -1, 0, 0 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) - halo_width );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::J] > 0 )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, 0, -1, 0 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) - halo_width );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::K] > 0 )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, 0, 0, -1 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) - halo_width );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+    }
+
+    if ( cart_rank[Dim::I] + 1 < cart_dims[Dim::I] )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, 1, 0, 0 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) + halo_width );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::J] + 1 < cart_dims[Dim::J] )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, 0, 1, 0 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) + halo_width );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::K ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+    }
+    if ( cart_rank[Dim::K] + 1 < cart_dims[Dim::K] )
+    {
+        auto ghosted_shared_tile_space =
+            local_grid_ptr->sharedTileIndexSpace<2>( Ghost(), t2, 0, 0, 1 );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::I ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::I ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.min( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::J ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::J ) );
+        EXPECT_EQ( ghosted_shared_tile_space.min( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) );
+        EXPECT_EQ( ghosted_shared_tile_space.max( Dim::K ) *
+                       cell_num_per_tile_dim,
+                   owned_cell_space.max( Dim::K ) + halo_width );
+    }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( sparse_local_grid, 3d_sprase_local_grid )
+{
+    // Currently, periodic BC is not supported in Sparse Grid
+    sparseLocalGridTest( Cell() );
+    sparseLocalGridTest( Node() );
+}
+
+//---------------------------------------------------------------------------//
+} // namespace Test


### PR DESCRIPTION
1. SparseLocalGrid: get owned/ghosted (cell) index space, and owned/ghosted shared tile index spaces (global index)
2. TileIndexSpace: inherent from the general index space but with tile as the unit, with specialized interfaces computing tile sizes