### PR TITLE
Fix arraySize for fully occupied AoSoA

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -442,8 +442,10 @@ class AoSoA
     KOKKOS_INLINE_FUNCTION
     size_type arraySize( const size_type s ) const
     {
-        return ( (size_type)s < _num_soa - 1 ) ? vector_length
-                                               : ( _size % vector_length );
+        return ( ( (size_type)s < _num_soa - 1 ) ||
+                 ( _size % vector_length == 0 ) )
+                   ? vector_length
+                   : ( _size % vector_length );
     }
 
     /*!

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -442,10 +442,13 @@ class AoSoA
     KOKKOS_INLINE_FUNCTION
     size_type arraySize( const size_type s ) const
     {
+        // the SoA struct size should be full size, i.e. vector_length if:
+        // 1) s is not the last SoA struct
+        // or 2) if _size = _num_soa * vector_length
         return ( ( (size_type)s < _num_soa - 1 ) ||
                  ( _size % vector_length == 0 ) )
-                   ? vector_length
-                   : ( _size % vector_length );
+                   ? vector_length              // if s is a full SoA struct
+                   : ( _size % vector_length ); // if s is the last SoA struct
     }
 
     /*!

--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -233,6 +233,16 @@ void testAoSoA()
     EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
     EXPECT_EQ( aosoa.arraySize( 1 ), int( 16 ) );
     EXPECT_EQ( aosoa.arraySize( 2 ), int( 15 ) );
+
+    // Now resize to numSoA*vector_length
+    // Make sure it works when all SoA structures are fully occupied
+    aosoa.resize( 48 );
+    EXPECT_EQ( aosoa.size(), int( 48 ) );
+    EXPECT_EQ( aosoa.capacity(), int( 48 ) );
+    EXPECT_EQ( aosoa.numSoA(), int( 3 ) );
+    EXPECT_EQ( aosoa.arraySize( 0 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 1 ), int( 16 ) );
+    EXPECT_EQ( aosoa.arraySize( 2 ), int( 16 ) );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Fix `arraySize` implementation in `Cabana::AoSoA` for cases when all SoA sturctures are fully occupied.
(when size = numSoA * vector_lenght)