### PR TITLE
Only run nightly build with Kokkos develop

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Nightly
 on:
   push:
     branches:
@@ -24,7 +24,7 @@ jobs:
       - name: Build kokkos
         working-directory: kokkos
         run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_CXX_STANDARD=14 -DKokkos_ENABLE_${{ matrix.backend }}=ON
+          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_ENABLE_${{ matrix.backend }}=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout Cabana

--- a/.github/workflows/CI2.yml
+++ b/.github/workflows/CI2.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   CI:
     # FIXME: remove failing distributions here when passing
-    continue-on-error: ${{ matrix.kokkos_ver == 'develop' || matrix.distro == 'fedora:rawhide' || (matrix.distro == 'fedora:intel' && matrix.backend == 'SERIAL' && matrix.cmake_build_type == 'Release') }}
+    continue-on-error: ${{ (matrix.distro == 'fedora:intel' && matrix.backend == 'SERIAL' && matrix.cmake_build_type == 'Release') }}
     defaults:
       run:
         shell: bash
@@ -31,7 +31,7 @@ jobs:
         cxx: ['g++', 'clang++']
         backend: ['OPENMP', 'SERIAL']
         cmake_build_type: ['Debug', 'Release']
-        kokkos_ver: ['3.4.00', 'master', 'develop']
+        kokkos_ver: ['3.4.00', 'master']
         arborx: ['NoArborX']
         heffte: ['NoheFFTe' ]
         hypre: ['NoHYPRE']
@@ -43,8 +43,7 @@ jobs:
             cxx: 'g++'
             backend: 'THREADS'
             cmake_build_type: 'Debug'
-            # FIXME: switch to master when available: https://github.com/kokkos/kokkos/pull/5109
-            kokkos_ver: 'develop'
+            kokkos_ver: 'master'
             arborx: 'NoArborX'
             heffte: 'NoheFFTe'
             hypre: 'NoHYPRE'


### PR DESCRIPTION
Nightly already set up to highlight issues with the develop branch

Nightly was also failing because of the standard config, but I haven't gotten notifications...