### PR TITLE
Add Gather/Scatter for avoiding MPI comms buffer reallocation

### DIFF
--- a/benchmark/core/Cabana_CommPerformance.cpp
+++ b/benchmark/core/Cabana_CommPerformance.cpp
@@ -390,17 +390,13 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
         // Run preallocated AoSoA buffer tests and time the ensemble.
         auto comm_particles = Cabana::create_mirror_view_and_copy(
             comm_memory_space(), particles );
-        auto send_buffer_aosoa = Cabana::gatherAllocateSendBuffer(
-            halo, comm_particles, overallocation );
-        auto recv_buffer_aosoa = Cabana::gatherAllocateRecvBuffer(
-            halo, comm_particles, overallocation );
+        auto gather = createGather( halo, comm_particles, overallocation );
         for ( int t = 0; t < num_run; ++t )
         {
             halo_buffer_aosoa_gather.start( fraction );
             auto comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
-            Cabana::gather( halo, comm_particles, send_buffer_aosoa,
-                            recv_buffer_aosoa );
+            gather.apply( comm_particles );
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_aosoa_gather.stop( fraction );
         }
@@ -412,22 +408,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
         auto s1 = Cabana::slice<1>( comm_particles );
         auto s2 = Cabana::slice<2>( comm_particles );
         auto s3 = Cabana::slice<3>( comm_particles );
-        auto gather_send_s0 =
-            Cabana::gatherAllocateSendBuffer( halo, s0, overallocation );
-        auto gather_recv_s0 =
-            Cabana::gatherAllocateRecvBuffer( halo, s0, overallocation );
-        auto gather_send_s1 =
-            Cabana::gatherAllocateSendBuffer( halo, s1, overallocation );
-        auto gather_recv_s1 =
-            Cabana::gatherAllocateRecvBuffer( halo, s1, overallocation );
-        auto gather_send_s2 =
-            Cabana::gatherAllocateSendBuffer( halo, s2, overallocation );
-        auto gather_recv_s2 =
-            Cabana::gatherAllocateRecvBuffer( halo, s2, overallocation );
-        auto gather_send_s3 =
-            Cabana::gatherAllocateSendBuffer( halo, s3, overallocation );
-        auto gather_recv_s3 =
-            Cabana::gatherAllocateRecvBuffer( halo, s3, overallocation );
+        auto gather_s0 = createGather( halo, s0, overallocation );
+        auto gather_s1 = createGather( halo, s1, overallocation );
+        auto gather_s2 = createGather( halo, s2, overallocation );
+        auto gather_s3 = createGather( halo, s3, overallocation );
         for ( int t = 0; t < num_run; ++t )
         {
             halo_buffer_slice_gather.start( fraction );
@@ -435,16 +419,16 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
                 comm_memory_space(), particles );
 
             auto s0 = Cabana::slice<0>( comm_particles );
-            Cabana::gather( halo, s0, gather_send_s0, gather_recv_s0 );
+            gather_s0.apply( s0 );
 
             auto s1 = Cabana::slice<1>( comm_particles );
-            Cabana::gather( halo, s1, gather_send_s1, gather_recv_s1 );
+            gather_s1.apply( s1 );
 
             auto s2 = Cabana::slice<2>( comm_particles );
-            Cabana::gather( halo, s2, gather_send_s2, gather_recv_s2 );
+            gather_s2.apply( s2 );
 
             auto s3 = Cabana::slice<3>( comm_particles );
-            Cabana::gather( halo, s3, gather_send_s3, gather_recv_s3 );
+            gather_s3.apply( s3 );
 
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_slice_gather.stop( fraction );
@@ -457,22 +441,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
         s1 = Cabana::slice<1>( comm_particles );
         s2 = Cabana::slice<2>( comm_particles );
         s3 = Cabana::slice<3>( comm_particles );
-        auto scatter_send_s0 =
-            Cabana::scatterAllocateSendBuffer( halo, s0, overallocation );
-        auto scatter_recv_s0 =
-            Cabana::scatterAllocateRecvBuffer( halo, s0, overallocation );
-        auto scatter_send_s1 =
-            Cabana::scatterAllocateSendBuffer( halo, s1, overallocation );
-        auto scatter_recv_s1 =
-            Cabana::scatterAllocateRecvBuffer( halo, s1, overallocation );
-        auto scatter_send_s2 =
-            Cabana::scatterAllocateSendBuffer( halo, s2, overallocation );
-        auto scatter_recv_s2 =
-            Cabana::scatterAllocateRecvBuffer( halo, s2, overallocation );
-        auto scatter_send_s3 =
-            Cabana::scatterAllocateSendBuffer( halo, s3, overallocation );
-        auto scatter_recv_s3 =
-            Cabana::scatterAllocateRecvBuffer( halo, s3, overallocation );
+        auto scatter_s0 = createScatter( halo, s0, overallocation );
+        auto scatter_s1 = createScatter( halo, s1, overallocation );
+        auto scatter_s2 = createScatter( halo, s2, overallocation );
+        auto scatter_s3 = createScatter( halo, s3, overallocation );
         for ( int t = 0; t < num_run; ++t )
         {
             halo_buffer_slice_scatter.start( fraction );
@@ -480,16 +452,16 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
                 comm_memory_space(), particles );
 
             s0 = Cabana::slice<0>( comm_particles );
