### PR TITLE
Sparse Array

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADERS_PUBLIC
   Cajita_Types.hpp
   Cajita_UniformDimPartitioner.hpp
   Cajita_SparseDimPartitioner.hpp
+  Cajita_SparseArray.hpp
   )
 
 if(Cabana_ENABLE_HYPRE)

--- a/cajita/src/Cajita_Array.hpp
+++ b/cajita/src/Cajita_Array.hpp
@@ -37,7 +37,7 @@ namespace Cajita
   \brief Entity layout for array data on the local mesh.
 
   \tparam EntityType Array entity type: Cell, Node, Edge, or Face
-  \tparam MeshType Mesh type: UniformMesh, NonUniformMesh, SparseMesh
+  \tparam MeshType Mesh type: UniformMesh, NonUniformMesh
 */
 template <class EntityType, class MeshType>
 class ArrayLayout
@@ -217,7 +217,7 @@ createArrayLayout( const std::shared_ptr<GlobalGrid<MeshType>>& global_grid,
 
   \tparam Scalar Scalar type.
   \tparam EntityType Array entity type (node, cell, face, edge).
-  \tparam MeshType Mesh type (uniform, non-uniform, sparse).
+  \tparam MeshType Mesh type (uniform, non-uniform).
   \tparam Params Kokkos View parameters.
 */
 template <class Scalar, class EntityType, class MeshType, class... Params>

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -316,9 +316,6 @@ class SparseArray
     //! Least bits required to represent all cells inside a tile
     static constexpr unsigned long long cell_bits_per_tile =
         sparse_map_type::cell_bits_per_tile;
-    //! Cell mask, get local 1D cell ID when operate on global 1D cell ID
-    static constexpr unsigned long long cell_mask_per_tile =
-        sparse_map_type::cell_mask_per_tile;
 
     // AoSoA related types
     //! DataTypes Data types (Cabana::MemberTypes).

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -126,7 +126,14 @@ class SparseArrayLayout
     //! clear valid info inside array layout; i.e. clear sparse map
     inline void clear() { _map.clear(); }
 
-    //! register valid grids in sparse map according to input particle positions
+    /*!
+      \brief Register valid grids in sparse map according to input particle
+      positions.
+      \param positions Input particle positions.
+      \param particle_num Number of valid particles inside positions
+      \param p2g_radius The half range of grids that will be influenced by each
+      particle, depending on the interpolation kernel
+    */
     template <class ExecSpace, class PositionSliceType>
     void registerSparseMap( PositionSliceType& positions,
                             const int particle_num, const int p2g_radius = 1 )
@@ -414,6 +421,7 @@ class SparseArray
       \brief Register valid grids in sparse map according to input particle
       positions.
       \param positions Input particle positions.
+      \param particle_num Number of valid particles inside positions
       \param p2g_radius The half range of grids that will be influenced by each
       particle, depending on the interpolation kernel
     */

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -1,0 +1,541 @@
+#include <Cajita_MpiTraits.hpp>
+#include <Cajita_SparseIndexSpace.hpp>
+#include <Cajita_Types.hpp>
+
+#include <Cabana_AoSoA.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <cmath>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+#include <mpi.h>
+
+namespace Cajita
+{
+
+namespace Experimental
+{
+//---------------------------------------------------------------------------//
+// Indexing type tags
+//---------------------------------------------------------------------------//
+// H - Hierachical
+// T_C: indexing manner: tile ijk - cell ijk
+struct Index_H_T_C
+{
+};
+
+// C: indexing matter: cell ijk
+struct Index_H_C
+{
+};
+
+// ID: real array id
+struct Index_H_ID_C
+{
+};
+
+struct Index_ID
+{
+};
+
+//---------------------------------------------------------------------------//
+template <class DataTypes, class EntityType, class MeshType,
+          class SparseMapType>
+class SparseArrayLayout
+{
+  public:
+    using mesh_type = MeshType;
+    using entity_type = EntityType;
+    using member_types = DataTypes;
+
+    static_assert( isSparseMesh<MeshType>::value,
+                   "[SparesArrayLayout] Support only SparseMesh" );
+
+    using sparse_map_type = SparseMapType;
+    using value_type = typename sparse_map_type::value_type;
+    using key_type = typename sparse_map_type::key_type;
+    static constexpr unsigned long long cell_bits_per_tile_dim =
+        sparse_map_type::cell_bits_per_tile_dim;
+    static constexpr unsigned long long cell_num_per_tile_dim =
+        sparse_map_type::cell_num_per_tile_dim;
+    static constexpr std::size_t num_space_dim = sparse_map_type::rank;
+
+    using memory_space = typename sparse_map_type::memory_space;
+
+    // [0] shared_owned_num [1] shared_ghost_num
+    // using indices_view = Kokkos::View<value_type* [2], memory_space>;
+    // [0] shared_owned_num [1] shared_ghost_num
+    // using counting_view = Kokkos::View<int[2], memory_space,
+    //    Kokkos::MemoryTraits<Kokkos::Atomic>>;
+
+    SparseArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
+                       SparseMapType& sparse_map, const float bc_factor )
+        : _bc_factor( bc_factor )
+        , _local_grid_ptr( local_grid )
+        , _map( std::forward<sparse_map_type>( sparse_map ) )
+    {
+    }
+
+    const std::shared_ptr<LocalGrid<MeshType>> localGrid() const
+    {
+        return _local_grid_ptr;
+    }
+
+    SparseMapType& sparseMap() { return _map; }
+
+    // size
+    inline uint64_t arraySizeCell() const
+    {
+        entity_type t;
+        return arraySizeCellImpl( t );
+    }
+    inline uint64_t arraySizeTile() const
+    {
+        entity_type t;
+        return arraySizeTileImpl( t );
+    }
+
+    inline void clear() { _map.clear(); }
+
+    template <class ExecSpace, class PositionSliceType>
+    void register_sparse_map( PositionSliceType& poses )
+    {
+        using scalar_type = typename mesh_type::scalar_type;
+
+        auto& sparse_mesh = _local_grid_ptr->globalGrid().globalMesh();
+        Kokkos::Array<scalar_type, 3> dx_inv = {
+            1.0 / sparse_mesh.cellSize( 0 ), 1.0 / sparse_mesh.cellSize( 1 ),
+            1.0 / sparse_mesh.cellSize( 2 ) };
+        auto& map = _map;
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy<ExecSpace>( 0, poses.size() ),
+            KOKKOS_LAMBDA( const int pid ) {
+                scalar_type pos[3] = { poses( pid, 0 ), poses( pid, 1 ),
+                                       poses( pid, 2 ) };
+                int grid_base[3] = {
+                    static_cast<int>( std::lround( pos[0] * dx_inv[0] ) - 1 ),
+                    static_cast<int>( std::lround( pos[1] * dx_inv[1] ) - 1 ),
+                    static_cast<int>( std::lround( pos[2] * dx_inv[2] ) - 1 ) };
+                for ( int i = 0; i <= 2; ++i )
+                    for ( int j = 0; j <= 2; ++j )
+                        for ( int k = 0; k <= 2; ++k )
+                        {
+                            int cell_id[3] = { grid_base[0] + i,
+                                               grid_base[1] + j,
+                                               grid_base[2] + k };
+                            map.insertCell( cell_id[0], cell_id[1],
+                                            cell_id[2] );
+                        }
+            } );
+    }
+
+    // query index
+    KOKKOS_FORCEINLINE_FUNCTION
+    value_type queryCell( const int i, const int j, const int k ) const
+    {
+        return _map.queryCell( i, j, k );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    value_type queryTile( const int i, const int j, const int k ) const
+    {
+        return _map.queryTile( i, j, k );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    value_type queryTile_FT( const int i, const int j, const int k ) const
+    {
+        return _map.queryTile_FT( i, j, k );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    value_type queryTileFromTileKey( const key_type tile_key ) const
+    {
+        return _map.queryTileFromTileKey( tile_key );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    value_type cell_local_id( const int cell_i, const int cell_j,
+                              const int cell_k ) const
+    {
+        return _map.cell_local_id( cell_i, cell_j, cell_k );
+    }
+
+    // Default unit: cell
+    inline uint64_t arraySize() const { return arraySizeCell(); }
+
+  private:
+    //-------------------------------------------------------------------//
+    inline uint64_t arraySizeCellImpl( Cell ) const
+    {
+        return static_cast<uint64_t>( _map.reservedCellSize() );
+    }
+    inline uint64_t arraySizeCellImpl( Node ) const
+    {
+        return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
+    }
+    template <int dim>
+    inline uint64_t arraySizeCellImpl( Face<dim> ) const
+    {
+        return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
+    }
+    template <int dim>
+    inline uint64_t arraySizeCellImpl( Edge<dim> ) const
+    {
+        return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
+    }
+
+    //-------------------------------------------------------------------//
+    inline uint64_t arraySizeTileImpl( Cell ) const
+    {
+        return static_cast<uint64_t>( _map.reservedTileSize() );
+    }
+    inline uint64_t arraySizeTileImpl( Node ) const
+    {
+        return static_cast<uint64_t>( _map.reservedTileSize() * _bc_factor );
+    }
+    template <int dim>
+    inline uint64_t arraySizeTileImpl( Face<dim> ) const
+    {
+        return static_cast<uint64_t>( _map.reservedTileSize() * _bc_factor );
+    }
+    template <int dim>
+    inline uint64_t arraySizeTileImpl( Edge<dim> ) const
+    {
+        return static_cast<uint64_t>( _map.reservedTileSize() * _bc_factor );
+    }
+
+  private:
+    float _bc_factor;
+    std::shared_ptr<LocalGrid<MeshType>> _local_grid_ptr;
+    sparse_map_type _map;
+}; // end class SparseArrayLayout
+
+//! Array static type checker.
+template <class>
+struct is_sparse_array_layout : public std::false_type
+{
+};
+
+//! Array static type checker.
+template <class DataTypes, class EntityType, class MeshType,
+          class SparseMapType>
+struct is_sparse_array_layout<
+    SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>>
+    : public std::true_type
+{
+};
+
+//! Array static type checker.
+template <class DataTypes, class EntityType, class MeshType,
+          class SparseMapType>
+struct is_sparse_array_layout<
+    const SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>>
+    : public std::true_type
+{
+};
+
+//---------------------------------------------------------------------------//
+// Array layout creation.
+//---------------------------------------------------------------------------//
+template <class DataTypes, class EntityType, class MeshType,
+          class SparseMapType>
+SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>
+createSparseArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
+                         SparseMapType& sparse_map, EntityType,
+                         const float bc_factor = 1.01f )
+{
+    return SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>(
+        local_grid, sparse_map, bc_factor );
+}
+
+//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+
+template <class DataTypes, class DeviceType, class EntityType, class MeshType,
+          class SparseMapType>
+class SparseArray
+{
+  public:
+    using sparse_array_type =
+        SparseArray<DataTypes, DeviceType, EntityType, MeshType, SparseMapType>;
+    // Device Types
+    using device_type = DeviceType;
+    using memory_space = typename device_type::memory_space;
+    using execution_space = typename device_type::execution_space;
+    using size_type = typename memory_space::size_type;
+    // Other types
+    using entity_type = EntityType;
+    using mesh_type = MeshType;
+    using sparse_map_type = SparseMapType;
+    static constexpr std::size_t num_space_dim = mesh_type::num_space_dim;
+    static constexpr unsigned long long cell_bits_per_tile =
+        sparse_map_type::cell_bits_per_tile;
+    static constexpr unsigned long long cell_mask_per_tile =
+        sparse_map_type::cell_mask_per_tile;
+
+    // AoSoA related types
+    using member_types = DataTypes;
+    static constexpr int vector_length = sparse_map_type::cell_num_per_tile;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space, vector_length>;
+    using soa_type = Cabana::SoA<member_types, vector_length>;
+    using tuple_type = Cabana::Tuple<member_types>;
+
+    using array_layout = SparseArrayLayout<member_types, entity_type, mesh_type,
+                                           sparse_map_type>;
+    // Constructor
+    SparseArray( const std::string label, array_layout& layout )
+        : _layout( std::forward<array_layout>( layout ) )
+        , _data( label )
+    {
+        reserve( _layout.arraySizeCell() );
+    }
+
+    // ------------------------------------------------------------------------
+    // AoSoA interfaces
+    aosoa_type& aosoa() { return _data; }
+    std::string label() const { return _data.label(); }
+    array_layout& layout() { return _layout; }
+
+    inline void resize( const size_type n ) { _data.resize( n ); }
+    inline void reserve( const size_type n ) { _data.reserve( n ); }
+    inline void shrinkToFit() { _data.shrinkToFit(); }
+    inline void clear()
+    {
+        resize( 0 );
+        _layout.clear();
+    };
+
+    template <class PositionSliceType>
+    void register_sparse_grid( PositionSliceType& poses )
+    {
+        _layout
+            .template register_sparse_map<execution_space, PositionSliceType>(
+                poses );
+        this->resize( _layout.sparseMap().sizeCell() );
+    }
+
+    KOKKOS_FUNCTION
+    size_type capacity() { return _data.capacity(); }
+    KOKKOS_FUNCTION
+    size_type size() const { return _data.size(); }
+    KOKKOS_FUNCTION
+    bool empty() const { return ( size() == 0 ); }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    size_type numSoA() const { return _data.numSoA(); }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    size_type arraySize( const size_type s ) const
+    {
+        return _data.arraySize( s );
+    }
+
+    // ------------------------------------------------------------------------
+    // data access
+    // access soa
+    KOKKOS_FORCEINLINE_FUNCTION
+    soa_type& access_tile_FT( const int tile_i, const int tile_j,
+                              const int tile_k ) const
+    {
+        auto tile_id = _layout.queryTile_FT( tile_i, tile_j, tile_k );
+        return _data.access( tile_id );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    soa_type& access_tile( const int cell_i, const int cell_j,
+                           const int cell_k ) const
+    {
+        auto tile_id = _layout.queryTile( cell_i, cell_j, cell_k );
+        return _data.access( tile_id );
+    }
+
+    template <typename Value>
+    KOKKOS_FORCEINLINE_FUNCTION soa_type&
+    access_tile( const Value tile_id ) const
+    {
+        return _data.access( tile_id );
+    }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    tuple_type getTuple( const int cell_i, const int cell_j,
+                         const int cell_k ) const
+    {
+        auto cell_id = _layout.queryCell( cell_i, cell_j, cell_k );
+        return _data.getTuple( cell_id );
+    }
+
+    template <typename Key>
+    KOKKOS_FORCEINLINE_FUNCTION tuple_type
+    getTuple( const Key tile_key, const int cell_local_id ) const
+    {
+        auto tile_id = _layout.queryTileFromTileKey( tile_key );
+        return _data.getTuple( ( tile_id << cell_bits_per_tile ) |
+                               ( cell_local_id & cell_mask_per_tile ) );
+    }
+
+    template <std::size_t M, typename... Indices>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_C, const int cell_i, const int cell_j, const int cell_k,
+             Indices&&... ids ) const
+    {
+        auto& soa = access_tile( cell_i, cell_j, cell_k );
+        auto array_index = _layout.cell_local_id( cell_i, cell_j, cell_k );
+        return Cabana::get<M>( soa, array_index, ids... );
+    }
+
+    template <std::size_t M>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_C, const int cell_i, const int cell_j,
+             const int cell_k ) const
+    {
+        auto& soa = access_tile( cell_i, cell_j, cell_k );
+        auto array_index = _layout.cell_local_id( cell_i, cell_j, cell_k );
+        return Cabana::get<M>( soa, array_index );
+    }
+
+    template <std::size_t M, typename... Indices>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_T_C, const int tile_i, const int tile_j, const int tile_k,
+             const int local_cell_i, const int local_cell_j,
+             const int local_cell_k, Indices&&... ids ) const
+    {
+        auto& soa = access_tile_FT( tile_i, tile_j, tile_k );
+        auto array_index =
+            _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k );
+        return Cabana::get<M>( soa, array_index, ids... );
+    }
+
+    template <std::size_t M>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_T_C, const int tile_i, const int tile_j, const int tile_k,
+             const int local_cell_i, const int local_cell_j,
+             const int local_cell_k ) const
+    {
+        auto& soa = access_tile_FT( tile_i, tile_j, tile_k );
+        auto array_index =
+            _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k );
+        return Cabana::get<M>( soa, array_index );
+    }
+
+    // template <std::size_t M>
+    // KOKKOS_INLINE_FUNCTION typename soa_type::template
+    // member_reference_type<M> get( Index_H_T_C, const int tile_i, const int
+    // tile_j, const int tile_k,
+    //      const int local_cell_i, const int local_cell_j,
+    //      const int local_cell_k ) const
+    // {
+    //     auto& soa = access_tile_FT( tile_i, tile_j, tile_k );
+    //     auto array_index = _layout.sparseMap().cell_local_id(
+    //         local_cell_i, local_cell_j, local_cell_k );
+    //     return Cabana::get<M>( soa, array_index );
+    // }
+
+    template <std::size_t M, typename... Indices>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_ID_C, const int array_id, const int local_cell_i,
+             const int local_cell_j, const int local_cell_k,
+             Indices&&... ids ) const
+    {
+        auto& soa = _data.access( array_id );
+        auto cell_id =
+            _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k );
+        return Cabana::get<M>( soa, cell_id, ids... );
+    }
+
+    // template <std::size_t M>
+    // KOKKOS_FORCEINLINE_FUNCTION
+    //     typename soa_type::template member_reference_type<M>
+    //     get( Index_H_ID_C, const int array_id, const int local_cell_i,
+    //          const int local_cell_j, const int local_cell_k ) const
+    // {
+    //     auto& soa = _data.access( array_id );
+    //     auto cell_id =
+    //         _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k
+    //         );
+    //     return Cabana::get<M>( soa, cell_id );
+    // }
+
+    template <std::size_t M, typename... Indices>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_ID, const int array_id, const int cell_id,
+             Indices&&... ids ) const
+    {
+        auto& soa = _data.access( array_id );
+        return Cabana::get<M>( soa, cell_id, ids... );
+    }
+
+    template <std::size_t M>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_ID, const int array_id, const int cell_id ) const
+    {
+        auto& soa = _data.access( array_id );
+        return Cabana::get<M>( soa, cell_id );
+    }
+    // should add more data access interfaces
+    // such as slices, or index based data accessing
+
+  private:
+    array_layout _layout;
+    aosoa_type _data;
+
+}; // end class SparseArray
+
+//---------------------------------------------------------------------------//
+// Scatic type checker.
+//---------------------------------------------------------------------------//
+// Static type checker.
+template <class>
+struct is_sparse_array : public std::false_type
+{
+};
+
+template <class DataTypes, class DeviceType, class EntityType, class MeshType,
+          class SparseMapType>
+struct is_sparse_array<
+    SparseArray<DataTypes, DeviceType, EntityType, MeshType, SparseMapType>>
+    : public std::true_type
+{
+};
+
+template <class DataTypes, class DeviceType, class EntityType, class MeshType,
+          class SparseMapType>
+struct is_sparse_array<const SparseArray<DataTypes, DeviceType, EntityType,
+                                         MeshType, SparseMapType>>
+    : public std::true_type
+{
+};
+
+//---------------------------------------------------------------------------//
+// Array creation.
+//---------------------------------------------------------------------------//
+template <class DeviceType, class DataTypes, class EntityType, class MeshType,
+          class SparseMapType>
+SparseArray<DataTypes, DeviceType, EntityType, MeshType, SparseMapType>
+createSparseArray(
+    const std::string label,
+    SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>& layout )
+{
+    return SparseArray<DataTypes, DeviceType, EntityType, MeshType,
+                       SparseMapType>( label, layout );
+}
+
+namespace SparseArrayOp
+{
+
+}; // end namespace SparseArrayOp
+
+} // namespace Experimental
+} // end namespace Cajita
+
+#endif

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -85,11 +85,12 @@ class SparseArrayLayout
     \brief (Host) Constructor
     \param local_grid Shared pointer to local grid
     \param sparse_map Reference to sparse map
