### PR TITLE
Generate fully random particles in benchmarks

### DIFF
--- a/benchmark/core/Cabana_LinkedCellPerformance.cpp
+++ b/benchmark/core/Cabana_LinkedCellPerformance.cpp
@@ -31,7 +31,6 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
                       std::vector<double> cutoff_ratios )
 {
     // Declare problem sizes.
-    double min_dist = 1.0;
     int num_problem_size = problem_sizes.size();
     std::vector<double> x_min( num_problem_size );
     std::vector<double> x_max( num_problem_size );
@@ -55,11 +54,10 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
         // Define problem grid.
         x_min[p] = 0.0;
-        x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
+        x_max[p] = 1.3 * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
         auto x = Cabana::slice<0>( aosoas[p], "position" );
-        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
-                                                  x_max[p], min_dist );
+        Cabana::createRandomParticles( x, x.size(), x_min[p], x_max[p] );
     }
 
     // Loop over number of ratios (neighbors per particle).
@@ -91,7 +89,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
             // Create the linked cell list.
             auto x = Cabana::slice<0>( aosoas[p], "position" );
-            double cutoff = cutoff_ratios[c] * min_dist;
+            double cutoff = cutoff_ratios[c];
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };

--- a/benchmark/core/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborArborXPerformance.cpp
@@ -38,7 +38,6 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     using IterTag = Cabana::SerialOpTag;
 
     // Declare problem sizes.
-    double min_dist = 1.0;
     int num_problem_size = problem_sizes.size();
     std::vector<double> x_min( num_problem_size );
     std::vector<double> x_max( num_problem_size );
@@ -62,11 +61,10 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
         // Define problem grid.
         x_min[p] = 0.0;
-        x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
+        x_max[p] = 1.3 * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
         auto x = Cabana::slice<0>( aosoas[p], "position" );
-        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
-                                                  x_max[p], min_dist );
+        Cabana::createRandomParticles( x, x.size(), x_min[p], x_max[p] );
 
         if ( sort )
         {
@@ -74,7 +72,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             // simulation. They likely won't be randomly scattered about, but
             // rather will be periodically sorted for spatial locality. Bin them
             // in cells the size of the smallest cutoff distance.
-            double cutoff = cutoff_ratios.front() * min_dist;
+            double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };
@@ -126,7 +124,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             for ( int t = 0; t < num_run; ++t )
             {
                 // Create the neighbor list.
-                double cutoff = cutoff_ratios[c] * min_dist;
+                double cutoff = cutoff_ratios[c];
                 create_timer.start( pid );
                 auto const nlist =
                     Cabana::Experimental::make2DNeighborList<Device>(

--- a/benchmark/core/Cabana_NeighborVerletPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborVerletPerformance.cpp
@@ -41,7 +41,6 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     using IterTag = Cabana::SerialOpTag;
 
     // Declare problem sizes.
-    double min_dist = 1.0;
     int num_problem_size = problem_sizes.size();
     std::vector<double> x_min( num_problem_size );
     std::vector<double> x_max( num_problem_size );
@@ -68,11 +67,10 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
         // Define problem grid.
         x_min[p] = 0.0;
-        x_max[p] = 1.3 * min_dist * std::pow( num_p, 1.0 / 3.0 );
+        x_max[p] = 1.3 * std::pow( num_p, 1.0 / 3.0 );
         aosoas[p].resize( num_p );
         auto x = Cabana::slice<0>( aosoas[p], "position" );
-        Cabana::createRandomParticlesMinDistance( x, x.size(), x_min[p],
-                                                  x_max[p], min_dist );
+        Cabana::createRandomParticles( x, x.size(), x_min[p], x_max[p] );
 
         if ( sort )
         {
@@ -80,7 +78,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             // simulation. They likely won't be randomly scattered about, but
             // rather will be periodically sorted for spatial locality. Bin them
             // in cells the size of the smallest cutoff distance.
-            double cutoff = cutoff_ratios.front() * min_dist;
+            double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };
@@ -139,7 +137,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
                 for ( int t = 0; t < num_run; ++t )
                 {
                     // Create the neighbor list.
-                    double cutoff = cutoff_ratios[c0] * min_dist;
+                    double cutoff = cutoff_ratios[c0];
                     create_timer.start( pid );
                     Cabana::VerletList<memory_space, ListTag, LayoutTag,
                                        BuildTag>


### PR DESCRIPTION
Creating systems with minimum distance between particles is extremely slow as compared to running the actual benchmarks. Performance profiles with or without minimum separation are extremely similar