-            Cabana::scatter( halo, s0, scatter_send_s0, scatter_recv_s0 );
+            scatter_s0.apply( s0 );
 
             s1 = Cabana::slice<1>( comm_particles );
-            Cabana::scatter( halo, s1, scatter_send_s1, scatter_recv_s1 );
+            scatter_s1.apply( s1 );
 
             s2 = Cabana::slice<2>( comm_particles );
-            Cabana::scatter( halo, s2, scatter_send_s2, scatter_recv_s2 );
+            scatter_s2.apply( s2 );
 
             s3 = Cabana::slice<3>( comm_particles );
-            Cabana::scatter( halo, s3, scatter_send_s3, scatter_recv_s3 );
+            scatter_s3.apply( s3 );
 
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_slice_scatter.stop( fraction );

--- a/benchmark/core/Cabana_CommPerformance.cpp
+++ b/benchmark/core/Cabana_CommPerformance.cpp
@@ -396,7 +396,7 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             halo_buffer_aosoa_gather.start( fraction );
             auto comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
-            gather.apply( comm_particles );
+            gather.apply();
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_aosoa_gather.stop( fraction );
         }
@@ -418,17 +418,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
 
-            auto s0 = Cabana::slice<0>( comm_particles );
-            gather_s0.apply( s0 );
-
-            auto s1 = Cabana::slice<1>( comm_particles );
-            gather_s1.apply( s1 );
-
-            auto s2 = Cabana::slice<2>( comm_particles );
-            gather_s2.apply( s2 );
-
-            auto s3 = Cabana::slice<3>( comm_particles );
-            gather_s3.apply( s3 );
+            gather_s0.apply();
+            gather_s1.apply();
+            gather_s2.apply();
+            gather_s3.apply();
 
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_slice_gather.stop( fraction );
@@ -451,17 +444,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
 
-            s0 = Cabana::slice<0>( comm_particles );
-            scatter_s0.apply( s0 );
-
-            s1 = Cabana::slice<1>( comm_particles );
-            scatter_s1.apply( s1 );
-
-            s2 = Cabana::slice<2>( comm_particles );
-            scatter_s2.apply( s2 );
-
-            s3 = Cabana::slice<3>( comm_particles );
-            scatter_s3.apply( s3 );
+            scatter_s0.apply();
+            scatter_s1.apply();
+            scatter_s2.apply();
+            scatter_s3.apply();
 
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_slice_scatter.stop( fraction );