-    \param bc_factor Factor to increase reserved size for Edge and Face entity
+    \param over_allocation  Factor to increase reserved size for Edge and Face
+    entity
     */
     SparseArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
-                       SparseMapType& sparse_map, const float bc_factor )
-        : _bc_factor( bc_factor )
+                       SparseMapType& sparse_map, const float over_allocation )
+        : _over_allocation( over_allocation )
         , _map( std::forward<sparse_map_type>( sparse_map ) )
     {
         auto sparse_mesh = local_grid->globalGrid().globalMesh();
@@ -230,7 +231,7 @@ class SparseArrayLayout
 
   private:
     //! factor to increase array size for special grid entities
-    float _bc_factor;
+    float _over_allocation;
     //! cell size
     Kokkos::Array<scalar_type, 3> _cell_size;
     //! global low corner
@@ -270,7 +271,8 @@ struct is_sparse_array_layout<
   \brief Create sparse array layout over the entities of a sparse local grid.
   \param local_grid The sparse local grid over which to create the layout.
   \param sparse_map The reference to a pre-created sparse map.
-  \param bc_factor Factor used to increase allocation size for special entities.
+  \param over_allocation  Factor used to increase allocation size for special
+  entities.
 
   \note EntityType The entity: Cell, Node, Face, or Edge.
 */
@@ -279,10 +281,10 @@ template <class DataTypes, class EntityType, class MeshType,
 SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>
 createSparseArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
                          SparseMapType& sparse_map, EntityType,
-                         const float bc_factor = 1.01f )
+                         const float over_allocation = 1.01f )
 {
     return SparseArrayLayout<DataTypes, EntityType, MeshType, SparseMapType>(
-        local_grid, sparse_map, bc_factor );
+        local_grid, sparse_map, over_allocation );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -10,7 +10,7 @@
  ****************************************************************************/
 
 /*!
-  \file Cabana_SparseArray.hpp
+  \file Cajita_SparseArray.hpp
   \brief Sparse grid fields arrays using AoSoA
 */
 #ifndef CAJITA_SPARSE_ARRAY_HPP
