### PR TITLE
WIP: Add LinkedCellList parallel_for

### DIFF
--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -16,6 +16,7 @@
 #ifndef CABANA_LINKEDCELLLIST_HPP
 #define CABANA_LINKEDCELLLIST_HPP
 
+#include <Cabana_NeighborList.hpp>
 #include <Cabana_Slice.hpp>
 #include <Cabana_Sort.hpp>
 #include <impl/Cabana_CartesianGrid.hpp>
@@ -115,6 +116,10 @@ class LinkedCellList
         allocate( totalBins(), end - begin );
         build( positions, begin, end );
     }
+
+    //! Number of binned particles.
+    KOKKOS_INLINE_FUNCTION
+    int numParticles() const { return _permutes.extent( 0 ); }
 
     /*!
       \brief Get the total number of bins.
@@ -322,6 +327,30 @@ class LinkedCellList
         build( positions, 0, positions.size() );
     }
 
+    /*!
+      \brief Get the bin cell index for each binned particle.
+
+      \param begin The beginning index of the sorted range.
+
+      \param end The end index of the sorted range.
+    */
+    auto cells( const std::size_t begin, const std::size_t end ) const
+    {
+        CountView particle_cells( "particle_cells", end - begin );
+        Kokkos::parallel_for(
+            "Cabana::LinkedCellList::find_bin_index",
+            Kokkos::RangePolicy<execution_space>( 0, totalBins() ),
+            KOKKOS_LAMBDA( const int i ) {
+                int bin_ijk[3];
+                ijkBinIndex( i, bin_ijk[0], bin_ijk[1], bin_ijk[2] );
+                auto offset = binOffset( bin_ijk[0], bin_ijk[1], bin_ijk[2] );
+                auto size = binSize( bin_ijk[0], bin_ijk[1], bin_ijk[2] );
+                for ( size_t p = offset; p < offset + size; ++p )
+                    particle_cells( p ) = i;
+            } );
+        return particle_cells;
+    }
+
   private:
     BinningData<DeviceType> _bin_data;
     Impl::CartesianGrid<double> _grid;
@@ -410,6 +439,115 @@ void permute(
 }
 
 //---------------------------------------------------------------------------//
+//! Stencil of cells surrounding each cell.
+template <class Scalar>
+struct LinkedCellStencil
+{
+    //! Cutoff squared.
+    Scalar rsqr;
+    //! Background grid.
+    Impl::CartesianGrid<double> grid;
+    //! Maximum cells per dimension.
+    int max_cells_dir;
+    //! Maximum total cells.
+    int max_cells;
+    //! Range of cells to search based on cutoff.
+    int cell_range;
+
+    //! Constructor
+    LinkedCellStencil( const Scalar neighborhood_radius,
+                       const Scalar cell_size_ratio, const Scalar grid_min[3],
+                       const Scalar grid_max[3] )
+        : rsqr( neighborhood_radius * neighborhood_radius )
+    {
+        Scalar dx = neighborhood_radius * cell_size_ratio;
+        grid = Impl::CartesianGrid<double>(
+            grid_min[0], grid_min[1], grid_min[2], grid_max[0], grid_max[1],
+            grid_max[2], dx, dx, dx );
+        cell_range = std::ceil( 1 / cell_size_ratio );
+        max_cells_dir = 2 * cell_range + 1;
+        max_cells = max_cells_dir * max_cells_dir * max_cells_dir;
+    }
+
+    //! Given a cell, get the index bounds of the cell stencil.
+    KOKKOS_INLINE_FUNCTION
+    void getCells( const int cell, int& imin, int& imax, int& jmin, int& jmax,
+                   int& kmin, int& kmax ) const
+    {
+        int i, j, k;
+        grid.ijkBinIndex( cell, i, j, k );
+
+        kmin = ( k - cell_range > 0 ) ? k - cell_range : 0;
+        kmax =
+            ( k + cell_range + 1 < grid._nz ) ? k + cell_range + 1 : grid._nz;
+
+        jmin = ( j - cell_range > 0 ) ? j - cell_range : 0;
+        jmax =
+            ( j + cell_range + 1 < grid._ny ) ? j + cell_range + 1 : grid._ny;
+
+        imin = ( i - cell_range > 0 ) ? i - cell_range : 0;
+        imax =
+            ( i + cell_range + 1 < grid._nx ) ? i + cell_range + 1 : grid._nx;
+    }
+};
+
+//---------------------------------------------------------------------------//
+//! LinkedCellList NeighborList interface.
+template <class DeviceType>
+class NeighborList<LinkedCellList<DeviceType>>
+{
+  public:
+    //! Kokkos memory space.
+    using device_type = DeviceType;
+    //! Neighbor list type.
+    using list_type = LinkedCellList<DeviceType>;
+
+    //! Get the maximum number of neighbors per particle.
+    template <class CellIndexType, class StencilType>
+    KOKKOS_INLINE_FUNCTION static std::size_t
+    maxNeighbor( const list_type& list, const CellIndexType cell,
+                 const StencilType stencil )
+    {
+        int total_count = 0;
+        for ( int p = 0; p < list.numParticles(); ++p )
+            total_count += numNeighbor( list, cell, stencil, p );
+        return total_count;
+    }
+
+    //! Get the number of neighbors for a given particle index.
+    template <class CellIndexType, class StencilType>
+    KOKKOS_INLINE_FUNCTION static std::size_t
+    numNeighbor( const list_type& list, const CellIndexType cell,
+                 const StencilType stencil, const std::size_t particle_index )
+    {
+        int total_count = 0;
+        int imin, imax, jmin, jmax, kmin, kmax;
+        stencil.getCells( cell( particle_index ), imin, imax, jmin, jmax, kmin,
+                          kmax );
+
+        // Loop over the cell stencil.
+        for ( int i = imin; i < imax; ++i )
+            for ( int j = jmin; j < jmax; ++j )
+                for ( int k = kmin; k < kmax; ++k )
+                {
+                    total_count += list.binSize( i, j, k );
+                }
+        return total_count;
+    }
+
+    //! Get the id for a neighbor for a given particle index and the index of
+    //! the neighbor relative to the particle.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t getNeighbor( const list_type& list, const std::size_t,
+                                    const std::size_t neighbor_index,
+                                    const bool sorted = true )
+    {
+        if ( sorted )
+            return neighbor_index;
+        else
+            return list.permutation( neighbor_index );
+    }
+};
 
 } // end namespace Cabana
 

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -48,6 +48,61 @@ class HalfNeighborTag
 };
 
 //---------------------------------------------------------------------------//