--- a/benchmark/core/Cabana_CommPerformance.cpp
+++ b/benchmark/core/Cabana_CommPerformance.cpp
@@ -394,14 +394,15 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
         for ( int t = 0; t < num_run; ++t )
         {
             halo_buffer_aosoa_gather.start( fraction );
-            auto comm_particles = Cabana::create_mirror_view_and_copy(
+            comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
             gather.apply();
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_aosoa_gather.stop( fraction );
         }
 
-        // Run preallocated slice buffer gather tests and time the ensemble.
+        // Run preallocated slice buffer gather/scatter tests and time the
+        // ensemble.
         comm_particles = Cabana::create_mirror_view_and_copy(
             comm_memory_space(), particles );
         auto s0 = Cabana::slice<0>( comm_particles );
@@ -412,11 +413,23 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
         auto gather_s1 = createGather( halo, s1, overallocation );
         auto gather_s2 = createGather( halo, s2, overallocation );
         auto gather_s3 = createGather( halo, s3, overallocation );
+        auto scatter_s0 = createScatter( halo, s0, overallocation );
+        auto scatter_s1 = createScatter( halo, s1, overallocation );
+        auto scatter_s2 = createScatter( halo, s2, overallocation );
+        auto scatter_s3 = createScatter( halo, s3, overallocation );
         for ( int t = 0; t < num_run; ++t )
         {
             halo_buffer_slice_gather.start( fraction );
             comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
+            s0 = Cabana::slice<0>( comm_particles );
+            s1 = Cabana::slice<1>( comm_particles );
+            s2 = Cabana::slice<2>( comm_particles );
+            s3 = Cabana::slice<3>( comm_particles );
+            gather_s0.setParticles( s0 );
+            gather_s1.setParticles( s1 );
+            gather_s2.setParticles( s2 );
+            gather_s3.setParticles( s3 );
 
             gather_s0.apply();
             gather_s1.apply();
@@ -425,24 +438,18 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
 
             Cabana::deep_copy( particles, comm_particles );
             halo_buffer_slice_gather.stop( fraction );
-        }
 
-        // Run preallocated slice buffer scatter tests and time the ensemble.
-        comm_particles = Cabana::create_mirror_view_and_copy(
-            comm_memory_space(), particles );
-        s0 = Cabana::slice<0>( comm_particles );
-        s1 = Cabana::slice<1>( comm_particles );
-        s2 = Cabana::slice<2>( comm_particles );
-        s3 = Cabana::slice<3>( comm_particles );
-        auto scatter_s0 = createScatter( halo, s0, overallocation );
-        auto scatter_s1 = createScatter( halo, s1, overallocation );
-        auto scatter_s2 = createScatter( halo, s2, overallocation );
-        auto scatter_s3 = createScatter( halo, s3, overallocation );
-        for ( int t = 0; t < num_run; ++t )
-        {
             halo_buffer_slice_scatter.start( fraction );
             comm_particles = Cabana::create_mirror_view_and_copy(
                 comm_memory_space(), particles );
+            s0 = Cabana::slice<0>( comm_particles );
+            s1 = Cabana::slice<1>( comm_particles );
+            s2 = Cabana::slice<2>( comm_particles );
+            s3 = Cabana::slice<3>( comm_particles );
+            scatter_s0.setParticles( s0 );
+            scatter_s1.setParticles( s1 );
+            scatter_s2.setParticles( s2 );
+            scatter_s3.setParticles( s3 );
 
             scatter_s0.apply();
             scatter_s1.apply();

--- a/benchmark/core/Cabana_CommPerformance.cpp
+++ b/benchmark/core/Cabana_CommPerformance.cpp
@@ -426,10 +426,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             s1 = Cabana::slice<1>( comm_particles );
             s2 = Cabana::slice<2>( comm_particles );
             s3 = Cabana::slice<3>( comm_particles );
-            gather_s0.setParticles( s0 );
-            gather_s1.setParticles( s1 );
-            gather_s2.setParticles( s2 );
-            gather_s3.setParticles( s3 );
+            gather_s0.setData( s0 );
+            gather_s1.setData( s1 );
+            gather_s2.setData( s2 );
+            gather_s3.setData( s3 );
 
             gather_s0.apply();
             gather_s1.apply();
@@ -446,10 +446,10 @@ void performanceTest( std::ostream& stream, const std::size_t num_particle,
             s1 = Cabana::slice<1>( comm_particles );
             s2 = Cabana::slice<2>( comm_particles );
             s3 = Cabana::slice<3>( comm_particles );
-            scatter_s0.setParticles( s0 );
-            scatter_s1.setParticles( s1 );
-            scatter_s2.setParticles( s2 );
-            scatter_s3.setParticles( s3 );
+            scatter_s0.setData( s0 );
+            scatter_s1.setData( s1 );
+            scatter_s2.setData( s2 );
+            scatter_s3.setData( s3 );
 
             scatter_s0.apply();
             scatter_s1.apply();

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -946,24 +946,19 @@ class CommunicationPlan
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Store communication plan and send/receive buffers. AoSoA version.
+  \brief Store AoSoA send/receive buffers.
 */
-template <class CommPlanType, class AoSoAType>
-class CommunicateAoSoA
+template <class AoSoAType>
+struct CommunicationDataAoSoA
 {
     static_assert( is_aosoa<AoSoAType>::value, "" );
 
-  public:
-    //! Communication plan type (Halo, Distributor)
-    using plan_type = CommPlanType;
-    //! Kokkos execution space.
-    using execution_space = typename plan_type::execution_space;
-    //! AoSoA type.
-    using aosoa_type = AoSoAType;
+    //! Particle data type.
+    using particle_data_type = AoSoAType;
     //! Kokkos memory space.
-    using memory_space = typename aosoa_type::memory_space;
+    using memory_space = typename particle_data_type::memory_space;
     //! Communication data type.
-    using data_type = typename aosoa_type::tuple_type;
+    using data_type = typename particle_data_type::tuple_type;
     //! Communication buffer type.
     using buffer_type = typename Kokkos::View<data_type*, memory_space>;
 
@@ -973,10 +968,7 @@ class CommunicateAoSoA
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    CommunicateAoSoA( const CommPlanType& comm_plan,
-                      const double overallocation = 1.0 )
-        : _comm_plan( comm_plan )
-        , _overallocation( overallocation )
+    CommunicationDataAoSoA()
     {
         _send_buffer = buffer_type(
             Kokkos::ViewAllocateWithoutInitializing( "send_buffer" ), 0 );
@@ -984,56 +976,23 @@ class CommunicateAoSoA
             Kokkos::ViewAllocateWithoutInitializing( "recv_buffer" ), 0 );
     }
 
-    //! Get the communication send buffer.
-    buffer_type getSendBuffer() const { return _send_buffer; }
-    //! Get the communication receive buffer.
-    buffer_type getReceiveBuffer() const { return _recv_buffer; }
-
-    /*!
-      \brief Perform the gather operation, automatically recreating the
-      comm_plan and communication buffers as needed.
-
-      \param aosoa The AoSoA on which to perform the gather.
-      \param overallocation An optional factor to keep extra space in the
-      buffers to avoid frequent resizing.
-    */
-    void apply( AoSoAType& aosoa, const double overallocation = -1 )
+    //! Resize the send buffer.
+    void reallocateSend( AoSoAType, const std::size_t num_send )
     {
-        update( _comm_plan, aosoa, overallocation );
-        apply( aosoa );
+        Kokkos::realloc( _send_buffer, num_send );
     }
-
-    //! Perform the communication (migrate, gather, scatter).
-    virtual void apply( AoSoAType& aosoa ) = 0;
-
-    //! Udpate the communciation plan and particle data to communicate.
-    virtual void update( const CommPlanType& comm_plan, AoSoAType& aosoa,
-                         const double overallocation = -1 ) = 0;
-
-  protected:
-    //! \cond Impl
-    void updateImpl( const CommPlanType& comm_plan,
-                     const std::size_t total_send, const std::size_t total_recv,
-                     const double overallocation = -1 )
+    //! Resize the receive buffer.
+    void reallocateReceive( AoSoAType, const std::size_t num_recv )
     {
-        _comm_plan = comm_plan;
-
-        if ( overallocation != -1 )
-            _overallocation = overallocation;
-
-        std::size_t new_send_size = total_send * _overallocation;
-        if ( new_send_size > _send_buffer.extent( 0 ) )
-            Kokkos::realloc( _send_buffer, new_send_size );
-        std::size_t new_recv_size = total_recv * _overallocation;
-        if ( new_recv_size > _recv_buffer.extent( 0 ) )
-            Kokkos::realloc( _recv_buffer, new_recv_size );
+        Kokkos::realloc( _recv_buffer, num_recv );
+    }
+    //! \cond Impl
+    auto getSliceComponents( AoSoAType )
+    {
+        throw std::runtime_error( "Slice components not valid for AoSoA!" );
     }
     //! \endcond
 
-    //! Communication plan.
-    plan_type _comm_plan;
-    //! Overallocation factor.
-    int _overallocation;
     //! Send buffer.
     buffer_type _send_buffer;
     //! Receive buffer.
@@ -1041,24 +1000,19 @@ class CommunicateAoSoA
 };
 
 /*!
-  \brief Store communication plan and send/receive buffers. Slice version.
+  \brief Store slice send/receive buffers.
 */
-template <class CommPlanType, class SliceType>
-class CommunicateSlice
+template <class SliceType>
+struct CommunicationDataSlice
 {
     static_assert( is_slice<SliceType>::value, "" );
 
-  public:
-    //! Communication plan type (Halo, Distributor).
-    using plan_type = CommPlanType;
-    //! Kokkos execution space.
-    using execution_space = typename plan_type::execution_space;
-    //! Slice type.
-    using slice_type = SliceType;
+    //! Particle data type.
+    using particle_data_type = SliceType;
     //! Kokkos memory space.
-    using memory_space = typename slice_type::memory_space;
+    using memory_space = typename particle_data_type::memory_space;
     //! Communication data type.
-    using data_type = typename slice_type::value_type;
+    using data_type = typename particle_data_type::value_type;
     //! Communication buffer type.
     using buffer_type =
         typename Kokkos::View<data_type**, Kokkos::LayoutRight, memory_space>;
@@ -1069,10 +1023,7 @@ class CommunicateSlice
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    CommunicateSlice( const CommPlanType& comm_plan,
-                      const double overallocation = 1.0 )
-        : _comm_plan( comm_plan )
-        , _overallocation( overallocation )
+    CommunicationDataSlice()
     {
         _send_buffer = buffer_type(
             Kokkos::ViewAllocateWithoutInitializing( "send_buffer" ), 0, 0 );
@@ -1080,72 +1031,123 @@ class CommunicateSlice
             Kokkos::ViewAllocateWithoutInitializing( "recv_buffer" ), 0, 0 );
     }
 
-    //! Get the communication send buffer.
-    buffer_type getSendBuffer() const { return _send_buffer; }
-    //! Get the communication receive buffer.
-    buffer_type getReceiveBuffer() const { return _recv_buffer; }
-
-    /*!
-      \brief Perform the gather operation, automatically recreating the
-      comm_plan and communication buffers as needed.
-
-      \param slice The AoSoA on which to perform the gather.
-      \param overallocation An optional factor to keep extra space in the
-      buffers to avoid frequent resizing.
-    */
-    void apply( SliceType& slice, const double overallocation = -1 )
+    //! Resize the send buffer.
+    void reallocateSend( const SliceType slice, const std::size_t num_send )
     {
-        update( _comm_plan, slice, overallocation );
-        apply( slice );
+        auto num_comp = getSliceComponents( slice );
+        Kokkos::realloc( _send_buffer, num_send, num_comp );
+    }
+    //! Resize the receive buffer.
+    void reallocateReceive( const SliceType slice, const std::size_t num_recv )
+    {
+        auto num_comp = getSliceComponents( slice );
+        Kokkos::realloc( _recv_buffer, num_recv, num_comp );
     }
 
-    //! Perform the communication (migrate, gather, scatter).
-    virtual void apply( SliceType& slice ) = 0;
-
-    //! Udpate the communciation plan and particle data to communicate.
-    virtual void update( const CommPlanType& comm_plan, const SliceType& slice,
-                         const double overallocation = -1 ) = 0;
-
-  protected:
-    //! \cond Impl
-    void updateImpl( const CommPlanType& comm_plan,
-                     const std::size_t total_send, const std::size_t total_recv,
-                     const std::size_t num_comp,
-                     const double overallocation = -1 )
-    {
-        _comm_plan = comm_plan;
-
-        if ( overallocation != -1 )
-            _overallocation = overallocation;
-
-        std::size_t new_send_size = total_send * _overallocation;
-        if ( new_send_size > _send_buffer.extent( 0 ) )
-            Kokkos::realloc( _send_buffer, new_send_size, num_comp );
-        std::size_t new_recv_size = total_recv * _overallocation;
-        if ( new_recv_size > _recv_buffer.extent( 0 ) )
-            Kokkos::realloc( _recv_buffer, new_recv_size, num_comp );
-    }
-
+    //! Get the total number of components in the slice.
     auto getSliceComponents( SliceType slice )
     {
-        // Get the number of components in the slice.
         std::size_t num_comp = 1;
         for ( std::size_t d = 2; d < slice.rank(); ++d )
             num_comp *= slice.extent( d );
         return num_comp;
     }
-    //! \endcond
 
-    //! Communication plan.
-    plan_type _comm_plan;
-    //! Overallocation factor.
-    int _overallocation;
     //! Send buffer.
     buffer_type _send_buffer;
     //! Receive buffer.
     buffer_type _recv_buffer;
 };
 //---------------------------------------------------------------------------//
+
+/*!
+  \brief Store communication plan and communication buffers.
+*/
+template <class CommPlanType, class CommDataType>
+class CommunicationData
+{
+  public:
+    //! Communication plan type (Halo, Distributor)
+    using plan_type = CommPlanType;
+    //! Kokkos execution space.
+    using execution_space = typename plan_type::execution_space;
+    //! Communication data type.
+    using comm_data_type = CommDataType;
+    //! Particle data type.
+    using particle_data_type = typename comm_data_type::particle_data_type;
+    //! Kokkos memory space.
+    using memory_space = typename comm_data_type::memory_space;
+    //! Communication data type.
+    using data_type = typename comm_data_type::data_type;
+    //! Communication buffer type.
+    using buffer_type = typename comm_data_type::buffer_type;
+
+    /*!
+      \param comm_plan The communication plan.
+
+      \param overallocation An optional factor to keep extra space in the
+      buffers to avoid frequent resizing.
+    */
+    CommunicationData( const CommPlanType& comm_plan,
+                       const double overallocation = 1.0 )
+        : _comm_plan( comm_plan )
+        , _overallocation( overallocation )
+    {
+        _comm_data = CommDataType();
+    }
+
+    //! Get the communication send buffer.
+    buffer_type getSendBuffer() const { return _comm_data._send_buffer; }
+    //! Get the communication receive buffer.
+    buffer_type getReceiveBuffer() const { return _comm_data._recv_buffer; }
+
+    //! Perform the communication (migrate, gather, scatter).
+    virtual void apply( particle_data_type& particles ) = 0;
+
+    //! \cond Impl
+    void updateImpl( const CommPlanType& comm_plan,
+                     const particle_data_type particles,
+                     const std::size_t total_send, const std::size_t total_recv,
+                     const double overallocation )
+    {
+        if ( overallocation < 1.0 )
+            throw std::runtime_error( "Cannot allocate buffers with less space "
+                                      "than data to communicate!" );
+        _overallocation = overallocation;
+
+        updateImpl( comm_plan, particles, total_send, total_recv );
+    }
+    void updateImpl( const CommPlanType& comm_plan,
+                     const particle_data_type particles,
+                     const std::size_t total_send,
+                     const std::size_t total_recv )
+    {
+        _comm_plan = comm_plan;
+
+        std::size_t new_send_size = total_send * _overallocation;
+        if ( new_send_size > _comm_data._send_buffer.extent( 0 ) )
+            _comm_data.reallocateSend( particles, new_send_size );
+
+        std::size_t new_recv_size = total_recv * _overallocation;
+        if ( new_recv_size > _comm_data._recv_buffer.extent( 0 ) )
+            _comm_data.reallocateReceive( particles, new_recv_size );
+    }
+    //! \endcond
+
+  protected:
+    //! Get the total number of components in the slice.
+    auto getSliceComponents( particle_data_type slice )
+    {
+        return _comm_data.getSliceComponents( slice );
+    };
+
+    //! Communication plan.
+    plan_type _comm_plan;
+    //! Communication plan.
+    comm_data_type _comm_data;
+    //! Overallocation factor.
+    int _overallocation;
+};
 
 } // end namespace Cabana
 

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1070,6 +1070,8 @@ class CommunicationData
     using plan_type = CommPlanType;
     //! Kokkos execution space.
     using execution_space = typename plan_type::execution_space;