@@ -270,8 +270,9 @@ struct is_sparse_array_layout<
   \brief Create sparse array layout over the entities of a sparse local grid.
   \param local_grid The sparse local grid over which to create the layout.
   \param sparse_map The reference to a pre-created sparse map.
-  \param EntityType The entity: Cell, Node, Face, or Edge.
   \param bc_factor Factor used to increase allocation size for special entities.
+
+  \note EntityType The entity: Cell, Node, Face, or Edge.
 */
 template <class DataTypes, class EntityType, class MeshType,
           class SparseMapType>

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -25,16 +25,30 @@ namespace Experimental
 // T_C: indexing manner: tile ijk - cell ijk
 struct Index_H_T_C
 {
+    // access cell (channel) by
+    // (tile i, tile j, tile k, local_cell i, local_cell j, local_cell k)
+    // Or
+    // (tile i, tile j, tile k, local_cell i, local_cell j, local_cell k,
+    // channel id)
 };
 
 // C: indexing matter: cell ijk
 struct Index_H_C
 {
+    // access cell (channel) by
+    // (global_cell i, global_cell j, global_cell k)
+    // Or
+    // (global_cell i, global_cell j, global_cell k)
 };
 
 // ID: real array id
 struct Index_H_ID_C
 {
+    // access cell (channel) by
+    // (array_id (1D tile_id), local_cell i, local_cell j, local_cell k)
+    // Or
+    // (array_id (1D tile_id), local_cell i, local_cell j, local_cell k, channel
+    // id)
 };
 
 struct Index_ID
