### PR TITLE
Add particle list with field tags

### DIFF
--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADERS_PUBLIC
   Cajita_MpiTraits.hpp
   Cajita_Parallel.hpp
   Cajita_ParticleGridDistributor.hpp
+  Cajita_ParticleList.hpp
   Cajita_Partitioner.hpp
   Cajita_ReferenceStructuredSolver.hpp
   Cajita_SparseArray.hpp

--- a/cajita/src/Cajita.hpp
+++ b/cajita/src/Cajita.hpp
@@ -32,6 +32,7 @@
 #include <Cajita_MpiTraits.hpp>
 #include <Cajita_Parallel.hpp>
 #include <Cajita_ParticleGridDistributor.hpp>
+#include <Cajita_ParticleList.hpp>
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_ReferenceStructuredSolver.hpp>
 #ifndef KOKKOS_ENABLE_SYCL // FIXME_SYCL

--- a/cajita/src/Cajita_ParticleList.hpp
+++ b/cajita/src/Cajita_ParticleList.hpp
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+/*!
+  \file Cajita_ParticleList.hpp
+  \brief Application-level particle/mesh storage and single particle access.
+*/
+#ifndef CAJITA_PARTICLELIST_HPP
+#define CAJITA_PARTICLELIST_HPP
+
+#include <Cabana_AoSoA.hpp>
+#include <Cabana_MemberTypes.hpp>
+#include <Cabana_ParticleList.hpp>
+#include <Cabana_SoA.hpp>
+#include <Cabana_Tuple.hpp>
+
+#include <Cajita_ParticleGridDistributor.hpp>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+namespace Cajita
+{
+
+//---------------------------------------------------------------------------//
+// Particle List
+//---------------------------------------------------------------------------//
+template <class MeshType, class... FieldTags>
+class MeshParticleList
+    : public Cabana::ParticleList<typename MeshType::memory_space, FieldTags...>
+{
+  public:
+    using memory_space = typename MeshType::memory_space;
+    using base = Cabana::ParticleList<memory_space, FieldTags...>;
+    using mesh_type = MeshType;
+
+    using traits = typename base::traits;
+    using aosoa_type = typename base::aosoa_type;
+    using tuple_type = typename base::tuple_type;
+
+    template <std::size_t M>
+    using slice_type = typename aosoa_type::template member_slice_type<M>;
+
+    using particle_type = typename base::particle_type;
+
+    using particle_view_type = typename base::particle_view_type;
+
+    //! Default constructor.
+    MeshParticleList( const std::string& label,
+                      const std::shared_ptr<MeshType>& mesh )
+        : base( label )
+        , _mesh( mesh )
+    {
+    }
+    // Get the mesh.
+    const MeshType& mesh() { return *_mesh; }
+
+    // Redistribute particles to new owning grids. Return true if the particles
+    // were actually redistributed.
+    bool redistribute( const bool force_redistribute = false )
+    {
+        return particleGridMigrate(
+            *( _mesh->localGrid() ),
+            this->slice( Cabana::Field::Position<mesh_type::num_space_dim>() ),
+            _aosoa, _mesh->minimumHaloWidth(), force_redistribute );
+    }
+
+  private:
+    using base::_aosoa;
+    using base::_label;
+
+    std::shared_ptr<MeshType> _mesh;
+};
+
+//---------------------------------------------------------------------------//
+// Creation function.
+template <class Mesh, class... FieldTags>
+std::shared_ptr<MeshParticleList<Mesh, FieldTags...>>
+createMeshParticleList( const std::string& label,
+                        const std::shared_ptr<Mesh>& mesh,
+                        Cabana::ParticleTraits<FieldTags...> )
+{
+    return std::make_shared<MeshParticleList<Mesh, FieldTags...>>( label,
+                                                                   mesh );
+}
+
+//---------------------------------------------------------------------------//
+
+} // namespace Cajita
+
+#endif // end CAJITA_PARTICLELIST_HPP