+    //! Kokkos execution policy.
+    using policy_type = Kokkos::RangePolicy<execution_space>;
     //! Communication data type.
     using comm_data_type = CommDataType;
     //! Particle data type.
@@ -1180,15 +1182,29 @@ class CommunicationData
 
         _send_size = total_send;
         _recv_size = total_recv;
+
+        // Update policies with new sizes.
+        updateRangePolicy();
     }
     //! \endcond
 
   protected:
+    //! Update range policy based on new communication plan.
+    void updateRangePolicy()
+    {
+        _send_policy = policy_type( 0, _send_size );
+        _recv_policy = policy_type( 0, _recv_size );
+    }
+
     //! Get the total number of components in the slice.
     auto getSliceComponents() { return _comm_data._num_comp; };
 
     //! Communication plan.
     plan_type _comm_plan;
+    //! Send range policy.
+    policy_type _send_policy;
+    //! Receive range policy.
+    policy_type _recv_policy;
     //! Communication plan.
     comm_data_type _comm_data;
     //! Overallocation factor.

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1104,9 +1104,9 @@ class CommunicationData
     buffer_type getReceiveBuffer() const { return _comm_data._recv_buffer; }
 
     //! Get the particles to communicate.
-    particle_data_type getParticles() const { return _comm_data._particles; }
+    particle_data_type getData() const { return _comm_data._particles; }
     //! Update particles to communicate.