@@ -47,30 +61,41 @@ template <class DataTypes, class EntityType, class MeshType,
 class SparseArrayLayout
 {
   public:
+    //! Mesh Type, should be SparseMesh
     using mesh_type = MeshType;
-    using entity_type = EntityType;
-    using member_types = DataTypes;
-
+    // check if mesh_type is SparseMesh
     static_assert( isSparseMesh<MeshType>::value,
                    "[SparesArrayLayout] Support only SparseMesh" );
 
+    //! Entity Type
+    using entity_type = EntityType;
+    //! Data Type, such as float or double
+    using member_types = DataTypes;
+
+    //! Abbreviation for Sparse Map Type
     using sparse_map_type = SparseMapType;
+    //! value type in sparse map, i.e., the tile ID (array ID) type
     using value_type = typename sparse_map_type::value_type;
+    //! key type in sparse map, i.e., the tile key type
     using key_type = typename sparse_map_type::key_type;
+    //! least bit number required to represent local cell ids inside a tile per
+    //! dimension
     static constexpr unsigned long long cell_bits_per_tile_dim =
         sparse_map_type::cell_bits_per_tile_dim;
+    //! cell number inside each tile per dimension
     static constexpr unsigned long long cell_num_per_tile_dim =
         sparse_map_type::cell_num_per_tile_dim;
+    //! dimension number
     static constexpr std::size_t num_space_dim = sparse_map_type::rank;
-
+    //! Memory space, the same memory space in sparse map
     using memory_space = typename sparse_map_type::memory_space;
 
-    // [0] shared_owned_num [1] shared_ghost_num
-    // using indices_view = Kokkos::View<value_type* [2], memory_space>;
-    // [0] shared_owned_num [1] shared_ghost_num
-    // using counting_view = Kokkos::View<int[2], memory_space,
-    //    Kokkos::MemoryTraits<Kokkos::Atomic>>;
-
+    /*!
+    \brief (Host) Constructor
+    \param local_grid Shared pointer to local grid
+    \param sparse_map Reference to sparse map
+    \param bc_factor Factor to increase researved size for Edge and Face entity
+    */
     SparseArrayLayout( const std::shared_ptr<LocalGrid<MeshType>>& local_grid,
                        SparseMapType& sparse_map, const float bc_factor )
         : _bc_factor( bc_factor )
@@ -79,46 +104,56 @@ class SparseArrayLayout
     {
     }
 
+    //! get local grid shared pointer
     const std::shared_ptr<LocalGrid<MeshType>> localGrid() const
     {
         return _local_grid_ptr;
     }
 
+    //! get reference of sparse map
     SparseMapType& sparseMap() { return _map; }
 
-    // size
+    //! array size in cell
     inline uint64_t arraySizeCell() const
     {
-        entity_type t;
-        return arraySizeCellImpl( t );
+        return arraySizeCellImpl( entity_type() );
     }
+
+    //! array size in tile
     inline uint64_t arraySizeTile() const
     {
-        entity_type t;
-        return arraySizeTileImpl( t );
+        return arraySizeTileImpl( entity_type() );
     }
 
+    //! Array size in cell (default size measurse: cell)
+    inline uint64_t arraySize() const { return arraySizeCell(); }
+
+    //! clear valid info inside array layout; i.e. clear sparse map
     inline void clear() { _map.clear(); }
 
+    //! register valid grids in sparse map according to input particle positions
     template <class ExecSpace, class PositionSliceType>
-    void register_sparse_map( PositionSliceType& poses )
+    void registerSparseMap( PositionSliceType& positions )
     {
         using scalar_type = typename mesh_type::scalar_type;
-
+        // get references
         auto& sparse_mesh = _local_grid_ptr->globalGrid().globalMesh();
         Kokkos::Array<scalar_type, 3> dx_inv = {
             1.0 / sparse_mesh.cellSize( 0 ), 1.0 / sparse_mesh.cellSize( 1 ),
             1.0 / sparse_mesh.cellSize( 2 ) };
         auto& map = _map;
+        // register sparse map in sparse array layout
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecSpace>( 0, poses.size() ),
+            "register sparse map in sparse array layout",
+            Kokkos::RangePolicy<ExecSpace>( 0, positions.size() ),
             KOKKOS_LAMBDA( const int pid ) {
-                scalar_type pos[3] = { poses( pid, 0 ), poses( pid, 1 ),
-                                       poses( pid, 2 ) };
+                scalar_type pos[3] = { positions( pid, 0 ), positions( pid, 1 ),
+                                       positions( pid, 2 ) };
                 int grid_base[3] = {
                     static_cast<int>( std::lround( pos[0] * dx_inv[0] ) - 1 ),
                     static_cast<int>( std::lround( pos[1] * dx_inv[1] ) - 1 ),
                     static_cast<int>( std::lround( pos[2] * dx_inv[2] ) - 1 ) };
+                // register grids that will have data transfer with the particle
                 for ( int i = 0; i <= 2; ++i )
                     for ( int j = 0; j <= 2; ++j )
                         for ( int k = 0; k <= 2; ++k )
@@ -132,31 +167,53 @@ class SparseArrayLayout
             } );
     }
 
-    // query index
+    /*!
+      \brief (Device) Query the 1D cell ID from the 3D cell ijk
+      \param cell_i, cell_j, cell_k Cell ID in each dimension
+    */
     KOKKOS_FORCEINLINE_FUNCTION
-    value_type queryCell( const int i, const int j, const int k ) const
+    value_type queryCell( const int cell_i, const int cell_j,
+                          const int cell_k ) const
     {
-        return _map.queryCell( i, j, k );
+        return _map.queryCell( cell_i, cell_j, cell_k );
     }
 
+    /*!
+      \brief (Device) Query the 1D tile ID from the 3D tile ijk
+      \param cell_i, cell_j, cell_k Cell ID in each dimension
+    */
     KOKKOS_FORCEINLINE_FUNCTION
     value_type queryTile( const int i, const int j, const int k ) const
     {
         return _map.queryTile( i, j, k );
     }
 
+    /*!
+      \brief (Device) Query the 1D tile key from the 3D tile ijk
+      \param tile_i, tile_j, tile_k Tile ID in each dimension
+    */
     KOKKOS_FORCEINLINE_FUNCTION
-    value_type queryTile_FT( const int i, const int j, const int k ) const
+    value_type queryTileFromTileId( const int tile_i, const int tile_j,
+                                    const int tile_k ) const
     {
-        return _map.queryTile_FT( i, j, k );
+        return _map.queryTileFromTileId( i, j, k );
     }
 
+    /*!
+      \brief (Device) Query the 1D tile key from the 1D tile key
+      \param tile_key 1D tile key
+    */
     KOKKOS_FORCEINLINE_FUNCTION
     value_type queryTileFromTileKey( const key_type tile_key ) const
     {
         return _map.queryTileFromTileKey( tile_key );
     }
 
+    /*!
+      \brief (Device) Get local cell ID from cell IJK
+      \param cell_i, cell_j, cell_k Cell ID in each dimension (both local and
+      global IJK work)
+    */
     KOKKOS_FORCEINLINE_FUNCTION
     value_type cell_local_id( const int cell_i, const int cell_j,
                               const int cell_k ) const
@@ -164,44 +221,53 @@ class SparseArrayLayout
         return _map.cell_local_id( cell_i, cell_j, cell_k );
     }
 
-    // Default unit: cell
-    inline uint64_t arraySize() const { return arraySizeCell(); }
-
   private:
-    //-------------------------------------------------------------------//
+    // Array size (in cell) for Cell entity
     inline uint64_t arraySizeCellImpl( Cell ) const
     {
         return static_cast<uint64_t>( _map.reservedCellSize() );
     }
+
+    // Array size (in cell) for Node entity
     inline uint64_t arraySizeCellImpl( Node ) const
     {
-        return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
+        return static_cast<uint64_t>( _map.reservedCellSize() );
     }
+
+    // Array size (in cell) for Face entity
     template <int dim>
     inline uint64_t arraySizeCellImpl( Face<dim> ) const
     {
         return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
     }
+
+    // Array size (in cell) for Edge entity
     template <int dim>
     inline uint64_t arraySizeCellImpl( Edge<dim> ) const
     {
         return static_cast<uint64_t>( _map.reservedCellSize() * _bc_factor );
     }
 
-    //-------------------------------------------------------------------//
+    // Array size (in tile) for Cell entity
     inline uint64_t arraySizeTileImpl( Cell ) const
     {
         return static_cast<uint64_t>( _map.reservedTileSize() );
     }
+
+    // Array size (in tile) for Node entity
     inline uint64_t arraySizeTileImpl( Node ) const
     {
-        return static_cast<uint64_t>( _map.reservedTileSize() * _bc_factor );
+        return static_cast<uint64_t>( _map.reservedTileSize() );
     }
+
+    // Array size (in tile) for Face entity
     template <int dim>
     inline uint64_t arraySizeTileImpl( Face<dim> ) const
     {
         return static_cast<uint64_t>( _map.reservedTileSize() * _bc_factor );
     }