+//! Neighborhood discriminator.
+template <class Tag>
+class NeighborDiscriminator;
+
+//! Full list discriminator specialization.
+template <>
+class NeighborDiscriminator<FullNeighborTag>
+{
+  public:
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Full neighbor lists count and store the neighbors of all particles. The
+      only criteria for a potentially valid neighbor is that the particle does
+      not neighbor itself (i.e. the particle index "p" is not the same as the
+      neighbor index "n").
+    */
+    KOKKOS_INLINE_FUNCTION
+    static bool isValid( const std::size_t p, const double, const double,
+                         const double, const std::size_t n, const double,
+                         const double, const double )
+    {
+        return ( p != n );
+    }
+};
+
+//! Half list discriminator specialization.
+template <>
+class NeighborDiscriminator<HalfNeighborTag>
+{
+  public:
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Half neighbor lists only store half of the neighbors be eliminating
+      duplicate pairs such that the fact that particle "p" neighbors particle
+      "n" is stored in the list but "n" neighboring "p" is not stored but rather
+      implied. We discriminate by only storing neighbors whose coordinates are
+      greater in the x direction. If they are the same then the y direction is
+      checked next and finally the z direction if the y coordinates are the
+      same.
+    */
+    KOKKOS_INLINE_FUNCTION static bool
+    isValid( const std::size_t p, const double xp, const double yp,
+             const double zp, const std::size_t n, const double xn,
+             const double yn, const double zn )
+    {
+        return ( ( p != n ) &&
+                 ( ( xn > xp ) ||
+                   ( ( xn == xp ) &&
+                     ( ( yn > yp ) || ( ( yn == yp ) && ( zn > zp ) ) ) ) ) );
+    }
+};
+
+//---------------------------------------------------------------------------//
 /*!
   \brief Neighbor list interface. Provides an interface callable at the
   functor level that gives access to neighbor data for particles.

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -19,7 +19,6 @@
 #include <Cabana_LinkedCellList.hpp>
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_Parallel.hpp>
-#include <impl/Cabana_CartesianGrid.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -99,100 +98,6 @@ struct VerletListData<MemorySpace, VerletLayout2D>
 namespace Impl
 {
 //! \cond Impl
-
-//---------------------------------------------------------------------------//
-// Neighborhood discriminator.
-template <class Tag>
-class NeighborDiscriminator;
-
-// Full list specialization.
-template <>
-class NeighborDiscriminator<FullNeighborTag>
-{
-  public:
-    // Full neighbor lists count and store the neighbors of all
-    // particles. The only criteria for a potentially valid neighbor is
-    // that the particle does not neighbor itself (i.e. the particle index
-    // "p" is not the same as the neighbor index "n").
-    KOKKOS_INLINE_FUNCTION
-    static bool isValid( const std::size_t p, const double, const double,
-                         const double, const std::size_t n, const double,
-                         const double, const double )
-    {
-        return ( p != n );
-    }
-};
-
-// Half list specialization.
-template <>
-class NeighborDiscriminator<HalfNeighborTag>
-{
-  public:
-    // Half neighbor lists only store half of the neighbors be eliminating
-    // duplicate pairs such that the fact that particle "p" neighbors
-    // particle "n" is stored in the list but "n" neighboring "p" is not
-    // stored but rather implied. We discriminate by only storing neighbors
-    // who's coordinates are greater in the x direction. If they are the same
-    // then the y direction is checked next and finally the z direction if the
-    // y coordinates are the same.
-    KOKKOS_INLINE_FUNCTION
-    static bool isValid( const std::size_t p, const double xp, const double yp,
-                         const double zp, const std::size_t n, const double xn,
-                         const double yn, const double zn )
-    {
-        return ( ( p != n ) &&
-                 ( ( xn > xp ) ||
-                   ( ( xn == xp ) &&
-                     ( ( yn > yp ) || ( ( yn == yp ) && ( zn > zp ) ) ) ) ) );
-    }
-};
-
-//---------------------------------------------------------------------------//
-// Cell stencil.
-template <class Scalar>
-struct LinkedCellStencil
-{
-    Scalar rsqr;
-    CartesianGrid<double> grid;
-    int max_cells_dir;
-    int max_cells;
-    int cell_range;
-
-    LinkedCellStencil( const Scalar neighborhood_radius,
-                       const Scalar cell_size_ratio, const Scalar grid_min[3],
-                       const Scalar grid_max[3] )
-        : rsqr( neighborhood_radius * neighborhood_radius )
-    {
-        Scalar dx = neighborhood_radius * cell_size_ratio;
-        grid = CartesianGrid<double>( grid_min[0], grid_min[1], grid_min[2],
-                                      grid_max[0], grid_max[1], grid_max[2], dx,
-                                      dx, dx );
-        cell_range = std::ceil( 1 / cell_size_ratio );
-        max_cells_dir = 2 * cell_range + 1;
-        max_cells = max_cells_dir * max_cells_dir * max_cells_dir;
-    }
-
-    // Given a cell, get the index bounds of the cell stencil.
-    KOKKOS_INLINE_FUNCTION
-    void getCells( const int cell, int& imin, int& imax, int& jmin, int& jmax,
-                   int& kmin, int& kmax ) const
-    {
-        int i, j, k;
-        grid.ijkBinIndex( cell, i, j, k );
-
-        kmin = ( k - cell_range > 0 ) ? k - cell_range : 0;
-        kmax =
-            ( k + cell_range + 1 < grid._nz ) ? k + cell_range + 1 : grid._nz;
-
-        jmin = ( j - cell_range > 0 ) ? j - cell_range : 0;
-        jmax =
-            ( j + cell_range + 1 < grid._ny ) ? j + cell_range + 1 : grid._ny;
-
-        imin = ( i - cell_range > 0 ) ? i - cell_range : 0;
-        imax =
-            ( i + cell_range + 1 < grid._nx ) ? i + cell_range + 1 : grid._nx;
-    }
-};
 
 //---------------------------------------------------------------------------//
 // Verlet List Builder

--- a/core/unit_test/neighbor_unit_test.hpp
+++ b/core/unit_test/neighbor_unit_test.hpp
@@ -976,6 +976,21 @@ struct NeighborListTestData
         auto N2_list = computeFullNeighborList( positions, test_radius );
         N2_list_copy = createTestListHostCopy( N2_list );
     }
+
+    void build()
+    {
+        for ( int d = 0; d < 3; ++d )
+        {
+            grid_min[d] = box_min;
+            grid_max[d] = box_max;
+        }
+        auto positions = Cabana::slice<0>( aosoa );
+        Cabana::createRandomParticles( positions, positions.size(), box_min,
+                                       box_max );
+        // Create a full N^2 neighbor list to check against.
+        auto N2_list = computeFullNeighborList( positions, test_radius );
+        N2_list_copy = createTestListHostCopy( N2_list );
+    }
 };
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -32,8 +32,7 @@ void testLinkedCellStencil()
         double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
-        Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
-                                                         max );
+        Cabana::LinkedCellStencil<double> stencil( radius, ratio, min, max );
 
         double xp = 4.5;
         double yp = 5.5;
@@ -57,8 +56,7 @@ void testLinkedCellStencil()
         double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
-        Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
-                                                         max );
+        Cabana::LinkedCellStencil<double> stencil( radius, ratio, min, max );
 
         double xp = 0.5;
         double yp = 0.5;
@@ -82,8 +80,7 @@ void testLinkedCellStencil()
         double max[3] = { 10.0, 10.0, 10.0 };
         double radius = 1.0;
         double ratio = 1.0;
-        Cabana::Impl::LinkedCellStencil<double> stencil( radius, ratio, min,
-                                                         max );
+        Cabana::LinkedCellStencil<double> stencil( radius, ratio, min, max );
 
         double xp = 9.5;
         double yp = 9.5;


### PR DESCRIPTION
Add an interface for looping through a linked cell list as if it were a neighbor list. Part of #460. Still WIP:

- [ ] Probably makes more sense to rename `neighbor_parallel_for`
- [ ] Would prefer to store a stencil inside the LCL instead of passing them separately 
- [ ] Started adding the neighbor list traits, but not using them yet
- [ ] Needs more robust testing