-    void setParticles( const particle_data_type& particles )
+    void setData( const particle_data_type& particles )
     {
         _comm_data._particles = particles;
     }
@@ -1168,7 +1168,7 @@ class CommunicationData
                       const std::size_t total_recv )
     {
         _comm_plan = comm_plan;
-        setParticles( particles );
+        setData( particles );
 
         auto send_capacity = sendCapacity();
         std::size_t new_send_size = total_send * _overallocation;

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1115,22 +1115,23 @@ class CommunicationData
     virtual void apply() = 0;
 
     //! \cond Impl
-    void updateImpl( const CommPlanType& comm_plan,
-                     const particle_data_type particles,
-                     const std::size_t total_send, const std::size_t total_recv,
-                     const double overallocation )
+    void reserveImpl( const CommPlanType& comm_plan,
+                      const particle_data_type particles,
+                      const std::size_t total_send,
+                      const std::size_t total_recv,
+                      const double overallocation )
     {
         if ( overallocation < 1.0 )
             throw std::runtime_error( "Cannot allocate buffers with less space "
                                       "than data to communicate!" );
         _overallocation = overallocation;
 
-        updateImpl( comm_plan, particles, total_send, total_recv );
+        reserveImpl( comm_plan, particles, total_send, total_recv );
     }
-    void updateImpl( const CommPlanType& comm_plan,
-                     const particle_data_type particles,
-                     const std::size_t total_send,
-                     const std::size_t total_recv )
+    void reserveImpl( const CommPlanType& comm_plan,
+                      const particle_data_type particles,
+                      const std::size_t total_send,
+                      const std::size_t total_recv )
     {
         _comm_plan = comm_plan;
         setParticles( particles );

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -282,15 +282,13 @@ class Gather<HaloType, AoSoAType,
 
     /*!
       \brief Perform the gather operation.
-
-      \param aosoa The AoSoA on which to perform the gather.
     */
     void apply() override
     {
         // Get the buffers and particle data (local copies for lambdas below).
         auto send_buffer = this->getSendBuffer();
         auto recv_buffer = this->getReceiveBuffer();
-        auto aosoa = this->getParticles();
+        auto aosoa = this->getData();
 
         // Get the steering vector for the sends.
         auto steering = _halo.getExportSteering();
@@ -456,15 +454,13 @@ class Gather<HaloType, SliceType,
 
     /*!
       \brief Perform the gather operation.
-
-      \param slice The slice on which to perform the gather.
     */
     void apply() override
     {
         // Get the buffers (local copies for lambdas below).
         auto send_buffer = this->getSendBuffer();
         auto recv_buffer = this->getReceiveBuffer();
-        auto slice = this->getParticles();
+        auto slice = this->getData();
 
         // Get the number of components in the slice.
         std::size_t num_comp = this->getSliceComponents();
@@ -698,15 +694,13 @@ class Scatter
 
     /*!
       \brief Perform the scatter operation.
-
-      \param slice The slice on which to perform the scatter.
     */
     void apply() override
     {
         // Get the buffers (local copies for lambdas below).
         auto send_buffer = this->getSendBuffer();
         auto recv_buffer = this->getReceiveBuffer();
-        auto slice = this->getParticles();
+        auto slice = this->getData();
 
         // Get the number of components in the slice.
         std::size_t num_comp = this->getSliceComponents();

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -299,11 +299,8 @@ class Gather<HaloType, AoSoAType,
         {
             send_buffer( i ) = aosoa.getTuple( steering( i ) );
         };
-        Kokkos::RangePolicy<execution_space> gather_send_buffer_policy(
-            0, _halo.totalNumExport() );
         Kokkos::parallel_for( "Cabana::gather::gather_send_buffer",
-                              gather_send_buffer_policy,
-                              gather_send_buffer_func );
+                              _send_policy, gather_send_buffer_func );
         Kokkos::fence();
 
         // The halo has it's own communication space so choose any mpi tag.
@@ -356,11 +353,8 @@ class Gather<HaloType, AoSoAType,
             std::size_t ghost_idx = i + num_local;
             aosoa.setTuple( ghost_idx, recv_buffer( i ) );
         };
-        Kokkos::RangePolicy<execution_space> extract_recv_buffer_policy(
-            0, _halo.totalNumImport() );
         Kokkos::parallel_for( "Cabana::gather::extract_recv_buffer",
-                              extract_recv_buffer_policy,
-                              extract_recv_buffer_func );
+                              _recv_policy, extract_recv_buffer_func );
         Kokkos::fence();
 
         // Barrier before completing to ensure synchronization.
@@ -400,6 +394,8 @@ class Gather<HaloType, AoSoAType,
 
   private:
     plan_type _halo = base_type::_comm_plan;
+    using base_type::_recv_policy;
+    using base_type::_send_policy;
 };
 
 /*!
@@ -489,11 +485,8 @@ class Gather<HaloType, SliceType,
                 send_buffer( i, n ) =
                     slice_data[slice_offset + n * SliceType::vector_length];
         };
-        Kokkos::RangePolicy<execution_space> gather_send_buffer_policy(
-            0, _halo.totalNumExport() );
         Kokkos::parallel_for( "Cabana::gather::gather_send_buffer",
-                              gather_send_buffer_policy,
-                              gather_send_buffer_func );
+                              _send_policy, gather_send_buffer_func );
         Kokkos::fence();
 
         // The halo has it's own communication space so choose any mpi tag.
@@ -553,11 +546,8 @@ class Gather<HaloType, SliceType,
                 slice_data[slice_offset + SliceType::vector_length * n] =
                     recv_buffer( i, n );
         };
-        Kokkos::RangePolicy<execution_space> extract_recv_buffer_policy(
-            0, _halo.totalNumImport() );
         Kokkos::parallel_for( "Cabana::gather::extract_recv_buffer",
-                              extract_recv_buffer_policy,
-                              extract_recv_buffer_func );
+                              _recv_policy, extract_recv_buffer_func );
         Kokkos::fence();
 
         // Barrier before completing to ensure synchronization.
@@ -597,6 +587,8 @@ class Gather<HaloType, SliceType,
 
   private:
     plan_type _halo = base_type::_comm_plan;
+    using base_type::_recv_policy;
+    using base_type::_send_policy;
 };
 
 //---------------------------------------------------------------------------//
@@ -737,11 +729,8 @@ class Scatter
                 send_buffer( i, n ) =
                     slice_data( slice_offset + SliceType::vector_length * n );
         };
-        Kokkos::RangePolicy<execution_space> extract_send_buffer_policy(
-            0, _halo.totalNumImport() );
         Kokkos::parallel_for( "Cabana::scatter::extract_send_buffer",
-                              extract_send_buffer_policy,
-                              extract_send_buffer_func );
+                              _send_policy, extract_send_buffer_func );
         Kokkos::fence();
 
         // The halo has it's own communication space so choose any mpi tag.
@@ -803,11 +792,8 @@ class Scatter
                     &slice_data( slice_offset + SliceType::vector_length * n ),
                     recv_buffer( i, n ) );
         };
-        Kokkos::RangePolicy<execution_space> scatter_recv_buffer_policy(
-            0, _halo.totalNumExport() );
         Kokkos::parallel_for( "Cabana::scatter::scatter_recv_buffer",
-                              scatter_recv_buffer_policy,
-                              scatter_recv_buffer_func );
+                              _recv_policy, scatter_recv_buffer_func );
         Kokkos::fence();
 
         // Barrier before completing to ensure synchronization.
@@ -848,6 +834,8 @@ class Scatter
 
   private:
     plan_type _halo = base_type::_comm_plan;
+    using base_type::_recv_policy;
+    using base_type::_send_policy;
 };
 
 /*!

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -368,34 +368,34 @@ class Gather<HaloType, AoSoAType,
     }
 
     /*!
-      \brief Udpate the halo and AoSoA data for gather.
+      \brief Reserve new buffers as needed and update the halo and AoSoA data.
 
       \param halo The Halo to be used for the gather.
       \param aosoa The AoSoA on which to perform the gather.
     */
-    void update( const HaloType& halo, AoSoAType& aosoa )
+    void reserve( const HaloType& halo, AoSoAType& aosoa )
     {
         if ( !haloCheckValidSize( halo, aosoa ) )
             throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
-        this->updateImpl( halo, aosoa, totalSend(), totalReceive() );
+        this->reserveImpl( halo, aosoa, totalSend(), totalReceive() );
     }
     /*!
-      \brief Udpate the halo and AoSoA data for gather.
+      \brief Reserve new buffers as needed and update the halo and AoSoA data.
 
       \param halo The Halo to be used for the gather.
       \param aosoa The AoSoA on which to perform the gather.
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const HaloType& halo, AoSoAType& aosoa,
-                 const double overallocation )
+    void reserve( const HaloType& halo, AoSoAType& aosoa,
+                  const double overallocation )
     {
         if ( !haloCheckValidSize( halo, aosoa ) )
             throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
-        this->updateImpl( halo, aosoa, totalSend(), totalReceive(),
-                          overallocation );
+        this->reserveImpl( halo, aosoa, totalSend(), totalReceive(),
+                           overallocation );
     }
 
   private:
@@ -565,34 +565,34 @@ class Gather<HaloType, SliceType,
     }
 
     /*!
-      \brief Udpate the halo and slice data for gather.
+      \brief Reserve new buffers as needed and update the halo and slice data.
 
       \param halo The Halo to be used for the gather.
       \param slice The slice on which to perform the gather.
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const HaloType& halo, const SliceType& slice,
-                 const double overallocation )
+    void reserve( const HaloType& halo, const SliceType& slice,
+                  const double overallocation )
     {
         if ( !haloCheckValidSize( halo, slice ) )
             throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
-        this->updateImpl( halo, slice, totalSend(), totalReceive(),
-                          overallocation );
+        this->reserveImpl( halo, slice, totalSend(), totalReceive(),
+                           overallocation );
     }
     /*!
-      \brief Udpate the halo and slice data for gather.
+      \brief Reserve new buffers as needed and update the halo and slice data.
 
       \param halo The Halo to be used for the gather.
       \param slice The slice on which to perform the gather.
     */
-    void update( const HaloType& halo, const SliceType& slice )
+    void reserve( const HaloType& halo, const SliceType& slice )
     {
         if ( !haloCheckValidSize( halo, slice ) )
             throw std::runtime_error( "AoSoA is the wrong size for gather!" );
 
-        this->updateImpl( halo, slice, totalSend(), totalReceive() );
+        this->reserveImpl( halo, slice, totalSend(), totalReceive() );
     }
 
   private:
@@ -815,34 +815,35 @@ class Scatter
     }
 
     /*!
-      \brief Udpate the halo and slice data for scatter.
+      \brief Reserve new buffers as needed and update the halo and slice data.
+      Reallocation only occurs if there is not enough space in the buffers.
 
       \param halo The Halo to be used for the scatter.
       \param slice The slice on which to perform the scatter.
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const HaloType& halo, const SliceType& slice,
-                 const double overallocation )
+    void reserve( const HaloType& halo, const SliceType& slice,
+                  const double overallocation )
     {
         if ( !haloCheckValidSize( halo, slice ) )
             throw std::runtime_error( "AoSoA is the wrong size for scatter!" );
 
-        this->updateImpl( halo, slice, totalSend(), totalReceive(),
-                          overallocation );
+        this->reserveImpl( halo, slice, totalSend(), totalReceive(),
+                           overallocation );
     }
     /*!
-      \brief Udpate the halo and slice data for scatter.
+      \brief Reserve new buffers as needed and update the halo and slice data.
 
       \param halo The Halo to be used for the scatter.
       \param slice The slice on which to perform the scatter.
     */
