### PR TITLE
Add Migrate for avoiding MPI comms buffer reallocation

### DIFF
--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1149,6 +1149,7 @@ class CommunicationData
     //! Perform the communication (migrate, gather, scatter).
     virtual void apply() = 0;
 
+    //! Perform the communication (migrate, gather, scatter).
     virtual void apply( const particle_data_type& src,
                         particle_data_type& dst ) = 0;
 

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1096,6 +1096,7 @@ class CommunicationData
         , _comm_data( CommDataType( particles ) )
         , _overallocation( overallocation )
     {
+        updateRangePolicy();
     }
 
     //! Get the communication send buffer.

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1148,6 +1148,9 @@ class CommunicationData
     //! Perform the communication (migrate, gather, scatter).
     virtual void apply() = 0;
 
+    virtual void apply( const particle_data_type& src,
+                        particle_data_type& dst ) = 0;
+
     //! \cond Impl
     void reserveImpl( const CommPlanType& comm_plan,
                       const particle_data_type particles,
@@ -1163,7 +1166,7 @@ class CommunicationData
         reserveImpl( comm_plan, particles, total_send, total_recv );
     }
     void reserveImpl( const CommPlanType& comm_plan,
-                      const particle_data_type particles,
+                      const particle_data_type& particles,
                       const std::size_t total_send,
                       const std::size_t total_recv )
     {

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -218,8 +218,11 @@ bool distributorCheckValidSize(
   \param distributor The distributor that will be used for the migrate. Used to
   query import and export sizes.
 
-  \param particles The particle data (either AoSoA or slice). Used to query the
+  \param src The source particle data (either AoSoA or slice). Used to query the
   total size.
+
+  \param dst The destination particle data (either AoSoA or slice). Used to
+  query the total size.
 */
 template <class DistributorType, class ParticleData>
 bool distributorCheckValidSize(

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -285,7 +285,7 @@ class Migrate<DistributorType, AoSoAType,
              const double overallocation = 1.0 )
         : base_type( distributor, overallocation )
     {
-        update( _distributor, aosoa );
+        reserve( _distributor, aosoa );
     }
 
     /*!
@@ -305,7 +305,7 @@ class Migrate<DistributorType, AoSoAType,
              const double overallocation = 1.0 )
         : base_type( distributor, overallocation )
     {
-        update( _distributor, src, dst );
+        reserve( _distributor, src, dst );
     }
 
     /*!
@@ -359,8 +359,8 @@ class Migrate<DistributorType, AoSoAType,
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const DistributorType& distributor, AoSoAType& aosoa,
-                 const double overallocation )
+    void reserve( const DistributorType& distributor, AoSoAType& aosoa,
+                  const double overallocation )
     {
         // Check that the AoSoA is the right size.
         if ( !distributorCheckValidSize( distributor, aosoa ) )
@@ -376,8 +376,8 @@ class Migrate<DistributorType, AoSoAType,
         if ( dst_is_bigger )
             aosoa.resize( distributor.totalNumImport() );
 
-        this->updateImpl( distributor, aosoa, distributor.totalSend(),
-                          distributor.totalReceive(), overallocation );
+        this->reserveImpl( distributor, aosoa, distributor.totalSend(),
+                           distributor.totalReceive(), overallocation );
     }
     /*!
       \brief Update the distributor and AoSoA data for migration.
@@ -385,7 +385,7 @@ class Migrate<DistributorType, AoSoAType,
       \param distributor The Distributor to be used for the migrate.
       \param aosoa The AoSoA on which to perform the migrate.
     */
-    void update( const DistributorType& distributor, AoSoAType& aosoa )
+    void reserve( const DistributorType& distributor, AoSoAType& aosoa )
     {
         // Check that the AoSoA is the right size.
         if ( !distributorCheckValidSize( distributor, aosoa ) )
@@ -401,8 +401,8 @@ class Migrate<DistributorType, AoSoAType,
         if ( dst_is_bigger )
             aosoa.resize( distributor.totalNumImport() );
 
-        this->updateImpl( distributor, aosoa, distributor.totalSend(),
-                          distributor.totalReceive() );
+        this->reserveImpl( distributor, aosoa, distributor.totalSend(),
+                           distributor.totalReceive() );
     }
 
     /*!
@@ -417,15 +417,15 @@ class Migrate<DistributorType, AoSoAType,
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const DistributorType& distributor, const AoSoAType& src,
-                 AoSoAType& dst, const double overallocation )
+    void reserve( const DistributorType& distributor, const AoSoAType& src,
+                  AoSoAType& dst, const double overallocation )
     {
         // Check that src and dst are the right size.
         if ( !distributorCheckValidSize( distributor, src, dst ) )
             throw std::runtime_error( "AoSoA is the wrong size for migrate!" );
 
-        this->updateImpl( distributor, src, distributor.totalSend(),
-                          distributor.totalReceive(), overallocation );
+        this->reserveImpl( distributor, src, distributor.totalSend(),
+                           distributor.totalReceive(), overallocation );
     }
     /*!
       \brief Update the distributor and AoSoA data for migration.
@@ -437,15 +437,15 @@ class Migrate<DistributorType, AoSoAType,
       the same size as the number of imports given by the distributor on this
       rank.
     */
-    void update( const DistributorType& distributor, const AoSoAType& src,
-                 AoSoAType& dst )
+    void reserve( const DistributorType& distributor, const AoSoAType& src,
+                  AoSoAType& dst )
     {
         // Check that src and dst are the right size.
         if ( !distributorCheckValidSize( distributor, src, dst ) )
             throw std::runtime_error( "AoSoA is the wrong size for migrate!" );
 
-        this->updateImpl( distributor, src, distributor.totalSend(),
-                          distributor.totalReceive() );
+        this->reserveImpl( distributor, src, distributor.totalSend(),
+                           distributor.totalReceive() );
     }
 
   private:
@@ -597,7 +597,7 @@ class Migrate<DistributorType, SliceType,
         : base_type( distributor, overallocation )
     {
         _my_rank = _distributor.getRank();
-        update( _distributor, src, dst );
+        reserve( _distributor, src, dst );
     }
 
     /*!
@@ -725,7 +725,7 @@ class Migrate<DistributorType, SliceType,
     }
 
     //! \cond Impl
-    void apply( SliceType& ) override
+    void apply() override
     {
         // This should never be called. It exists to override the base.
         throw std::runtime_error(
@@ -742,15 +742,15 @@ class Migrate<DistributorType, SliceType,
       \param overallocation An optional factor to keep extra space in the
       buffers to avoid frequent resizing.
     */
-    void update( const DistributorType& distributor, const SliceType& src,
-                 SliceType& dst, const double overallocation )
+    void reserve( const DistributorType& distributor, const SliceType& src,
+                  SliceType& dst, const double overallocation )
     {
         // Check that src and dst are the right size.
         if ( !distributorCheckValidSize( distributor, src, dst ) )
             throw std::runtime_error( "AoSoA is the wrong size for migrate!" );
 
-        this->updateImpl( distributor, src, distributor.totalSend(),
-                          distributor.totalReceive(), overallocation );
+        this->reserveImpl( distributor, src, distributor.totalSend(),
+                           distributor.totalReceive(), overallocation );
     }
     /*!
       \brief Update the distributor and slice data for migrate.
@@ -759,15 +759,15 @@ class Migrate<DistributorType, SliceType,
       \param src The slice containing the data to be migrated.
       \param dst The slice to which the migrated data will be written.
     */
-    void update( const DistributorType& distributor, const SliceType& src,
-                 SliceType& dst )
+    void reserve( const DistributorType& distributor, const SliceType& src,
+                  SliceType& dst )
     {
         // Check that src and dst are the right size.
         if ( !distributorCheckValidSize( distributor, src, dst ) )
             throw std::runtime_error( "AoSoA is the wrong size for migrate!" );
 
-        this->updateImpl( distributor, src, distributor.totalSend(),
-                          distributor.totalReceive() );
+        this->reserveImpl( distributor, src, distributor.totalSend(),
+                           distributor.totalReceive() );
     }
 
   private:

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -512,8 +512,8 @@ class Migrate<DistributorType, AoSoAType,
 template <class DistributorType, class SliceType>
 class Migrate<DistributorType, SliceType,
               typename std::enable_if<is_slice<SliceType>::value>::type>
-    : CommunicationDataSeparate<DistributorType,
-                                CommunicationDataSliceSeparate<SliceType>>
+    : public CommunicationDataSeparate<
+          DistributorType, CommunicationDataSliceSeparate<SliceType>>
 {
   public:
     static_assert( is_distributor<DistributorType>::value, "" );
@@ -781,6 +781,7 @@ void migrate( const DistributorType& distributor, const ParticleDataType& src,
 {
     auto migrate = createMigrate( distributor, src, dst );
     migrate.apply();
+    dst = migrate.getDestinationParticles();
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -359,12 +359,6 @@ class Gather<HaloType, AoSoAType,
         MPI_Barrier( _halo.comm() );
     }
 
-    void apply( const AoSoAType&, AoSoAType& ) override
-    {
-        // This should never be called. It exists to override the base.
-        throw std::runtime_error( "Gather must be in place!" );
-    }
-
     /*!
       \brief Reserve new buffers as needed and update the halo and AoSoA data.
 
@@ -554,12 +548,6 @@ class Gather<HaloType, SliceType,
 
         // Barrier before completing to ensure synchronization.
         MPI_Barrier( _halo.comm() );
-    }
-
-    void apply( const SliceType&, SliceType& ) override
-    {
-        // This should never be called. It exists to override the base.
-        throw std::runtime_error( "Gather must be in place!" );
     }
 
     /*!
@@ -804,12 +792,6 @@ class Scatter
 
         // Barrier before completing to ensure synchronization.
         MPI_Barrier( _halo.comm() );
-    }
-
-    void apply( const SliceType&, SliceType& ) override
-    {
-        // This should never be called. It exists to override the base.
-        throw std::runtime_error( "Scatter must be in place!" );
     }
 
     /*!

--- a/core/src/Cabana_Halo.hpp
+++ b/core/src/Cabana_Halo.hpp
@@ -359,6 +359,12 @@ class Gather<HaloType, AoSoAType,
         MPI_Barrier( _halo.comm() );
     }
 
+    void apply( const AoSoAType&, AoSoAType& ) override
+    {
+        // This should never be called. It exists to override the base.
+        throw std::runtime_error( "Gather must be in place!" );
+    }
+
     /*!
       \brief Reserve new buffers as needed and update the halo and AoSoA data.
 
@@ -548,6 +554,12 @@ class Gather<HaloType, SliceType,
 
         // Barrier before completing to ensure synchronization.
         MPI_Barrier( _halo.comm() );
+    }
+
+    void apply( const SliceType&, SliceType& ) override
+    {
+        // This should never be called. It exists to override the base.
+        throw std::runtime_error( "Gather must be in place!" );
     }
 
     /*!
@@ -792,6 +804,12 @@ class Scatter
 
         // Barrier before completing to ensure synchronization.
         MPI_Barrier( _halo.comm() );
+    }
+
+    void apply( const SliceType&, SliceType& ) override
+    {
+        // This should never be called. It exists to override the base.
+        throw std::runtime_error( "Scatter must be in place!" );
     }
 
     /*!


### PR DESCRIPTION
Follow on to #549 for particle migration. Extends the same idea to a new `Migrate` object that can be reused. Still possible to call `migrate` for backwards compatibility (will still be slow and reallocate a new comm buffer every time)

Also rewrites migrate tests to be more reusable