--- a/cajita/src/Cajita_ParticleList.hpp
+++ b/cajita/src/Cajita_ParticleList.hpp
@@ -32,26 +32,34 @@ namespace Cajita
 {
 
 //---------------------------------------------------------------------------//
-// Particle List
-//---------------------------------------------------------------------------//
+//! List of particle fields stored in AoSoA with associated Cajita mesh.
 template <class MeshType, class... FieldTags>
 class MeshParticleList
     : public Cabana::ParticleList<typename MeshType::memory_space, FieldTags...>
 {
   public:
+    //! Kokkos memory space.
     using memory_space = typename MeshType::memory_space;
+    //! Base Cabana particle list type.
     using base = Cabana::ParticleList<memory_space, FieldTags...>;
+    //! Cajita mesh type.
     using mesh_type = MeshType;
 
+    //! Particle AoSoA member types.
     using traits = typename base::traits;
+    //! AoSoA type.
     using aosoa_type = typename base::aosoa_type;
+    //! Particle tuple type.
     using tuple_type = typename base::tuple_type;
-
+    /*!
+      \brief Single field slice type.
+      \tparam M AoSoA field index.
+    */
     template <std::size_t M>
     using slice_type = typename aosoa_type::template member_slice_type<M>;
-
+    //! Single particle type.
     using particle_type = typename base::particle_type;
-
+    //! Single SoA type.
     using particle_view_type = typename base::particle_view_type;
 
     //! Default constructor.
@@ -61,11 +69,15 @@ class MeshParticleList
         , _mesh( mesh )
     {
     }
-    // Get the mesh.
+
+    //! Get the mesh.
     const MeshType& mesh() { return *_mesh; }
 
-    // Redistribute particles to new owning grids. Return true if the particles
-    // were actually redistributed.
+    /*!
+      \brief Redistribute particles to new owning grids.
+
+      Return true if the particles were actually redistributed.
+    */
     bool redistribute( const bool force_redistribute = false )
     {
         return particleGridMigrate(
@@ -82,7 +94,7 @@ class MeshParticleList
 };
 
 //---------------------------------------------------------------------------//
-// Creation function.
+//! MeshParticleList creation function.
 template <class Mesh, class... FieldTags>
 std::shared_ptr<MeshParticleList<Mesh, FieldTags...>>
 createMeshParticleList( const std::string& label,

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HEADERS_PUBLIC
   Cabana_AoSoA.hpp
   Cabana_Core.hpp
   Cabana_DeepCopy.hpp
+  Cabana_Fields.hpp
   Cabana_ExecutionPolicy.hpp
   Cabana_LinkedCellList.hpp
   Cabana_MemberTypes.hpp
@@ -22,6 +23,7 @@ set(HEADERS_PUBLIC
   Cabana_Parallel.hpp
   Cabana_ParameterPack.hpp
   Cabana_ParticleInit.hpp
+  Cabana_ParticleList.hpp
   Cabana_Slice.hpp
   Cabana_SoA.hpp
   Cabana_Sort.hpp

--- a/core/src/Cabana_Core.hpp
+++ b/core/src/Cabana_Core.hpp
@@ -20,12 +20,14 @@
 
 #include <Cabana_AoSoA.hpp>
 #include <Cabana_DeepCopy.hpp>
+#include <Cabana_Fields.hpp>
 #include <Cabana_LinkedCellList.hpp>
 #include <Cabana_MemberTypes.hpp>
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_Parallel.hpp>
 #include <Cabana_ParameterPack.hpp>
 #include <Cabana_ParticleInit.hpp>
+#include <Cabana_ParticleList.hpp>
 #include <Cabana_Slice.hpp>
 #include <Cabana_SoA.hpp>
 #include <Cabana_Sort.hpp>

--- a/core/src/Cabana_Fields.hpp
+++ b/core/src/Cabana_Fields.hpp
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CABANA_FIELDS_HPP
+#define CABANA_FIELDS_HPP
+
+namespace Cabana
+{
+namespace Field
+{
+//---------------------------------------------------------------------------//
+// General field types.
+//---------------------------------------------------------------------------//
+// Forward declarations.
+template <class T>
+struct Scalar;
+
+template <class T, int D>
+struct Vector;
+
+template <class T, int D0, int D1>
+struct Matrix;
+
+template <class T>
+struct Scalar
+{
+    using value_type = T;
+    static constexpr int rank = 0;
+    static constexpr int size = 1;
+    using data_type = value_type;
+};
+
+template <class T, int D>
+struct Vector
+{
+    using value_type = T;
+    static constexpr int rank = 1;
+    static constexpr int size = D;
+    static constexpr int dim0 = D;
+    using data_type = value_type[D];
+};
+
+template <class T, int D0, int D1>
+struct Matrix
+{
+    using value_type = T;
+    static constexpr int rank = 2;
+    static constexpr int size = D0 * D1;
+    static constexpr int dim0 = D0;
+    static constexpr int dim1 = D1;
+    using data_type = value_type[D0][D1];
+};
+
+//---------------------------------------------------------------------------//
+// Common field types.
+//---------------------------------------------------------------------------//
+template <std::size_t NumSpaceDim>
+struct Position : Vector<double, NumSpaceDim>
+{
+    static std::string label() { return "position"; }
+};
+
+} // namespace Field
+
+//---------------------------------------------------------------------------//
+// General type indexer.
+//---------------------------------------------------------------------------//
+template <class T, int Size, int N, class Type, class... Types>
+struct TypeIndexerImpl
+{
+    static constexpr std::size_t value =
+        TypeIndexerImpl<T, Size, N - 1, Types...>::value *
+        ( std::is_same<T, Type>::value ? Size - 1 - N : 1 );
+};
+
+template <class T, int Size, class Type, class... Types>
+struct TypeIndexerImpl<T, Size, 0, Type, Types...>
+{
+    static constexpr std::size_t value =
+        std::is_same<T, Type>::value ? Size - 1 : 1;
+};
+
+template <class T, class... Types>
+struct TypeIndexer
+{
+    static constexpr std::size_t index =
+        TypeIndexerImpl<T, sizeof...( Types ), sizeof...( Types ) - 1,
+                        Types...>::value;
+};
+
+} // namespace Cabana
+#endif

--- a/core/src/Cabana_Fields.hpp
+++ b/core/src/Cabana_Fields.hpp
@@ -9,6 +9,10 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+/*!
+  \file Cabana_Fields.hpp
+  \brief Particle field types and common field examples.
+*/
 #ifndef CABANA_FIELDS_HPP
 #define CABANA_FIELDS_HPP
 
@@ -20,6 +24,7 @@ namespace Field
 // General field types.
 //---------------------------------------------------------------------------//
 // Forward declarations.
+//! \cond Impl
 template <class T>
 struct Scalar;
 
@@ -28,43 +33,64 @@ struct Vector;
 
 template <class T, int D0, int D1>
 struct Matrix;
+//! \endcond
 
+//! Scalar particle field type.
 template <class T>
 struct Scalar
 {
+    //! Field type.
     using value_type = T;
+    //! Field rank.
     static constexpr int rank = 0;
+    //! Field total size.
     static constexpr int size = 1;
+    //! Scalar type.
     using data_type = value_type;
 };
 
+//! Vector (1D) particle field type.
 template <class T, int D>
 struct Vector
 {
+    //! Field type.
     using value_type = T;
+    //! Field rank.
     static constexpr int rank = 1;
+    //! Field total size.
     static constexpr int size = D;
+    //! Field first dimension size.
     static constexpr int dim0 = D;
+    //! Scalar type.
     using data_type = value_type[D];
 };
 
+//! Matrix (2D) particle field type.
 template <class T, int D0, int D1>
 struct Matrix
 {
+    //! Field type.
     using value_type = T;
+    //! Field rank.
     static constexpr int rank = 2;
+    //! Field total size.
     static constexpr int size = D0 * D1;
+    //! Field first dimension size.
     static constexpr int dim0 = D0;
+    //! Field second dimension size.
     static constexpr int dim1 = D1;
+    //! Scalar type.
     using data_type = value_type[D0][D1];
 };
 
 //---------------------------------------------------------------------------//
 // Common field types.
 //---------------------------------------------------------------------------//
+//! Particle position field type.
 template <std::size_t NumSpaceDim>
 struct Position : Vector<double, NumSpaceDim>
 {
+    //! Field label.
     static std::string label() { return "position"; }
 };
 
@@ -73,6 +99,7 @@ struct Position : Vector<double, NumSpaceDim>
 //---------------------------------------------------------------------------//
 // General type indexer.
 //---------------------------------------------------------------------------//
+//! \cond Impl
 template <class T, int Size, int N, class Type, class... Types>
 struct TypeIndexerImpl
 {
@@ -87,10 +114,13 @@ struct TypeIndexerImpl<T, Size, 0, Type, Types...>
     static constexpr std::size_t value =
         std::is_same<T, Type>::value ? Size - 1 : 1;
 };
+//! \endcond
 
+//! Get the index of a field type within a particle type list.
 template <class T, class... Types>
 struct TypeIndexer
 {
+    //! Field index.
     static constexpr std::size_t index =
         TypeIndexerImpl<T, sizeof...( Types ), sizeof...( Types ) - 1,
                         Types...>::value;

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -9,6 +9,10 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
+/*!
+  \file Cabana_ParticleList.hpp
+  \brief Application-level particle storage and single particle access.
+*/
 #ifndef CABANA_PARTICLELIST_HPP
 #define CABANA_PARTICLELIST_HPP
 
@@ -25,61 +29,64 @@
 namespace Cabana
 {
 //---------------------------------------------------------------------------//
-// Particle Traits
-//---------------------------------------------------------------------------//
+//! Extract AoSoA particle fields for ParticleList.
 template <class... FieldTags>
 struct ParticleTraits
 {
+    //! AoSoA particle fields.
     using member_types = Cabana::MemberTypes<typename FieldTags::data_type...>;
 };
 
 //---------------------------------------------------------------------------//
-// Particle copy. Wraps a tuple copy of a particle.
-//---------------------------------------------------------------------------//
+//! Single particle copy. Wraps a tuple copy of a particle.
 template <class... FieldTags>
 struct Particle
 {
+    //! Particle AoSoA member types.
     using traits = ParticleTraits<FieldTags...>;
+    //! Particle tuple type.
     using tuple_type = Cabana::Tuple<typename traits::member_types>;
-
+    //! Vector length (for compatibility with ParticleView).
     static constexpr int vector_length = 1;
 
-    // Default constructor.
+    //! Default constructor.
     Particle() = default;
 
-    // Tuple wrapper constructor.
+    //! Tuple wrapper constructor.
     KOKKOS_FORCEINLINE_FUNCTION
     Particle( const tuple_type& tuple )
         : _tuple( tuple )
     {
     }
 
-    // Get the underlying tuple.
+    //! Get the underlying tuple.
     KOKKOS_FORCEINLINE_FUNCTION
     tuple_type& tuple() { return _tuple; }
 
+    //! Get the underlying tuple (const).
     KOKKOS_FORCEINLINE_FUNCTION
     const tuple_type& tuple() const { return _tuple; }
 
-    // The tuple this particle wraps.
+    //! The tuple this particle wraps.
     tuple_type _tuple;
 };
 
 //---------------------------------------------------------------------------//
-// Particle view. Wraps a view of the SoA the particle resides in.
-//---------------------------------------------------------------------------//
+//! Single SoA particle view. Wraps a view of the SoA the particle resides in.
 template <int VectorLength, class... FieldTags>
 struct ParticleView
 {
+    //! Particle AoSoA member types.
     using traits = ParticleTraits<FieldTags...>;
+    //! Particle SoA type.
     using soa_type = Cabana::SoA<typename traits::member_types, VectorLength>;
-
+    //! AoSoA vector length
     static constexpr int vector_length = VectorLength;
 
-    // Default constructor.
+    //! Default constructor.
     ParticleView() = default;
 
-    // Tuple wrapper constructor.
+    //! Tuple wrapper constructor.
     KOKKOS_FORCEINLINE_FUNCTION
     ParticleView( soa_type& soa, const int vector_index )
         : _soa( soa )
@@ -87,21 +94,22 @@ struct ParticleView
     {
     }
 
-    // Get the underlying SoA.
+    //! Get the underlying SoA.
     KOKKOS_FORCEINLINE_FUNCTION
     soa_type& soa() { return _soa; }
 
+    //! Get the underlying SoA (const).
     KOKKOS_FORCEINLINE_FUNCTION
     const soa_type& soa() const { return _soa; }
 
-    // Get the vector index of the particle in the SoA.
+    //! Get the vector index of the particle in the SoA.
     KOKKOS_FORCEINLINE_FUNCTION
     int vectorIndex() const { return _vector_index; }
 
-    // The soa the particle is in.
+    //! The soa the particle is in.
     soa_type& _soa;
 
-    // The local vector index of the particle.
+    //! The local vector index of the particle.
     int _vector_index;
 };
 
@@ -165,47 +173,51 @@ get( ParticleView<VectorLength, FieldTags...>& particle, FieldTag,
 }
 
 //---------------------------------------------------------------------------//
-// Particle List
-//---------------------------------------------------------------------------//
+//! List of particle fields stored in AoSoA.
 template <class MemorySpace, class... FieldTags>
 class ParticleList
 {
   public:
+    //! Kokkos memory space.
     using memory_space = MemorySpace;
-
+    //! Particle AoSoA member types.
     using traits = ParticleTraits<FieldTags...>;
-
+    //! AoSoA type.
     using aosoa_type =
         Cabana::AoSoA<typename traits::member_types, memory_space>;
-
+    //! Particle tuple type.
     using tuple_type = typename aosoa_type::tuple_type;
-
+    /*!
+      \brief Single field slice type.
+      \tparam M AoSoA field index.
+    */
     template <std::size_t M>
     using slice_type = typename aosoa_type::template member_slice_type<M>;
-
+    //! Single particle type.
     using particle_type = Particle<FieldTags...>;
-
+    //! Single SoA type.
     using particle_view_type =
         ParticleView<aosoa_type::vector_length, FieldTags...>;
 
-    // Default constructor.
+    //! Default constructor.
     ParticleList( const std::string& label )
         : _aosoa( label )
         , _label( label )
     {
     }
 
-    // Get the number of particles in the list.
+    //! Get the number of particles in the list.
     std::size_t size() const { return _aosoa.size(); }
 
-    // Get the AoSoA
+    //! Get the AoSoA.
     aosoa_type& aosoa() { return _aosoa; }
+    //! Get the AoSoA (const).
     const aosoa_type& aosoa() const { return _aosoa; }
 
     //! Get the label.
     const std::string& label() const { return _label; }
 
-    // Get a slice of a given field.
+    //! Get a slice of a given field.
     template <class FieldTag>
     slice_type<TypeIndexer<FieldTag, FieldTags...>::index>
     slice( FieldTag ) const
@@ -220,7 +232,7 @@ class ParticleList
 };
 
 //---------------------------------------------------------------------------//
-// Creation function.
+//! ParticleList creation function.
 template <class MemorySpace, class... FieldTags>
 std::shared_ptr<ParticleList<MemorySpace, FieldTags...>>
 createParticleList( const std::string& label, ParticleTraits<FieldTags...> )

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -1,0 +1,235 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CABANA_PARTICLELIST_HPP
+#define CABANA_PARTICLELIST_HPP
+
+#include <Cabana_AoSoA.hpp>
+#include <Cabana_Fields.hpp>
+#include <Cabana_MemberTypes.hpp>
+#include <Cabana_SoA.hpp>
+#include <Cabana_Tuple.hpp>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+namespace Cabana
+{
+//---------------------------------------------------------------------------//
+// Particle Traits
+//---------------------------------------------------------------------------//
+template <class... FieldTags>
+struct ParticleTraits
+{
+    using member_types = Cabana::MemberTypes<typename FieldTags::data_type...>;
+};
+
+//---------------------------------------------------------------------------//
+// Particle copy. Wraps a tuple copy of a particle.
+//---------------------------------------------------------------------------//
+template <class... FieldTags>
+struct Particle
+{
+    using traits = ParticleTraits<FieldTags...>;
+    using tuple_type = Cabana::Tuple<typename traits::member_types>;
+
+    static constexpr int vector_length = 1;
+
+    // Default constructor.
+    Particle() = default;
+
+    // Tuple wrapper constructor.
+    KOKKOS_FORCEINLINE_FUNCTION
+    Particle( const tuple_type& tuple )
+        : _tuple( tuple )
+    {
+    }
+
+    // Get the underlying tuple.
+    KOKKOS_FORCEINLINE_FUNCTION
+    tuple_type& tuple() { return _tuple; }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    const tuple_type& tuple() const { return _tuple; }
+
+    // The tuple this particle wraps.
+    tuple_type _tuple;
+};
+
+//---------------------------------------------------------------------------//
+// Particle view. Wraps a view of the SoA the particle resides in.
+//---------------------------------------------------------------------------//
+template <int VectorLength, class... FieldTags>
+struct ParticleView
+{
+    using traits = ParticleTraits<FieldTags...>;
+    using soa_type = Cabana::SoA<typename traits::member_types, VectorLength>;
+
+    static constexpr int vector_length = VectorLength;
+
+    // Default constructor.
+    ParticleView() = default;
+
+    // Tuple wrapper constructor.
+    KOKKOS_FORCEINLINE_FUNCTION
+    ParticleView( soa_type& soa, const int vector_index )
+        : _soa( soa )
+        , _vector_index( vector_index )
+    {
+    }
+
+    // Get the underlying SoA.
+    KOKKOS_FORCEINLINE_FUNCTION
+    soa_type& soa() { return _soa; }
+
+    KOKKOS_FORCEINLINE_FUNCTION
+    const soa_type& soa() const { return _soa; }
+
+    // Get the vector index of the particle in the SoA.
+    KOKKOS_FORCEINLINE_FUNCTION
+    int vectorIndex() const { return _vector_index; }
+
+    // The soa the particle is in.
+    soa_type& _soa;
+
+    // The local vector index of the particle.
+    int _vector_index;
+};
+
+//---------------------------------------------------------------------------//
+// Particle accessors.
+//---------------------------------------------------------------------------//
+//! Return a single element of a single field from indices.
+template <class FieldTag, class... FieldTags, class... IndexTypes>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    sizeof...( IndexTypes ) == FieldTag::rank,
+    typename Particle<FieldTags...>::tuple_type::
+        template member_const_reference_type<
+            TypeIndexer<FieldTag, FieldTags...>::index>>::type
+get( const Particle<FieldTags...>& particle, FieldTag, IndexTypes... indices )
+{
+    return Cabana::get<TypeIndexer<FieldTag, FieldTags...>::index>(
+        particle.tuple(), indices... );
+}
+
+//! Return a single element of a single field from indices.
+template <class FieldTag, class... FieldTags, class... IndexTypes>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    sizeof...( IndexTypes ) == FieldTag::rank,
+    typename Particle<FieldTags...>::tuple_type::template member_reference_type<
+        TypeIndexer<FieldTag, FieldTags...>::index>>::type
+get( Particle<FieldTags...>& particle, FieldTag, IndexTypes... indices )
+{
+    return Cabana::get<TypeIndexer<FieldTag, FieldTags...>::index>(
+        particle.tuple(), indices... );
+}
+
+//---------------------------------------------------------------------------//
+//! Return a single element of a single field from indices.
+template <class FieldTag, class... FieldTags, class... IndexTypes,
+          int VectorLength>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    sizeof...( IndexTypes ) == FieldTag::rank,
+    typename ParticleView<VectorLength, FieldTags...>::soa_type::
+        template member_const_reference_type<
+            TypeIndexer<FieldTag, FieldTags...>::index>>::type
+get( const ParticleView<VectorLength, FieldTags...>& particle, FieldTag,
+     IndexTypes... indices )
+{
+    return Cabana::get<TypeIndexer<FieldTag, FieldTags...>::index>(
+        particle.soa(), particle.vectorIndex(), indices... );
+}
+
+//! Return a single element of a single field from indices.
+template <class FieldTag, class... FieldTags, class... IndexTypes,
+          int VectorLength>
+KOKKOS_FORCEINLINE_FUNCTION typename std::enable_if<
+    sizeof...( IndexTypes ) == FieldTag::rank,
+    typename ParticleView<VectorLength, FieldTags...>::soa_type::
+        template member_reference_type<
+            TypeIndexer<FieldTag, FieldTags...>::index>>::type
+get( ParticleView<VectorLength, FieldTags...>& particle, FieldTag,
+     IndexTypes... indices )
+{
+    return Cabana::get<TypeIndexer<FieldTag, FieldTags...>::index>(
+        particle.soa(), particle.vectorIndex(), indices... );
+}
+
+//---------------------------------------------------------------------------//
+// Particle List
+//---------------------------------------------------------------------------//
+template <class MemorySpace, class... FieldTags>
+class ParticleList
+{
+  public:
+    using memory_space = MemorySpace;
+
+    using traits = ParticleTraits<FieldTags...>;
+
+    using aosoa_type =
+        Cabana::AoSoA<typename traits::member_types, memory_space>;
+
+    using tuple_type = typename aosoa_type::tuple_type;
+
+    template <std::size_t M>
+    using slice_type = typename aosoa_type::template member_slice_type<M>;
+
+    using particle_type = Particle<FieldTags...>;
+
+    using particle_view_type =
+        ParticleView<aosoa_type::vector_length, FieldTags...>;
+
+    // Default constructor.
+    ParticleList( const std::string& label )
+        : _aosoa( label )
+        , _label( label )
+    {
+    }
+
+    // Get the number of particles in the list.
+    std::size_t size() const { return _aosoa.size(); }
+
+    // Get the AoSoA
+    aosoa_type& aosoa() { return _aosoa; }
+    const aosoa_type& aosoa() const { return _aosoa; }
+
+    //! Get the label.
+    const std::string& label() const { return _label; }
+
+    // Get a slice of a given field.
+    template <class FieldTag>
+    slice_type<TypeIndexer<FieldTag, FieldTags...>::index>
+    slice( FieldTag ) const
+    {
+        return Cabana::slice<TypeIndexer<FieldTag, FieldTags...>::index>(
+            _aosoa, FieldTag::label() );
+    }
+
+  private:
+    aosoa_type _aosoa;
+    std::string _label;
+};
+
+//---------------------------------------------------------------------------//
+// Creation function.
+template <class MemorySpace, class... FieldTags>
+std::shared_ptr<ParticleList<MemorySpace, FieldTags...>>
+createParticleList( const std::string& label, ParticleTraits<FieldTags...> )
+{
+    return std::make_shared<ParticleList<MemorySpace, FieldTags...>>( label );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cabana
+
+#endif // end CABANA_PARTICLELIST_HPP

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -214,6 +214,30 @@ class ParticleList
     //! Get the AoSoA (const).
     const aosoa_type& aosoa() const { return _aosoa; }
 
+    //! Get a single particle.
+    template <class IndexType>
+    KOKKOS_INLINE_FUNCTION auto getParticle( IndexType p ) const
+    {
+        return particle_type( _aosoa.getTuple( p ) );
+    }
+
+    //! Set a single particle.
+    template <class ParticleType, class IndexType>
+    KOKKOS_INLINE_FUNCTION void setParticle( ParticleType particle,
+                                             IndexType p ) const
+    {
+        _aosoa.setTuple( p, particle.tuple() );
+    }
+
+    //! Set a single particle with the struct+array indexing.
+    template <class IndexType>
+    KOKKOS_INLINE_FUNCTION auto getParticleView( IndexType p ) const
+    {
+        auto s = Cabana::Impl::Index<particle_view_type::vector_length>::s( p );
+        auto a = Cabana::Impl::Index<particle_view_type::vector_length>::a( p );
+        return particle_view_type( _aosoa.access( s ), a );
+    }
+
     //! Get the label.
     const std::string& label() const { return _label; }
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SERIAL_TESTS
   Parallel
   ParameterPack
   ParticleInit
+  ParticleList
   Slice
   Sort
   Tuple

--- a/core/unit_test/tstParticleList.hpp
+++ b/core/unit_test/tstParticleList.hpp
@@ -1,0 +1,232 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cabana_DeepCopy.hpp>
+#include <Cabana_Fields.hpp>
+#include <Cabana_ParticleList.hpp>
+
+#include <gtest/gtest.h>
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+// Fields.
+struct CommRank : Cabana::Field::Scalar<int>
+{
+    static std::string label() { return "comm_rank"; }
+};
+
+struct Foo : Cabana::Field::Scalar<double>
+{
+    static std::string label() { return "foo"; }
+};
+
+struct Bar : Cabana::Field::Matrix<double, 3, 3>
+{
+    static std::string label() { return "bar"; }
+};
+
+//---------------------------------------------------------------------------//
+void particleListTest()
+{
+    // Make a particle list.
+    using list_type =
+        Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
+                             CommRank, Bar>;
+    list_type plist( "test_particles" );
+
+    // Resize the aosoa.
+    auto& aosoa = plist.aosoa();
+    std::size_t num_p = 10;
+    aosoa.resize( num_p );
+    EXPECT_EQ( plist.aosoa().size(), 10 );
+
+    // Populate fields.
+    auto px = plist.slice( Cabana::Field::Position<3>() );
+    auto pm = plist.slice( Foo() );
+    auto pc = plist.slice( CommRank() );
+    auto pf = plist.slice( Bar() );
+
+    Cabana::deep_copy( px, 1.23 );
+    Cabana::deep_copy( pm, 3.3 );
+    Cabana::deep_copy( pc, 5 );
+    Cabana::deep_copy( pf, -1.2 );
+
+    // Check the slices.
+    EXPECT_EQ( px.label(), "position" );
+    EXPECT_EQ( pm.label(), "foo" );
+    EXPECT_EQ( pc.label(), "comm_rank" );
+    EXPECT_EQ( pf.label(), "bar" );
+
+    // Check deep copy.
+    auto aosoa_host =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto px_h = Cabana::slice<0>( aosoa_host );
+    auto pm_h = Cabana::slice<1>( aosoa_host );
+    auto pc_h = Cabana::slice<2>( aosoa_host );
+    auto pf_h = Cabana::slice<3>( aosoa_host );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
+
+        EXPECT_EQ( pc_h( p ), 5 );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
+    }
+
+    // Locally modify.
+    Kokkos::parallel_for(
+        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
+        KOKKOS_LAMBDA( const int p ) {
+            typename list_type::particle_type particle( aosoa.getTuple( p ) );
+
+            for ( int d = 0; d < 3; ++d )
+                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
+
+            get( particle, Foo() ) += p;
+
+            get( particle, CommRank() ) += p;
+
+            for ( int i = 0; i < 3; ++i )
+                for ( int j = 0; j < 3; ++j )
+                    get( particle, Bar(), i, j ) += p + i + j;
+
+            aosoa.setTuple( p, particle.tuple() );
+        } );
+
+    // Check the modification.
+    Cabana::deep_copy( aosoa_host, aosoa );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
+
+        EXPECT_EQ( pc_h( p ), 5 + p );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
+    }
+}
+
+//---------------------------------------------------------------------------//
+void particleViewTest()
+{
+    // Make a particle list.
+    using list_type =
+        Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
+                             CommRank, Bar>;
+
+    list_type plist( "test_particles" );
+
+    // Resize the aosoa.
+    auto& aosoa = plist.aosoa();
+    std::size_t num_p = 10;
+    aosoa.resize( num_p );
+    EXPECT_EQ( plist.aosoa().size(), 10 );
+
+    // Populate fields.
+    auto px = plist.slice( Cabana::Field::Position<3>() );
+    auto pm = plist.slice( Foo() );
+    auto pc = plist.slice( CommRank() );
+    auto pf = plist.slice( Bar() );
+
+    Cabana::deep_copy( px, 1.23 );
+    Cabana::deep_copy( pm, 3.3 );
+    Cabana::deep_copy( pc, 5 );
+    Cabana::deep_copy( pf, -1.2 );
+
+    // Check the slices.
+    EXPECT_EQ( px.label(), "position" );
+    EXPECT_EQ( pm.label(), "foo" );
+    EXPECT_EQ( pc.label(), "comm_rank" );
+    EXPECT_EQ( pf.label(), "bar" );
+
+    // Check deep copy.
+    auto aosoa_host =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto px_h = Cabana::slice<0>( aosoa_host );
+    auto pm_h = Cabana::slice<1>( aosoa_host );
+    auto pc_h = Cabana::slice<2>( aosoa_host );
+    auto pf_h = Cabana::slice<3>( aosoa_host );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
+
+        EXPECT_EQ( pc_h( p ), 5 );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
+    }
+
+    // Locally modify.
+    Kokkos::parallel_for(
+        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
+        KOKKOS_LAMBDA( const int p ) {
+            auto s = Cabana::Impl::Index<
+                list_type::particle_view_type::vector_length>::s( p );
+            auto a = Cabana::Impl::Index<
+                list_type::particle_view_type::vector_length>::a( p );
+            typename list_type::particle_view_type particle( aosoa.access( s ),
+                                                             a );
+
+            for ( int d = 0; d < 3; ++d )
+                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
+
+            get( particle, Foo() ) += p;
+
+            get( particle, CommRank() ) += p;
+
+            for ( int i = 0; i < 3; ++i )
+                for ( int j = 0; j < 3; ++j )
+                    get( particle, Bar(), i, j ) += p + i + j;
+        } );
+
+    // Check the modification.
+    Cabana::deep_copy( aosoa_host, aosoa );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
+
+        EXPECT_EQ( pc_h( p ), 5 + p );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
+    }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, particle_test ) { particleListTest(); }
+
+TEST( TEST_CATEGORY, particle_view_test ) { particleViewTest(); }
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/core/unit_test/tstParticleList.hpp
+++ b/core/unit_test/tstParticleList.hpp
@@ -93,7 +93,7 @@ void particleListTest()
     Kokkos::parallel_for(
         "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
         KOKKOS_LAMBDA( const int p ) {
-            typename list_type::particle_type particle( aosoa.getTuple( p ) );
+            auto particle = plist.getParticle( p );
 
             for ( int d = 0; d < 3; ++d )
                 get( particle, Cabana::Field::Position<3>(), d ) += p + d;
@@ -106,7 +106,7 @@ void particleListTest()
                 for ( int j = 0; j < 3; ++j )
                     get( particle, Bar(), i, j ) += p + i + j;
 
-            aosoa.setTuple( p, particle.tuple() );
+            plist.setParticle( particle, p );
         } );
 
     // Check the modification.
@@ -184,12 +184,7 @@ void particleViewTest()
     Kokkos::parallel_for(
         "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
         KOKKOS_LAMBDA( const int p ) {
-            auto s = Cabana::Impl::Index<
-                list_type::particle_view_type::vector_length>::s( p );
-            auto a = Cabana::Impl::Index<
-                list_type::particle_view_type::vector_length>::a( p );
-            typename list_type::particle_view_type particle( aosoa.access( s ),
-                                                             a );
+            auto particle = plist.getParticleView( p );
 
             for ( int d = 0; d < 3; ++d )
                 get( particle, Cabana::Field::Position<3>(), d ) += p + d;


### PR DESCRIPTION
Wraps the AoSoA with more user friendly type tags and enables a thread-level particle interface. Adapted from Picasso

Currently single AoSoA only, with a separate version in Cajita that stores the mesh as well.


Should add an example before merging