+
+    // Array size (in tile) for Edge entity
     template <int dim>
     inline uint64_t arraySizeTileImpl( Edge<dim> ) const
     {
@@ -209,8 +275,11 @@ class SparseArrayLayout
     }
 
   private:
+    //! factor to increase array size for special grid entities
     float _bc_factor;
+    //! local grid pointer
     std::shared_ptr<LocalGrid<MeshType>> _local_grid_ptr;
+    //！ sparse map
     sparse_map_type _map;
 }; // end class SparseArrayLayout
 
@@ -310,11 +379,10 @@ class SparseArray
     };
 
     template <class PositionSliceType>
-    void register_sparse_grid( PositionSliceType& poses )
+    void register_sparse_grid( PositionSliceType& positions )
     {
-        _layout
-            .template register_sparse_map<execution_space, PositionSliceType>(
-                poses );
+        _layout.template registerSparseMap<execution_space, PositionSliceType>(
+            positions );
         this->resize( _layout.sparseMap().sizeCell() );
     }
 
@@ -341,7 +409,7 @@ class SparseArray
     soa_type& access_tile_FT( const int tile_i, const int tile_j,
                               const int tile_k ) const
     {
-        auto tile_id = _layout.queryTile_FT( tile_i, tile_j, tile_k );
+        auto tile_id = _layout.queryTileFromTileId( tile_i, tile_j, tile_k );
         return _data.access( tile_id );
     }
 
@@ -425,19 +493,6 @@ class SparseArray
         return Cabana::get<M>( soa, array_index );
     }
 
-    // template <std::size_t M>
-    // KOKKOS_INLINE_FUNCTION typename soa_type::template
-    // member_reference_type<M> get( Index_H_T_C, const int tile_i, const int
-    // tile_j, const int tile_k,
-    //      const int local_cell_i, const int local_cell_j,
-    //      const int local_cell_k ) const
-    // {
-    //     auto& soa = access_tile_FT( tile_i, tile_j, tile_k );
-    //     auto array_index = _layout.sparseMap().cell_local_id(
-    //         local_cell_i, local_cell_j, local_cell_k );
-    //     return Cabana::get<M>( soa, array_index );
-    // }
-
     template <std::size_t M, typename... Indices>
     KOKKOS_FORCEINLINE_FUNCTION
         typename soa_type::template member_reference_type<M>
@@ -451,18 +506,17 @@ class SparseArray
         return Cabana::get<M>( soa, cell_id, ids... );
     }
 
-    // template <std::size_t M>
-    // KOKKOS_FORCEINLINE_FUNCTION
-    //     typename soa_type::template member_reference_type<M>
-    //     get( Index_H_ID_C, const int array_id, const int local_cell_i,
-    //          const int local_cell_j, const int local_cell_k ) const
-    // {
-    //     auto& soa = _data.access( array_id );
-    //     auto cell_id =
-    //         _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k
-    //         );
-    //     return Cabana::get<M>( soa, cell_id );
-    // }
+    template <std::size_t M>
+    KOKKOS_FORCEINLINE_FUNCTION
+        typename soa_type::template member_reference_type<M>
+        get( Index_H_ID_C, const int array_id, const int local_cell_i,
+             const int local_cell_j, const int local_cell_k ) const
+    {
+        auto& soa = _data.access( array_id );
+        auto cell_id =
+            _layout.cell_local_id( local_cell_i, local_cell_j, local_cell_k );
+        return Cabana::get<M>( soa, cell_id );
+    }
 
     template <std::size_t M, typename... Indices>
     KOKKOS_FORCEINLINE_FUNCTION

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -333,7 +333,7 @@ class SparseArray
     using aosoa_type = Cabana::AoSoA<member_types, memory_space, vector_length>;
     //! SoA Type
     using soa_type = Cabana::SoA<member_types, vector_length>;
-    //！AoSoA tuple type
+    //! AoSoA tuple type
     using tuple_type = Cabana::Tuple<member_types>;
 
     //! Sparse array layout type

--- a/cajita/src/Cajita_SparseArray.hpp
+++ b/cajita/src/Cajita_SparseArray.hpp
@@ -159,9 +159,10 @@ class SparseArrayLayout
       \param cell_i, cell_j, cell_k Cell ID in each dimension
     */
     KOKKOS_FORCEINLINE_FUNCTION
-    value_type queryTile( const int i, const int j, const int k ) const
+    value_type queryTile( const int cell_i, const int cell_j,
+                          const int cell_k ) const
     {
-        return _map.queryTile( i, j, k );
+        return _map.queryTile( cell_i, cell_j, cell_k );
     }
 
     /*!
@@ -172,7 +173,7 @@ class SparseArrayLayout
     value_type queryTileFromTileId( const int tile_i, const int tile_j,
                                     const int tile_k ) const
     {
-        return _map.queryTileFromTileId( i, j, k );
+        return _map.queryTileFromTileId( tile_i, tile_j, tile_k );
     }
 
     /*!
@@ -355,7 +356,7 @@ class SparseArray
     using aosoa_type = Cabana::AoSoA<member_types, memory_space, vector_length>;
     //! SoA Type
     using soa_type = Cabana::SoA<member_types, vector_length>;
-    //！ AoSoA tuple type
+    //！AoSoA tuple type
     using tuple_type = Cabana::Tuple<member_types>;
 
     //! Sparse array layout type
@@ -377,7 +378,10 @@ class SparseArray
     // AoSoA-related interfaces
     //! Get AoSoA reference
     aosoa_type& aosoa() { return _data; }
-    //！Get array label (description)
+    /*!
+      \brief Get array label (description)
+      \return Array label (description)
+    */
     std::string label() const { return _data.label(); }
     //! Get array layout reference
     array_layout& layout() { return _layout; }
@@ -596,6 +600,7 @@ class SparseArray
       indices
       \param tile_id the 1D Tile ID
       \param cell_id the 1D Local Cell ID
+      \param ids Ids to access channels inside a data member/element
     */
     template <std::size_t M, typename... Indices>
     KOKKOS_FORCEINLINE_FUNCTION

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -431,6 +431,8 @@ class SparseMap
     using value_type = Value;
     //! Hash table type.
     static constexpr HashTypes hash_type = Hash;
+    //! memory space
+    using memory_space = MemorySpace;
 
     /*!
       \brief (Host) Constructor
@@ -622,6 +624,12 @@ class SparseMap
     void key2ijk( key_type& key, int& tile_i, int& tile_j, int& tile_k ) const
     {
         return _block_id_space.key2ijk( key, tile_i, tile_j, tile_k );
+    }
+
+    KOKKOS_INLINE_FUNCTION
+    key_type ijk2key( int tile_i, int tile_j, int tile_k ) const
+    {
+        return _block_id_space.ijk2key( tile_i, tile_j, tile_k );
     }
 
     /*!

--- a/cajita/src/Cajita_SparseIndexSpace.hpp
+++ b/cajita/src/Cajita_SparseIndexSpace.hpp
@@ -616,7 +616,7 @@ class SparseMap
     }
 
     /*!
-      \brief (Device) Transfer block hash key to block ijk
+      \brief (Device) Transfer tile hash key to tile ijk
       \param key Tile hash key
       \param tile_i, tile_j, tile_k Tile ID in each dimension
     */
@@ -626,6 +626,11 @@ class SparseMap
         return _block_id_space.key2ijk( key, tile_i, tile_j, tile_k );
     }
 
+    /*!
+      \brief (Device) Transfer tile ijk to til key
+      \param tile_i, tile_j, tile_k Tile ID in each dimension
+      \return tile hash key
+    */
     KOKKOS_INLINE_FUNCTION
     key_type ijk2key( int tile_i, int tile_j, int tile_k ) const
     {

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MPI_TESTS
   Parallel
   SparseDimPartitioner
   Partitioner
+  SparseArray
   )
 
 if(Kokkos_ENABLE_OPENMPTARGET) #FIXME_OPENMPTARGET

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -302,7 +302,7 @@ void sparse_array_test( int par_num, EntityType e )
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qtid_res );
     for ( int i = 0; i < cell_num; ++i )
     {
-        EXPECT_EQ( qtid_mirror( i ) < test_array.numSoA(), true );
+        EXPECT_EQ( qtid_mirror( i ) < (int)test_array.numSoA(), true );
         EXPECT_EQ( qtid_mirror( i ) >= 0, true );
     }
 

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -493,12 +493,6 @@ void full_occupy_test( EntityType e )
         gt_partitions[0][cart_rank[0] + 1] * cell_per_tile_dim,
         gt_partitions[1][cart_rank[1] + 1] * cell_per_tile_dim,
         gt_partitions[2][cart_rank[2] + 1] * cell_per_tile_dim };
