### PR TITLE
Run benchmarks with default and default host backends

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -120,6 +120,7 @@ pipeline {
                               -D Cabana_REQUIRE_MPI=ON \
                               -D Cabana_REQUIRE_SYCL=ON \
                               -D Cabana_ENABLE_TESTING=ON \
+                              -D Cabana_ENABLE_PERFORMANCE_TESTING=ON \
                               -D Cabana_ENABLE_EXAMPLES=ON \
                               -D Cabana_ENABLE_CAJITA=OFF \
                             .. && \

--- a/benchmark/cajita/CMakeLists.txt
+++ b/benchmark/cajita/CMakeLists.txt
@@ -9,30 +9,28 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
-if(Kokkos_ENABLE_SERIAL OR Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_OPENMP OR Kokkos_ENABLE_HIP)
-    add_executable(SparseMapPerformance Cajita_SparseMapPerformance.cpp)
-    target_link_libraries(SparseMapPerformance Cajita)
+add_executable(SparseMapPerformance Cajita_SparseMapPerformance.cpp)
+target_link_libraries(SparseMapPerformance Cajita)
 
-    add_executable(SparsePartitionerPerformance Cajita_SparsePartitionerPerformance.cpp)
-    target_link_libraries(SparsePartitionerPerformance Cajita)
-  
-    add_executable(HaloPerformance Cajita_HaloPerformance.cpp)
-    target_link_libraries(HaloPerformance Cajita)
+add_executable(SparsePartitionerPerformance Cajita_SparsePartitionerPerformance.cpp)
+target_link_libraries(SparsePartitionerPerformance Cajita)
 
-    if(Cabana_ENABLE_HEFFTE)
-      add_executable(FastFourierTransformPerformance Cajita_FastFourierTransformPerformance.cpp)
-      target_link_libraries(FastFourierTransformPerformance Cajita)
-    endif()
+add_executable(HaloPerformance Cajita_HaloPerformance.cpp)
+target_link_libraries(HaloPerformance Cajita)
 
-  if(Cabana_ENABLE_TESTING)
-    add_test(NAME Cajita_SparseMapPerformance COMMAND ${NONMPI_PRECOMMAND} SparseMapPerformance sparsemap_output.txt)
+if(Cabana_ENABLE_HEFFTE)
+  add_executable(FastFourierTransformPerformance Cajita_FastFourierTransformPerformance.cpp)
+  target_link_libraries(FastFourierTransformPerformance Cajita)
+endif()
 
-    add_test(NAME Cajita_SparsePartitionerPerformance COMMAND ${NONMPI_PRECOMMAND} SparsePartitionerPerformance sparsepartitioner_output.txt)
+if(Cabana_ENABLE_TESTING)
+  add_test(NAME Cajita_SparseMapPerformance COMMAND ${NONMPI_PRECOMMAND} SparseMapPerformance sparsemap_output.txt)
 
-    add_test(NAME Cajita_HaloPerformance COMMAND ${NONMPI_PRECOMMAND} HaloPerformance halo_output.txt)
+  add_test(NAME Cajita_SparsePartitionerPerformance COMMAND ${NONMPI_PRECOMMAND} SparsePartitionerPerformance sparsepartitioner_output.txt)
 
-    if (Cabana_ENABLE_HEFFTE)
-      add_test(NAME Cajita_FastFourierTransformPerformance COMMAND ${NONMPI_PRECOMMAND} FastFourierTransformPerformance fastfouriertransform_output.txt)
-    endif()
+  add_test(NAME Cajita_HaloPerformance COMMAND ${NONMPI_PRECOMMAND} HaloPerformance halo_output.txt)
+
+  if (Cabana_ENABLE_HEFFTE)
+    add_test(NAME Cajita_FastFourierTransformPerformance COMMAND ${NONMPI_PRECOMMAND} FastFourierTransformPerformance fastfouriertransform_output.txt)
   endif()
 endif()

--- a/benchmark/cajita/Cajita_SparseMapPerformance.cpp
+++ b/benchmark/cajita/Cajita_SparseMapPerformance.cpp
@@ -221,31 +221,21 @@ int main( int argc, char* argv[] )
     std::fstream file;
     file.open( filename, std::fstream::out );
 
-    // Run the tests.
-#ifdef KOKKOS_ENABLE_SERIAL
-    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-    performanceTest<SerialDevice>( file, "serial_", problem_sizes,
-                                   num_cells_per_dim );
-#endif
+    // Do everything on the default CPU.
+    using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+    using host_device_type = host_exec_space::device_type;
+    // Do everything on the default device with default memory.
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using device_type = exec_space::device_type;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-    performanceTest<OpenMPDevice>( file, "openmp_", problem_sizes,
-                                   num_cells_per_dim );
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA
-    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-    performanceTest<CudaDevice>( file, "cuda_", problem_sizes,
-                                 num_cells_per_dim );
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-    using HipDevice = Kokkos::Device<Kokkos::Experimental::HIP,
-                                     Kokkos::Experimental::HIPSpace>;
-    performanceTest<HipDevice>( file, "hip_", problem_sizes,
-                                num_cells_per_dim );
-#endif
+    // Don't run twice on the CPU if only host enabled.
+    if ( !std::is_same<device_type, host_device_type>{} )
+    {
+        performanceTest<device_type>( file, "device_", problem_sizes,
+                                      num_cells_per_dim );
+    }
+    performanceTest<host_device_type>( file, "host_", problem_sizes,
+                                       num_cells_per_dim );
 
     // Close the output file on rank 0.
     file.close();

--- a/benchmark/core/CMakeLists.txt
+++ b/benchmark/core/CMakeLists.txt
@@ -9,39 +9,37 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
-if(Kokkos_ENABLE_SERIAL OR Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_OPENMP OR Kokkos_ENABLE_HIP)
-  add_executable(BinSortPerformance Cabana_BinSortPerformance.cpp)
-  target_link_libraries(BinSortPerformance cabanacore)
+add_executable(BinSortPerformance Cabana_BinSortPerformance.cpp)
+target_link_libraries(BinSortPerformance cabanacore)
 
-  add_executable(NeighborVerletPerformance Cabana_NeighborVerletPerformance.cpp)
-  target_link_libraries(NeighborVerletPerformance cabanacore)
+add_executable(NeighborVerletPerformance Cabana_NeighborVerletPerformance.cpp)
+target_link_libraries(NeighborVerletPerformance cabanacore)
+
+if(Cabana_ENABLE_ARBORX)
+add_executable(NeighborArborXPerformance Cabana_NeighborArborXPerformance.cpp)
+target_link_libraries(NeighborArborXPerformance cabanacore)
+endif()
+
+add_executable(LinkedCellPerformance Cabana_LinkedCellPerformance.cpp)
+target_link_libraries(LinkedCellPerformance cabanacore)
+
+if(Cabana_ENABLE_MPI)
+add_executable(CommPerformance Cabana_CommPerformance.cpp)
+target_link_libraries(CommPerformance cabanacore)
+endif()
+
+if(Cabana_ENABLE_TESTING)
+  add_test(NAME Cabana_Performance_BinSort COMMAND ${NONMPI_PRECOMMAND} BinSortPerformance sort_output.txt)
+
+  add_test(NAME Cabana_Performance_NeighborVerlet COMMAND ${NONMPI_PRECOMMAND} NeighborVerletPerformance verlet_output.txt)
 
   if(Cabana_ENABLE_ARBORX)
-    add_executable(NeighborArborXPerformance Cabana_NeighborArborXPerformance.cpp)
-    target_link_libraries(NeighborArborXPerformance cabanacore)
+    add_test(NAME Cabana_Performance_NeighborArborX COMMAND ${NONMPI_PRECOMMAND} NeighborArborXPerformance arborx_output.txt)
   endif()
 
-  add_executable(LinkedCellPerformance Cabana_LinkedCellPerformance.cpp)
-  target_link_libraries(LinkedCellPerformance cabanacore)
+  add_test(NAME Cabana_Performance_LinkedCell COMMAND ${NONMPI_PRECOMMAND} LinkedCellPerformance lcl_output.txt)
 
   if(Cabana_ENABLE_MPI)
-    add_executable(CommPerformance Cabana_CommPerformance.cpp)
-    target_link_libraries(CommPerformance cabanacore)
-  endif()
-
-  if(Cabana_ENABLE_TESTING)
-    add_test(NAME Cabana_Performance_BinSort COMMAND ${NONMPI_PRECOMMAND} BinSortPerformance sort_output.txt)
-
-    add_test(NAME Cabana_Performance_NeighborVerlet COMMAND ${NONMPI_PRECOMMAND} NeighborVerletPerformance verlet_output.txt)
-
-    if(Cabana_ENABLE_ARBORX)
-      add_test(NAME Cabana_Performance_NeighborArborX COMMAND ${NONMPI_PRECOMMAND} NeighborArborXPerformance arborx_output.txt)
-    endif()
-
-    add_test(NAME Cabana_Performance_LinkedCell COMMAND ${NONMPI_PRECOMMAND} LinkedCellPerformance lcl_output.txt)
-
-    if(Cabana_ENABLE_MPI)
-      add_test(NAME Cabana_Performance_Comm COMMAND ${NONMPI_PRECOMMAND} CommPerformance comm_output.txt)
-    endif()
+    add_test(NAME Cabana_Performance_Comm COMMAND ${NONMPI_PRECOMMAND} CommPerformance comm_output.txt)
   endif()
 endif()

--- a/benchmark/core/Cabana_BinSortPerformance.cpp
+++ b/benchmark/core/Cabana_BinSortPerformance.cpp
@@ -212,27 +212,20 @@ int main( int argc, char* argv[] )
     std::fstream file;
     file.open( filename, std::fstream::out );
 
-    // Run the tests.
-#ifdef KOKKOS_ENABLE_SERIAL
-    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-    performanceTest<SerialDevice>( file, "serial_", problem_sizes, num_bins );
-#endif
+    // Do everything on the default CPU.
+    using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+    using host_device_type = host_exec_space::device_type;
+    // Do everything on the default device with default memory.
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using device_type = exec_space::device_type;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-    performanceTest<OpenMPDevice>( file, "openmp_", problem_sizes, num_bins );
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA
-    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-    performanceTest<CudaDevice>( file, "cuda_", problem_sizes, num_bins );
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-    using HipDevice = Kokkos::Device<Kokkos::Experimental::HIP,
-                                     Kokkos::Experimental::HIPSpace>;
-    performanceTest<HipDevice>( file, "hip_", problem_sizes, num_bins );
-#endif
+    // Don't run twice on the CPU if only host enabled.
+    if ( !std::is_same<device_type, host_device_type>{} )
+    {
+        performanceTest<device_type>( file, "device_", problem_sizes,
+                                      num_bins );
+    }
+    performanceTest<host_device_type>( file, "host_", problem_sizes, num_bins );
 
     // Close the output file on rank 0.
     file.close();

--- a/benchmark/core/Cabana_LinkedCellPerformance.cpp
+++ b/benchmark/core/Cabana_LinkedCellPerformance.cpp
@@ -151,29 +151,21 @@ int main( int argc, char* argv[] )
     std::fstream file;
     file.open( filename, std::fstream::out );
 
-// Run the tests.
-#ifdef KOKKOS_ENABLE_SERIAL
-    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-    performanceTest<SerialDevice>( file, "serial_", problem_sizes,
-                                   cutoff_ratios );
-#endif
+    // Do everything on the default CPU.
+    using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+    using host_device_type = host_exec_space::device_type;
+    // Do everything on the default device with default memory.
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using device_type = exec_space::device_type;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-    performanceTest<OpenMPDevice>( file, "openmp_", problem_sizes,
-                                   cutoff_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA
-    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-    performanceTest<CudaDevice>( file, "cuda_", problem_sizes, cutoff_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-    using HipDevice = Kokkos::Device<Kokkos::Experimental::HIP,
-                                     Kokkos::Experimental::HIPSpace>;
-    performanceTest<HipDevice>( file, "hip_", problem_sizes, cutoff_ratios );
-#endif
+    // Don't run twice on the CPU if only host enabled.
+    if ( !std::is_same<device_type, host_device_type>{} )
+    {
+        performanceTest<device_type>( file, "device_", problem_sizes,
+                                      cutoff_ratios );
+    }
+    performanceTest<host_device_type>( file, "host_", problem_sizes,
+                                       cutoff_ratios );
 
     // Close the output file on rank 0.
     file.close();

--- a/benchmark/core/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborArborXPerformance.cpp
@@ -188,29 +188,21 @@ int main( int argc, char* argv[] )
     std::fstream file;
     file.open( filename, std::fstream::out );
 
-// Run the tests.
-#ifdef KOKKOS_ENABLE_SERIAL
-    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-    performanceTest<SerialDevice>( file, "serial_", problem_sizes,
-                                   cutoff_ratios );
-#endif
+    // Do everything on the default CPU.
+    using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+    using host_device_type = host_exec_space::device_type;
+    // Do everything on the default device with default memory.
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using device_type = exec_space::device_type;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-    performanceTest<OpenMPDevice>( file, "openmp_", problem_sizes,
-                                   cutoff_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA
-    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-    performanceTest<CudaDevice>( file, "cuda_", problem_sizes, cutoff_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-    using HipDevice = Kokkos::Device<Kokkos::Experimental::HIP,
-                                     Kokkos::Experimental::HIPSpace>;
-    performanceTest<HipDevice>( file, "hip_", problem_sizes, cutoff_ratios );
-#endif
+    // Don't run twice on the CPU if only host enabled.
+    if ( !std::is_same<device_type, host_device_type>{} )
+    {
+        performanceTest<device_type>( file, "device_", problem_sizes,
+                                      cutoff_ratios );
+    }
+    performanceTest<host_device_type>( file, "host_", problem_sizes,
+                                       cutoff_ratios );
 
     // Close the output file on rank 0.
     file.close();

--- a/benchmark/core/Cabana_NeighborVerletPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborVerletPerformance.cpp
@@ -247,31 +247,21 @@ int main( int argc, char* argv[] )
     std::fstream file;
     file.open( filename, std::fstream::out );
 
-// Run the tests.
-#ifdef KOKKOS_ENABLE_SERIAL
-    using SerialDevice = Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>;
-    performanceTest<SerialDevice>( file, "serial_", problem_sizes,
-                                   cutoff_ratios, cell_ratios );
-#endif
+    // Do everything on the default CPU.
+    using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+    using host_device_type = host_exec_space::device_type;
+    // Do everything on the default device with default memory.
+    using exec_space = Kokkos::DefaultExecutionSpace;
+    using device_type = exec_space::device_type;
 
-#ifdef KOKKOS_ENABLE_OPENMP
-    using OpenMPDevice = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;
-    performanceTest<OpenMPDevice>( file, "openmp_", problem_sizes,
-                                   cutoff_ratios, cell_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_CUDA
-    using CudaDevice = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
-    performanceTest<CudaDevice>( file, "cuda_", problem_sizes, cutoff_ratios,
-                                 cell_ratios );
-#endif
-
-#ifdef KOKKOS_ENABLE_HIP
-    using HipDevice = Kokkos::Device<Kokkos::Experimental::HIP,
-                                     Kokkos::Experimental::HIPSpace>;
-    performanceTest<HipDevice>( file, "hip_", problem_sizes, cutoff_ratios,
-                                cell_ratios );
-#endif
+    // Don't run twice on the CPU if only host enabled.
+    if ( !std::is_same<device_type, host_device_type>{} )
+    {
+        performanceTest<device_type>( file, "device_", problem_sizes,
+                                      cutoff_ratios, cell_ratios );
+    }
+    performanceTest<host_device_type>( file, "host_", problem_sizes,
+                                       cutoff_ratios, cell_ratios );
 
     // Close the output file on rank 0.
     file.close();


### PR DESCRIPTION
Remove list of backends for each benchmark: 99% of cases we want to run with the default and default host backends.

Only use the default FFT backend