-    void update( const HaloType& halo, const SliceType& slice )
+    void reserve( const HaloType& halo, const SliceType& slice )
     {
         if ( !haloCheckValidSize( halo, slice ) )
             throw std::runtime_error( "AoSoA is the wrong size for scatter!" );
 
-        this->updateImpl( halo, slice, totalSend(), totalReceive() );
+        this->reserveImpl( halo, slice, totalSend(), totalReceive() );
     }
 
   private:

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -471,7 +471,7 @@ class Gather<HaloType, SliceType,
         auto slice = this->getParticles();
 
         // Get the number of components in the slice.
-        std::size_t num_comp = this->getSliceComponents( slice );
+        std::size_t num_comp = this->getSliceComponents();
 
         // Get the raw slice data.
         auto slice_data = slice.data();
@@ -717,7 +717,7 @@ class Scatter
         auto slice = this->getParticles();
 
         // Get the number of components in the slice.
-        std::size_t num_comp = this->getSliceComponents( slice );
+        std::size_t num_comp = this->getSliceComponents();
 
         // Get the raw slice data. Wrap in a 1D Kokkos View so we can unroll the
         // components of each slice element.


### PR DESCRIPTION
Add new `Gather`/`Scatter` objects to hold reusable communication buffers rather than reallocating for every gather/scatter. Main operation is now `apply` (previously `gather`/`scatter`, still available as wrappers that still allocate every time). Also includes `reserve`, `sendSize`/`receiveSize`, `sendCapacity`/`receiveCapacity`, and `shrinkToFit` to query and control buffer sizes