-    Kokkos::Array<int, 3> start_tile = { gt_partitions[0][cart_rank[0]],
-                                         gt_partitions[1][cart_rank[1]],
-                                         gt_partitions[2][cart_rank[2]] };
-    Kokkos::Array<int, 3> end_tile = { gt_partitions[0][cart_rank[0] + 1],
-                                       gt_partitions[1][cart_rank[1] + 1],
-                                       gt_partitions[2][cart_rank[2] + 1] };
 
     // fully insert
     auto& map = test_layout.sparseMap();

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -71,89 +71,112 @@ generate_random_partition( std::array<int, 3> ranks_per_dim,
     return gt_partition;
 }
 
-// return random generated particles and occupied tile numbers (last param)
-template <typename scalar_type>
-auto generate_random_particles(
-    const std::array<std::vector<int>, 3>& gt_partition,
-    const Kokkos::Array<int, 3>& cart_rank, const int size_tile_per_dim,
-    const int particle_number, std::array<int, 3>& occupy_tile_num )
-    -> Kokkos::View<scalar_type* [3], TEST_MEMSPACE>
+// convert std::set to device-side view
+template <typename T>
+auto set2view( const std::set<std::array<T, 3>>& in_set )
+    -> Kokkos::View<T* [3], TEST_MEMSPACE>
 {
-    // register valid tiles in each MPI rank
-    // compute the sub-domain size (divided by the ground truth partition)
-    // const int area_size = size_tile_per_dim * size_tile_per_dim;
-    // occupy_tile_num_per_rank = occupy_tile_num_per_rank >= area_size
-    //                                ? area_size
-    //                                : occupy_tile_num_per_rank;
-    std::set<std::array<scalar_type, 3>> tiles_set;
-
-    int start[3], size[3];
-    for ( int d = 0; d < 3; ++d )
-    {
-        start[d] = gt_partition[d][cart_rank[d]];
-        size[d] = gt_partition[d][cart_rank[d] + 1] - start[d];
-    }
-
-    // insert the corner tiles to the set, to ensure the uniqueness of the
-    // ground truth partition
-    tiles_set.insert( { start[0], start[1], start[2] } );
-    tiles_set.insert( { start[0] + size[0] - 1, start[1] + size[1] - 1,
-                        start[2] + size[2] - 1 } );
-
-    // insert random tiles to the set
-    while ( static_cast<int>( tiles_set.size() ) < occupy_tile_num_per_rank )
-    {
-        int rand_offset[3];
-        for ( int d = 0; d < 3; ++d )
-            rand_offset[d] = std::rand() % size[d];
-        tiles_set.insert( { start[0] + rand_offset[0],
-                            start[1] + rand_offset[1],
-                            start[2] + rand_offset[2] } );
-    }
-
-    // tiles_set => tiles_view (host)
+    // set => view (host)
     typedef typename TEST_EXECSPACE::array_layout layout;
-    Kokkos::View<int* [3], layout, Kokkos::HostSpace> tiles_view_host(
-        "tiles_view_host", tiles_set.size() );
-    int i = 0;
-    for ( auto it = tiles_set.begin(); it != tiles_set.end(); ++it )
+    Kokkos::View<T* [3], layout, Kokkos::HostSpace> host_view( "view_host",
+                                                               in_set.size() );
+    for ( int i = 0, auto it = tiles_set.begin(); it != tiles_set.end();
+          ++it, ++i )
     {
         for ( int d = 0; d < 3; ++d )
-            tiles_view_host( i, d ) = ( *it )[d];
-        i++;
+            host_view( i, d ) = ( *it )[d];
     }
 
     // create tiles view on device
-    Kokkos::View<int* [3], TEST_MEMSPACE> tiles_view =
-        Kokkos::create_mirror_view_and_copy( TEST_MEMSPACE(), tiles_view_host );
-    return tiles_view;
+    Kokkos::View<int* [3], TEST_MEMSPACE> dev_view =
+        Kokkos::create_mirror_view_and_copy( TEST_MEMSPACE(), host_view );
+    return dev_view;
 }
 
