### PR TITLE
Update heffte to 2.2.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout heffte
         # actions/checkout doesn't work for external repos yet
         run: |
-          git clone --depth 1 --branch v2.0.0 https://bitbucket.org/icl/heffte.git heffte
+          git clone --depth 1 --branch v2.2.0 https://bitbucket.org/icl/heffte.git heffte
       - name: Checkout hypre
         uses: actions/checkout@v2.2.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ find_package( CLANG_FORMAT 10 )
 Cabana_add_dependency( PACKAGE HYPRE VERSION 2.22.1 )
 
 # find heffte
-Cabana_add_dependency( PACKAGE Heffte VERSION 2.1.0 )
+Cabana_add_dependency( PACKAGE Heffte VERSION 2.2.0 )
 
 # find Silo
 Cabana_add_dependency( PACKAGE SILO )

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -452,7 +452,12 @@ class HeffteFastFourierTransform
 
         heffte::plan_options heffte_params =
             heffte::default_options<heffte_backend_type>();
-        heffte_params.use_alltoall = params.getAllToAll();
+        // TODO: use all three heffte options for algorithm
+        bool alltoall = params.getAllToAll();
+        if ( alltoall )
+            heffte_params.algorithm = heffte::reshape_algorithm::alltoallv;
+        else
+            heffte_params.algorithm = heffte::reshape_algorithm::p2p;
         heffte_params.use_pencils = params.getPencils();
         heffte_params.use_reorder = params.getReorder();
 
@@ -605,7 +610,8 @@ auto createHeffteFastFourierTransform(
     const heffte::plan_options heffte_params =
         heffte::default_options<heffte_backend_type>();
     FastFourierTransformParams params;
-    params.setAllToAll( heffte_params.use_alltoall );
+    // TODO: set appropriate default for AllToAll
+    params.setAllToAll( true );
     params.setPencils( heffte_params.use_pencils );
     params.setReorder( heffte_params.use_reorder );
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,7 @@ RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
     rm -rf ${SCRATCH_DIR}
 
 # Install heffte
-ARG HEFFTE_VERSION=2.1.0
+ARG HEFFTE_VERSION=2.2.0
 ENV HEFFTE_DIR=/opt/heffte
 RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
     HEFFTE_ARCHIVE=heffte.tar.gz && \

--- a/docker/Dockerfile.hipcc
+++ b/docker/Dockerfile.hipcc
@@ -133,7 +133,7 @@ RUN FFTW_URL=http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz && \
     rm -rf ${SCRATCH_DIR}
 
 # Install heffte
-ARG HEFFTE_VERSION=2.1.0
+ARG HEFFTE_VERSION=2.2.0
 ENV HEFFTE_DIR=/opt/heffte
 RUN HEFFTE_URL=https://bitbucket.org/icl/heffte/get/v${HEFFTE_VERSION}.tar.gz && \
     HEFFTE_ARCHIVE=heffte.tar.gz && \


### PR DESCRIPTION
Update heffte version to 2.2.0

needed a slight change to the `alltoall` option. We had that as a bool and heffte now has three options. Future change should allow choosing any of those three options, but for now it's true -> all-to-all, and false -> point-to-point. (heffte also allows p2p_plined)