Final version:
Before:
```
Cabana::gather( halo, particles );
```

After:
```
auto gather = createGather( halo, particles );
gather.apply();
```

----
Evan's original description below:


This draft PR demonstrates an interface to allocate and utilize static MPI comms buffers for the `gather`/`scatter` routines in `Cabana_Halo.hpp`, as opposed to reallocating a new buffer with each call. The interface contains functions that can be used to query the necessary buffer size given the current comms situation, allocate buffers (including support for a multiplicative "overallocation" factor), and check if the current buffer is big enough (which may be an overcomplete set of functions).

The interface is backwards compatible in a way that preserves existing behavior: the existing `gather`/`scatter` routines not utilize the new routines "under the hood," dynamically allocating and freeing buffers with each call.

This PR is not merge ready, but it is functional. I am opening this draft PR as an opportunity to share the code and have a discussion on how to evolve it from here. Indeed, some parts of it are redundant (checks, patterns in the `gather`/`scatter`, routines that take buffers, etc), and I ran out of stream with documentation in later routines, all of which needs to be addressed.

A representative before/after, demonstrating a `gather` of atom coordinates:

Before:
```
Cabana::gather( *halo_all[phase], x );
```

After:
```
if (!gather_check_send_buffer(*halo_all[phase], x_send_buffer))
  x_send_buffer = Cabana::gather_preallocate_send_buffer(*halo_all[phase], x, 1.1);
if (!gather_check_recv_buffer(*halo_all[phase], x_recv_buffer))
  x_recv_buffer = Cabana::gather_preallocate_recv_buffer(*halo_all[phase], x, 1.1);

Cabana::gather( *halo_all[phase], x, x_send_buffer, x_recv_buffer);
```

In the "before" case, exactly sized send and receive buffers are allocated within `gather` each time it's called. On the other hand, in the later case, we carry around a static send (`x_send_buffer`) and receive (`x_recv_buffer`) buffer, and follow a standard pattern:
* Check and see if the existing buffer is large enough (`gather_check_[send/recv]_buffer`); if not allocate a new one (`gather_preallocate_[send/recv]_buffer`) with an optional overallocation factor, here `1.1`, to avoid frequent re-allocations.
* Call a new variation of `gather` which takes in these send and receive buffers.

This pattern can be applied directly to the atom migration routines as well, I just hadn't gotten there yet. Since `gather`, `scatter`, and particle migration can all follow the same pattern of buffer check/reallocate if necessary/perform exchange, there's some scope to unify how buffer (re-)allocation is done.