-void sparse_array_test()
+// return random generated particles and occupied tile numbers (last two params)
+template <typename T>
+void generate_random_particles( const int particle_number,
+                                const std::array<int, 3>& part_start,
+                                const std::array<int, 3>& part_end,
+                                const int cell_per_tile_dim,
+                                const std::array<T, 3> global_low_corner,
+                                const T cell_size,
+                                std::set<std::array<int, 3>>& tile_set,
+                                std::set<std::array<scalar, 3>>& par_pos_set )
+{
+    // range of particle positions
+    T start[3], size[3];
+    for ( int d = 0; d < 3; ++d )
+    {
+        // because each particle will activate three around tiles, we apply
+        // 1.01 cell_size offset compared to the real partition to ensure
+        // all the activated tiles sit inside the valid partition range
+        start[d] = global_low_corner[d] +
+                   cell_size * ( 1.01f + cell_per_tile_dim * (T)part_start[d] );
+        size[d] =
+            cell_size *
+            ( cell_per_tile_dim * (T)( part_end[d] - part_start[d] ) - 2.02f );
+    }
+
+    // insert random particles to the set
+    while ( static_cast<int>( par_pos_set.size() ) < occupy_tile_num_per_rank )
+    {
+        T rand_offset[3];
+        for ( int d = 0; d < 3; ++d )
+            rand_offset[d] = std::rand() / RAND_MAX * size[d];
+        std::array<T, 3> new_pos = { start[0] + rand_offset[0],
+                                     start[1] + rand_offset[1],
+                                     start[2] + rand_offset[2] };
+        auto old_size = par_pos_set.size();
+        par_pos_set.insert( new_pos );
+        if ( old_size == par_pos_set.size() )
+            continue;
+
+        std::array<int, 3> grid_base;
+        for ( int d = 0; d < 3; ++d )
+        {
+            grid_base[d] = int( std::lround( new_pos[d] / cell_size ) ) - 1;
+        }
+
+        for ( int i = 0; i <= 2; i++ )
+            for ( int j = 0; j <= 2; j++ )
+                for ( int k = 0; k <= 2; k++ )
+                {
+                    tile_set.insert( {
+                        ( grid_base[0] + i ) / cell_per_tile_dim,
+                        ( grid_base[1] + j ) / cell_per_tile_dim,
+                        ( grid_base[2] + k ) / cell_per_tile_dim,
+                    } );
+                }
+    }
+}
+template <typename EntityType>
+void sparse_array_test( int par_num, EntityType e )
 {
     // basic senario information
-    constexpr int dim_n = 3;
     constexpr int size_tile_per_dim = 32;
     constexpr int cell_per_tile_dim = 4;
+    constexpr int cell_per_tile =
+        cell_per_tile_dim * cell_per_tile_dim * cell_per_tile_dim;
     constexpr int size_per_dim = size_tile_per_dim * cell_per_tile_dim;
 
     int pre_alloc_size = size_per_dim * size_per_dim;
 
-    using scalar_type = float;
+    using T = float;
     // Create global mesh
-    scalar_type cell_size = 0.1f;
-    std::array<int, dim_n> global_num_cell(
+    T cell_size = 0.1f;
+    std::array<int, 3> global_num_cell(
         { size_per_dim, size_per_dim, size_per_dim } );
     // global low corners: random numbuers
-    std::array<scalar_type, dim_n> global_low_corner = { 1.2f, 3.3f, -2.8f };
-    std::array<scalar_type, dim_n> global_high_corner = {
+    std::array<T, 3> global_low_corner = { 1.2f, 3.3f, -2.8f };
+    std::array<T, 3> global_high_corner = {
         global_low_corner[0] + cell_size * global_num_cell[0],
         global_low_corner[1] + cell_size * global_num_cell[1],
         global_low_corner[2] + cell_size * global_num_cell[2] };
-    std::array<bool, dim_n> is_dim_periodic = { false, false, false };
+    std::array<bool, 3> is_dim_periodic = { false, false, false };
 
     // sparse partitioner
-    scalar_type max_workload_coeff = 1.5;
+    T max_workload_coeff = 1.5;
     int workload_num = size_per_dim * size_per_dim * size_per_dim;
     int num_step_rebalance = 200;
     int max_optimize_iteration = 10;
@@ -162,8 +185,8 @@ void sparse_array_test()
         global_num_cell, max_optimize_iteration );
 
     // rank-related information
-    Kokkos::Array<int, dim_n> cart_rank;
-    std::array<int, dim_n> periodic_dims = { 0, 0, 0 };
+    Kokkos::Array<int, 3> cart_rank;
+    std::array<int, 3> periodic_dims = { 0, 0, 0 };
     int reordered_cart_ranks = 1;
     MPI_Comm cart_comm;
     int linear_rank;
@@ -171,7 +194,7 @@ void sparse_array_test()
     // MPI rank topo and rank ID
     auto ranks_per_dim =
         partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
-    MPI_Cart_create( MPI_COMM_WORLD, dim_n, ranks_per_dim.data(),
+    MPI_Cart_create( MPI_COMM_WORLD, 3, ranks_per_dim.data(),
                      periodic_dims.data(), reordered_cart_ranks, &cart_comm );
     MPI_Comm_rank( cart_comm, &linear_rank );
     MPI_Cart_coords( cart_comm, linear_rank, 3, cart_rank.data() );
@@ -179,6 +202,70 @@ void sparse_array_test()
     // scene initialization
     auto gt_partitions =
         generate_random_partition( ranks_per_dim, size_tile_per_dim );
+    partitioner.initializeRecPartition( gt_partitions[0], gt_partitions[1],
+                                        gt_partitions[2] );
+
+    std::set<std::array<int, 3>> tile_set;
+    std::set<std::array<T, 3>> par_pos_set;
+    generate_random_particles( par_num,
+                               { gt_partitions[0][cart_rank[0]],
+                                 gt_partitions[1][cart_rank[1]],
+                                 gt_partitions[2][cart_rank[2]] },
+                               { gt_partitions[0][cart_rank[0] + 1],
+                                 gt_partitions[1][cart_rank[1] + 1],
+                                 gt_partitions[2][cart_rank[2] + 1] },
+                               cell_per_tile_dim, global_low_corner, cell_size,
+                               tile_set, par_pos_set );
+    auto tile_view = set2view( tile_set );
+    auto par_view = set2view( par_pos_set );
+
+    // DEBUG [TODO]
+    printf( "rank %d (%d, %d, %d), par_num = %d, par_pos_set size = %llu, "
+            "tile_set_size = %llu\n",
+            linear_rank, cart_rank[0], cart_rank[1], cart_rank[2], par_num,
+            par_pos_set.size(), tile_set.size() );
+    // END [TODO]
+
+    // mesh/grid related initilization
+    auto global_mesh = createSparseGlobalMesh(
+        global_low_corner, global_high_corner, global_num_cell );
+
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                         is_dim_periodic, partitioner );
+    int halo_width = 2;
+    auto local_grid =
+        createSparseLocalGrid( global_grid, halo_width, cell_per_tile_dim );
+
+    auto sparse_map =
+        createSparseMap<TEST_EXECSPACE>( global_mesh, pre_alloc_size );
+
+    // def test sparse array
+    using DataTypes = Cabana::MemberTypes<int, float, double[3]>;
+    auto test_layout =
+        createSparseArrayLayout<DataTypes>( local_grid, sparse_map, e );
+    auto test_array = createSparseArray<TEST_DEVICE>(
+        std::string( "test_sparse_grid" ), test_layout );
+
+    // insert particles
+    test_array.registerSparseMap( par_view );
+    test_array.reserve( 1.2 );
+
+    // size-realted tests
+    EXPECT_EQ( test_array.size(), sparse_map.sizeCell() );
+    EXPECT_EQ( test_array.capacity() >= test_layout.reservedCellSize( 1.2 ),
+               true );
+    EXPECT_EQ( test_array.empty(), false );
+    EXPECT_EQ( test_array.numSoA(), sparse_map.sizeTile() );
+    for ( std::size_t i = 0; i < test_array.numSoA(); ++i )
+        EXPECT_EQ( test_array.arraySize( i ), cell_per_dim )
+
+    // some test [TODO]
+
+    // test end
+
+    test_array.clear();
+    EXPECT_EQ( test_array.size(), 0 );
+    EXPECT_EQ( test_layout.sparseMap().sizeTile(), 0 );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -1,0 +1,190 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Cajita_SparseArray.hpp>
+#include <Cajita_SparseDimPartitioner.hpp>
+#include <Cajita_SparseLocalGrid.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+using namespace Cajita;
+using namespace Cajita::Experimental;
+
+namespace Test
+{
+
+// generate a random partition, to mimic a random simulation status
+std::array<std::vector<int>, 3>
+generate_random_partition( std::array<int, 3> ranks_per_dim,
+                           int size_tile_per_dim )
+{
+    std::array<std::set<int>, 3> gt_partition_set;
+    std::array<std::vector<int>, 3> gt_partition;
+    int world_rank, world_size;
+    MPI_Comm_rank( MPI_COMM_WORLD, &world_rank );
+    MPI_Comm_size( MPI_COMM_WORLD, &world_size );
+    for ( int d = 0; d < 3; ++d )
+    {
+        gt_partition[d].resize( ranks_per_dim[d] + 1 );
+    }
+
+    if ( world_rank == 0 )
+    {
+        for ( int d = 0; d < 3; ++d )
+        {
+            gt_partition_set[d].insert( 0 );
+            while ( static_cast<int>( gt_partition_set[d].size() ) <
+                    ranks_per_dim[d] )
+            {
+                int rand_num = std::rand() % size_tile_per_dim;
+                gt_partition_set[d].insert( rand_num );
+            }
+            gt_partition_set[d].insert( size_tile_per_dim );
+            int i = 0;
+            for ( auto it = gt_partition_set[d].begin();
+                  it != gt_partition_set[d].end(); ++it )
+            {
+                gt_partition[d][i++] = *it;
+            }
+        }
+    }
+
+    // broadcast the ground truth partition to all ranks
+    for ( int d = 0; d < 3; ++d )
+    {
+        MPI_Barrier( MPI_COMM_WORLD );
+        MPI_Bcast( gt_partition[d].data(), gt_partition[d].size(), MPI_INT, 0,
+                   MPI_COMM_WORLD );
+        MPI_Barrier( MPI_COMM_WORLD );
+    }
+
+    return gt_partition;
+}
+
+// return random generated particles and occupied tile numbers (last param)
+template <typename scalar_type>
+auto generate_random_particles(
+    const std::array<std::vector<int>, 3>& gt_partition,
+    const Kokkos::Array<int, 3>& cart_rank, const int size_tile_per_dim,
+    const int particle_number, std::array<int, 3>& occupy_tile_num )
+    -> Kokkos::View<scalar_type* [3], TEST_MEMSPACE>
+{
+    // register valid tiles in each MPI rank
+    // compute the sub-domain size (divided by the ground truth partition)
+    // const int area_size = size_tile_per_dim * size_tile_per_dim;
+    // occupy_tile_num_per_rank = occupy_tile_num_per_rank >= area_size
+    //                                ? area_size
+    //                                : occupy_tile_num_per_rank;
+    std::set<std::array<scalar_type, 3>> tiles_set;
+
+    int start[3], size[3];
+    for ( int d = 0; d < 3; ++d )
+    {
+        start[d] = gt_partition[d][cart_rank[d]];
+        size[d] = gt_partition[d][cart_rank[d] + 1] - start[d];
+    }
+
+    // insert the corner tiles to the set, to ensure the uniqueness of the
+    // ground truth partition
+    tiles_set.insert( { start[0], start[1], start[2] } );
+    tiles_set.insert( { start[0] + size[0] - 1, start[1] + size[1] - 1,
+                        start[2] + size[2] - 1 } );
+
+    // insert random tiles to the set
+    while ( static_cast<int>( tiles_set.size() ) < occupy_tile_num_per_rank )
+    {
+        int rand_offset[3];
+        for ( int d = 0; d < 3; ++d )
+            rand_offset[d] = std::rand() % size[d];
+        tiles_set.insert( { start[0] + rand_offset[0],
+                            start[1] + rand_offset[1],
+                            start[2] + rand_offset[2] } );
+    }
+
+    // tiles_set => tiles_view (host)
+    typedef typename TEST_EXECSPACE::array_layout layout;
+    Kokkos::View<int* [3], layout, Kokkos::HostSpace> tiles_view_host(
+        "tiles_view_host", tiles_set.size() );
+    int i = 0;
+    for ( auto it = tiles_set.begin(); it != tiles_set.end(); ++it )
+    {
+        for ( int d = 0; d < 3; ++d )
+            tiles_view_host( i, d ) = ( *it )[d];
+        i++;
+    }
+
+    // create tiles view on device
+    Kokkos::View<int* [3], TEST_MEMSPACE> tiles_view =
+        Kokkos::create_mirror_view_and_copy( TEST_MEMSPACE(), tiles_view_host );
+    return tiles_view;
+}
+
+void sparse_array_test()
+{
+    // basic senario information
+    constexpr int dim_n = 3;
+    constexpr int size_tile_per_dim = 32;
+    constexpr int cell_per_tile_dim = 4;
+    constexpr int size_per_dim = size_tile_per_dim * cell_per_tile_dim;
+
+    int pre_alloc_size = size_per_dim * size_per_dim;
+
+    using scalar_type = float;
+    // Create global mesh
+    scalar_type cell_size = 0.1f;
+    std::array<int, dim_n> global_num_cell(
+        { size_per_dim, size_per_dim, size_per_dim } );
+    // global low corners: random numbuers
+    std::array<scalar_type, dim_n> global_low_corner = { 1.2f, 3.3f, -2.8f };
+    std::array<scalar_type, dim_n> global_high_corner = {
+        global_low_corner[0] + cell_size * global_num_cell[0],
+        global_low_corner[1] + cell_size * global_num_cell[1],
+        global_low_corner[2] + cell_size * global_num_cell[2] };
+    std::array<bool, dim_n> is_dim_periodic = { false, false, false };
+
+    // sparse partitioner
+    scalar_type max_workload_coeff = 1.5;
+    int workload_num = size_per_dim * size_per_dim * size_per_dim;
+    int num_step_rebalance = 200;
+    int max_optimize_iteration = 10;
+    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+        MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
+        global_num_cell, max_optimize_iteration );
+
+    // rank-related information
+    Kokkos::Array<int, dim_n> cart_rank;
+    std::array<int, dim_n> periodic_dims = { 0, 0, 0 };
+    int reordered_cart_ranks = 1;
+    MPI_Comm cart_comm;
+    int linear_rank;
+
+    // MPI rank topo and rank ID
+    auto ranks_per_dim =
+        partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );
+    MPI_Cart_create( MPI_COMM_WORLD, dim_n, ranks_per_dim.data(),
+                     periodic_dims.data(), reordered_cart_ranks, &cart_comm );
+    MPI_Comm_rank( cart_comm, &linear_rank );
+    MPI_Cart_coords( cart_comm, linear_rank, 3, cart_rank.data() );
+
+    // scene initialization
+    auto gt_partitions =
+        generate_random_partition( ranks_per_dim, size_tile_per_dim );
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( sparse_array, 3d_sparse_array ) { sparse_array_test(); }
+
+//---------------------------------------------------------------------------//
+} // namespace Test

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -156,7 +156,7 @@ void generate_random_particles( const int particle_number,
     }
 }
 template <typename EntityType>
-void sparse_array_test( int par_num, EntityType e )
+void sparse_array_test( int par_num, EntityType entity )
 {
     // basic senario information
     constexpr int size_tile_per_dim = 32;
@@ -224,7 +224,7 @@ void sparse_array_test( int par_num, EntityType e )
     auto tile_view = set2view( tile_set );
     auto par_view = set2view( par_pos_set );
 
-    // mesh/grid related initilization
+    // mesh/grid related initialization
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -242,15 +242,15 @@ void sparse_array_test( int par_num, EntityType e )
     // i,j,k; forth: tilekey, tid
     using DataTypes = Cabana::MemberTypes<int[3], float, double[3], int[2]>;
     auto test_layout =
-        createSparseArrayLayout<DataTypes>( local_grid, sparse_map, e );
+        createSparseArrayLayout<DataTypes>( local_grid, sparse_map, entity );
     auto test_array = createSparseArray<TEST_DEVICE>(
         std::string( "test_sparse_grid" ), test_layout );
 
     // insert particles
-    test_array.register_sparse_grid( par_view, par_num );
-    test_array.reserve_cell( 1.2 );
+    test_array.registerSparseGrid( par_view, par_num );
+    test_array.reserveFromMap( 1.2 );
 
-    // size-realted tests
+    // size-related tests
     EXPECT_EQ( test_array.size(), sparse_map.sizeCell() );
     EXPECT_EQ( test_array.capacity() >= sparse_map.reservedCellSize( 1.2 ),
                true );
@@ -291,7 +291,7 @@ void sparse_array_test( int par_num, EntityType e )
                         offset++;
                     }
         } );
-    // check if all reuiqred cell are registered
+    // check if all required cell are registered
     auto qtid_mirror =
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), qtid_res );
     for ( int i = 0; i < cell_num; ++i )
@@ -402,7 +402,7 @@ void sparse_array_test( int par_num, EntityType e )
 }
 
 template <typename EntityType>
-void full_occupy_test( EntityType e )
+void full_occupy_test( EntityType entity )
 {
     // basic senario information
     constexpr int size_tile_per_dim = 8;
@@ -456,7 +456,7 @@ void full_occupy_test( EntityType e )
     partitioner.initializeRecPartition( gt_partitions[0], gt_partitions[1],
                                         gt_partitions[2] );
 
-    // mesh/grid related initilization
+    // mesh/grid related initialization
     auto global_mesh = createSparseGlobalMesh(
         global_low_corner, global_high_corner, global_num_cell );
 
@@ -474,7 +474,7 @@ void full_occupy_test( EntityType e )
     // tid
     using DataTypes = Cabana::MemberTypes<int[3], float[3], int[2]>;
     auto test_layout =
-        createSparseArrayLayout<DataTypes>( local_grid, sparse_map, e );
+        createSparseArrayLayout<DataTypes>( local_grid, sparse_map, entity );
     auto test_array = createSparseArray<TEST_DEVICE>(
         std::string( "test_sparse_grid" ), test_layout );
 
@@ -615,6 +615,7 @@ TEST( sparse_array, 3d_sparse_array_sparse_occupy )
 TEST( sparse_array, 3d_sparse_array_full_occupy )
 {
     full_occupy_test( Cajita::Node() );
+    full_occupy_test( Cajita::Cell() );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -132,7 +132,6 @@ void generate_random_particles( const int particle_number,
         std::array<T, 3> new_pos = { start[0] + rand_offset[0],
                                      start[1] + rand_offset[1],
                                      start[2] + rand_offset[2] };
-        auto old_size = par_pos_set.size();
         par_pos_set.insert( new_pos );
 
         std::array<int, 3> grid_base;

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -256,14 +256,8 @@ void sparse_array_test( int par_num, EntityType e )
                true );
     EXPECT_EQ( test_array.empty(), false );
     EXPECT_EQ( test_array.numSoA(), sparse_map.sizeTile() );
-    for ( std::size_t i = 0; i < test_array.numSoA() - 1; ++i )
-    // for ( std::size_t i = 0; i < test_array.numSoA(); ++i )
-    {
+    for ( std::size_t i = 0; i < test_array.numSoA(); ++i )
         EXPECT_EQ( test_array.arraySize( i ), cell_per_tile );
-        // printf( "cellSize %d, array id %d, arraySize %d\n",
-        //         (int)test_array.size(), (int)i,
-        //         (int)test_array.arraySize( i ) );
-    }
 
     // check particle insertion results
     int cell_num = par_view.extent( 0 ) * 27;


### PR DESCRIPTION
Add new support to the sparse array. 

Updates include:
1. `SparseArrayLayout` that supports:
    - record valid sparse tiles inside the sparse map
    - query sparse map
    - query array-related info (e.g. size)
    - insert tiles according to particle positions 
2. `SparseArray` that supports:
    - array allocation
    - array access with multiple indexing style 
3. Corresponding unit tests  