### PR TITLE
Convert class templates to Kokkos memory spaces

### DIFF
--- a/benchmark/cajita/Cajita_FastFourierTransformPerformance.cpp
+++ b/benchmark/cajita/Cajita_FastFourierTransformPerformance.cpp
@@ -78,7 +78,7 @@ void performanceTest( std::ostream& stream,
         auto ghosted_space = local_grid->indexSpace( Ghost(), Cell(), Local() );
 
         auto vector_layout = createArrayLayout( local_grid, 2, Cell() );
-        auto lhs = createArray<double, Device>( "lhs", vector_layout );
+        auto lhs = createArray<double, memory_space>( "lhs", vector_layout );
         auto lhs_view = lhs->view();
         uint64_t seed = global_grid->blockId() +
                         ( 19383747 % ( global_grid->blockId() + 1 ) );
@@ -103,9 +103,9 @@ void performanceTest( std::ostream& stream,
         // Create FFT options
         Experimental::FastFourierTransformParams params;
 
-        auto fft =
-            Experimental::createHeffteFastFourierTransform<double, Device>(
-                *vector_layout, params );
+        auto fft = Experimental::createHeffteFastFourierTransform<double,
+                                                                  memory_space>(
+            *vector_layout, params );
 
         setup_timer.stop( p );
 

--- a/benchmark/cajita/Cajita_InterpolationPerformance.cpp
+++ b/benchmark/cajita/Cajita_InterpolationPerformance.cpp
@@ -23,20 +23,20 @@ using namespace Cajita;
 // This is an example fused kernel version of p2g. It is not intended to be
 // physical, but only to compare performance.
 template <class ScalarValue, class VectorValue, class ScalarGrad,
-          class VectorDiv, class TensorDiv, class Coordinates, class DeviceType,
-          class ScalarArrayType, class VectorArrayType>
+          class VectorDiv, class TensorDiv, class Coordinates,
+          class MemorySpace, class ScalarArrayType, class VectorArrayType>
 void fused_p2g( const ScalarValue& scalar_value,
                 const VectorValue& vector_value, const ScalarGrad& scalar_grad,
                 const VectorDiv& vector_div, const TensorDiv& tensor_div,
                 const Coordinates& points, const std::size_t num_point,
-                const Halo<DeviceType>& halo, ScalarArrayType& scalar_array,
+                const Halo<MemorySpace>& halo, ScalarArrayType& scalar_array,
                 VectorArrayType& vector_array )
 {
-    using execution_space = typename DeviceType::execution_space;
+    using execution_space = typename MemorySpace::execution_space;
 
     // Create the local mesh.
     auto local_mesh =
-        createLocalMesh<DeviceType>( *( scalar_array.layout()->localGrid() ) );
+        createLocalMesh<MemorySpace>( *( scalar_array.layout()->localGrid() ) );
 
     // Create a scatter view of the arrays.
     auto scalar_view = scalar_array.view();
@@ -79,19 +79,19 @@ void fused_p2g( const ScalarValue& scalar_value,
 // This is an example fused kernel version of g2p. It is not intended to be
 // physical, but only to compare performance.
 template <class ScalarArrayType, class VectorArrayType, class Coordinates,
-          class DeviceType, class ScalarValue, class VectorValue,
+          class MemorySpace, class ScalarValue, class VectorValue,
           class ScalarGrad, class VectorGrad, class VectorDiv>
 void fused_g2p( ScalarArrayType& scalar_array, VectorArrayType& vector_array,
-                const Halo<DeviceType>& halo, const Coordinates& points,
+                const Halo<MemorySpace>& halo, const Coordinates& points,
                 const std::size_t num_point, const ScalarValue& scalar_value,
                 const VectorValue& vector_value, const ScalarGrad& scalar_grad,
                 const VectorGrad& vector_grad, const VectorDiv& vector_div )
 {
-    using execution_space = typename DeviceType::execution_space;
+    using execution_space = typename MemorySpace::execution_space;
 
     // Create the local mesh.
     auto local_mesh =
-        createLocalMesh<DeviceType>( *( scalar_array.layout()->localGrid() ) );
+        createLocalMesh<MemorySpace>( *( scalar_array.layout()->localGrid() ) );
 
     // Gather data into the halo before interpolating.
     halo.gather( execution_space(), scalar_array );
@@ -127,17 +127,17 @@ void fused_g2p( ScalarArrayType& scalar_array, VectorArrayType& vector_array,
 }
 
 // This is an example fused kernel scalar g2p2g.
-template <class ScalarValueP2GType, class Coordinates, class DeviceType,
+template <class ScalarValueP2GType, class Coordinates, class MemorySpace,
           class ScalarArrayType, class ScalarValueG2PType>
 void g2p2g( const ScalarValueP2GType& scalar_p2g, const Coordinates& points,
-            const std::size_t num_point, const Halo<DeviceType>& halo,
+            const std::size_t num_point, const Halo<MemorySpace>& halo,
             ScalarArrayType& scalar_array, ScalarValueG2PType& scalar_g2p )
 {
-    using execution_space = typename DeviceType::execution_space;
+    using execution_space = typename MemorySpace::execution_space;
 
     // Create the local mesh.
     auto local_mesh =
-        createLocalMesh<DeviceType>( *( scalar_array.layout()->localGrid() ) );
+        createLocalMesh<MemorySpace>( *( scalar_array.layout()->localGrid() ) );
 
     // Gather data into the halo before interpolating.
     halo.gather( execution_space(), scalar_array );
@@ -198,7 +198,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     // Define the particle types.
     using member_types =
         Cabana::MemberTypes<double[3][3], double[3], double[3], double>;
-    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
 
     // Define properties that do not depend on mesh size.
     Cajita::DimBlockPartitioner<3> partitioner;

--- a/benchmark/cajita/Cajita_SparseMapPerformance.cpp
+++ b/benchmark/cajita/Cajita_SparseMapPerformance.cpp
@@ -63,10 +63,10 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
     // Some helper views
     int max_num_tiles_per_dim =
         num_cells_per_dim.back() / cell_num_per_tile_dim;
-    Kokkos::View<uint64_t***, Device> tile_ids(
+    Kokkos::View<uint64_t***, memory_space> tile_ids(
         Kokkos::ViewAllocateWithoutInitializing( "tile_ids" ),
         max_num_tiles_per_dim, max_num_tiles_per_dim, max_num_tiles_per_dim );
-    Kokkos::View<bool***, Device> is_tile_valid(
+    Kokkos::View<bool***, memory_space> is_tile_valid(
         Kokkos::ViewAllocateWithoutInitializing( "is_tile_valid" ),
         max_num_tiles_per_dim, max_num_tiles_per_dim, max_num_tiles_per_dim );
 

--- a/benchmark/cajita/Cajita_SparsePartitionerPerformance.cpp
+++ b/benchmark/cajita/Cajita_SparsePartitionerPerformance.cpp
@@ -142,9 +142,10 @@ void performanceTest( ParticleWorkloadTag, std::ostream& stream, MPI_Comm comm,
         int num_tiles_per_dim = num_cells_per_dim[c] >> cell_bits_per_tile_dim;
 
         // set up partitioner
-        Cajita::SparseDimPartitioner<Device, cell_num_per_tile_dim> partitioner(
-            comm, max_workload_coeff, max_par_num, num_step_rebalance,
-            global_num_cell, max_optimize_iteration );
+        Cajita::SparseDimPartitioner<memory_space, cell_num_per_tile_dim>
+            partitioner( comm, max_workload_coeff, max_par_num,
+                         num_step_rebalance, global_num_cell,
+                         max_optimize_iteration );
         auto ranks_per_dim =
             partitioner.ranksPerDimension( comm, global_num_cell );
         auto ave_partition =
@@ -231,6 +232,8 @@ void performanceTest( SparseMapTag, std::ostream& stream, MPI_Comm comm,
                       std::vector<int> num_cells_per_dim )
 {
     using exec_space = typename Device::execution_space;
+    using memory_space = typename Device::memory_space;
+
     // Domain size setup
     std::array<float, 3> global_low_corner = { 0.0, 0.0, 0.0 };
     std::array<float, 3> global_high_corner = { 1.0, 1.0, 1.0 };
@@ -267,15 +270,16 @@ void performanceTest( SparseMapTag, std::ostream& stream, MPI_Comm comm,
 
         // Generate a random set of occupied tiles
         auto tiles_host = generateRandomTileSequence( num_tiles_per_dim );
-        auto tiles_view = Kokkos::create_mirror_view_and_copy(
-            typename Device::memory_space(), tiles_host );
+        auto tiles_view =
+            Kokkos::create_mirror_view_and_copy( memory_space(), tiles_host );
 
         // set up partitioner
         auto total_num =
             num_tiles_per_dim * num_tiles_per_dim * num_tiles_per_dim;
-        Cajita::SparseDimPartitioner<Device, cell_num_per_tile_dim> partitioner(
-            comm, max_workload_coeff, total_num, num_step_rebalance,
-            global_num_cell, max_optimize_iteration );
+        Cajita::SparseDimPartitioner<memory_space, cell_num_per_tile_dim>
+            partitioner( comm, max_workload_coeff, total_num,
+                         num_step_rebalance, global_num_cell,
+                         max_optimize_iteration );
         auto ranks_per_dim =
             partitioner.ranksPerDimension( comm, global_num_cell );
         auto ave_partition =

--- a/benchmark/core/Cabana_BinSortPerformance.cpp
+++ b/benchmark/core/Cabana_BinSortPerformance.cpp
@@ -31,11 +31,13 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
                       std::vector<int> problem_sizes,
                       std::vector<int> num_bins )
 {
+    using memory_space = typename Device::memory_space;
+
     // Declare problem sizes.
     int num_problem_size = problem_sizes.size();
 
     // Generate a random set of keys
-    Kokkos::View<unsigned long*, Device> keys(
+    Kokkos::View<unsigned long*, memory_space> keys(
         Kokkos::ViewAllocateWithoutInitializing( "keys" ),
         problem_sizes.back() );
     Kokkos::View<unsigned long*, Kokkos::HostSpace> host_keys(
@@ -54,7 +56,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3], double[3], double, int>;
-    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
 
     // Create aosoas.
     std::vector<aosoa_type> aosoas( num_problem_size );

--- a/benchmark/core/Cabana_LinkedCellPerformance.cpp
+++ b/benchmark/core/Cabana_LinkedCellPerformance.cpp
@@ -30,6 +30,8 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
                       std::vector<int> problem_sizes,
                       std::vector<double> cutoff_ratios )
 {
+    using memory_space = typename Device::memory_space;
+
     // Declare problem sizes.
     int num_problem_size = problem_sizes.size();
     std::vector<double> x_min( num_problem_size );
@@ -44,7 +46,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
-    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
@@ -96,7 +98,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };
-            Cabana::LinkedCellList<Device> linked_cell_list(
+            Cabana::LinkedCellList<memory_space> linked_cell_list(
                 x, sort_delta, grid_min, grid_max );
 
             // Run tests and time the ensemble

--- a/benchmark/core/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborArborXPerformance.cpp
@@ -51,7 +51,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
-    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
@@ -78,7 +78,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             auto x = Cabana::slice<0>( aosoas[p], "position" );
-            Cabana::LinkedCellList<Device> linked_cell_list(
+            Cabana::LinkedCellList<memory_space> linked_cell_list(
                 x, sort_delta, grid_min, grid_max );
             Cabana::permute( linked_cell_list, aosoas[p] );
         }

--- a/benchmark/core/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborArborXPerformance.cpp
@@ -127,10 +127,9 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
                 // Create the neighbor list.
                 double cutoff = cutoff_ratios[c];
                 create_timer.start( pid );
-                auto const nlist =
-                    Cabana::Experimental::make2DNeighborList<Device>(
-                        ListTag{}, Cabana::slice<0>( aosoas[p], "position" ), 0,
-                        num_p, cutoff );
+                auto const nlist = Cabana::Experimental::make2DNeighborList(
+                    ListTag{}, Cabana::slice<0>( aosoas[p], "position" ), 0,
+                    num_p, cutoff );
                 create_timer.stop( pid );
 
                 // Iterate through the neighbor list.

--- a/benchmark/core/Cabana_NeighborVerletPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborVerletPerformance.cpp
@@ -57,7 +57,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
 
     // Define the aosoa.
     using member_types = Cabana::MemberTypes<double[3]>;
-    using aosoa_type = Cabana::AoSoA<member_types, Device>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
     std::vector<aosoa_type> aosoas( num_problem_size );
 
     // Create aosoas.
@@ -83,7 +83,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             // in cells the size of the smallest cutoff distance.
             double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
-            Cabana::LinkedCellList<Device> linked_cell_list(
+            Cabana::LinkedCellList<memory_space> linked_cell_list(
                 x, sort_delta, grid_min, grid_max );
             Cabana::permute( linked_cell_list, aosoas[p] );
         }

--- a/cajita/src/Cajita_Array.hpp
+++ b/cajita/src/Cajita_Array.hpp
@@ -247,14 +247,12 @@ class Array
         std::conditional_t<2 == num_space_dim,
                            Kokkos::View<value_type***, Params...>, void>>;
 
-    //! Device type.
-    using device_type = typename view_type::device_type;
-
     //! Memory space.
     using memory_space = typename view_type::memory_space;
-
-    //! Execution space.
-    using execution_space = typename view_type::execution_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     /*!
       \brief Create an array with the given layout. Arrays are constructed
@@ -310,7 +308,7 @@ class Array
     using subview_memory_traits = typename subview_type::memory_traits;
     //! Subarray type.
     using subarray_type = Array<Scalar, EntityType, MeshType, subview_layout,
-                                device_type, subview_memory_traits>;
+                                memory_space, subview_memory_traits>;
 };
 
 //---------------------------------------------------------------------------//
@@ -368,7 +366,7 @@ template <class Scalar, class EntityType, class MeshType, class... Params>
 std::shared_ptr<Array<
     Scalar, EntityType, MeshType,
     typename Array<Scalar, EntityType, MeshType, Params...>::subview_layout,
-    typename Array<Scalar, EntityType, MeshType, Params...>::device_type,
+    typename Array<Scalar, EntityType, MeshType, Params...>::memory_space,
     typename Array<Scalar, EntityType, MeshType,
                    Params...>::subview_memory_traits>>
 createSubarray( const Array<Scalar, EntityType, MeshType, Params...>& array,
@@ -394,7 +392,7 @@ createSubarray( const Array<Scalar, EntityType, MeshType, Params...>& array,
     return std::make_shared<Array<
         Scalar, EntityType, MeshType,
         typename Array<Scalar, EntityType, MeshType, Params...>::subview_layout,
-        typename Array<Scalar, EntityType, MeshType, Params...>::device_type,
+        typename Array<Scalar, EntityType, MeshType, Params...>::memory_space,
         typename Array<Scalar, EntityType, MeshType,
                        Params...>::subview_memory_traits>>( sub_layout,
                                                             sub_view );
@@ -501,7 +499,7 @@ scale( Array_t& array, const std::vector<typename Array_t::value_type>& alpha,
                  Kokkos::MemoryUnmanaged>
         alpha_view_host( alpha.data(), alpha.size() );
     auto alpha_view = Kokkos::create_mirror_view_and_copy(
-        typename Array_t::device_type(), alpha_view_host );
+        typename Array_t::memory_space(), alpha_view_host );
 
     auto array_view = array.view();
     Kokkos::parallel_for(
@@ -534,7 +532,7 @@ scale( Array_t& array, const std::vector<typename Array_t::value_type>& alpha,
                  Kokkos::MemoryUnmanaged>
         alpha_view_host( alpha.data(), alpha.size() );
     auto alpha_view = Kokkos::create_mirror_view_and_copy(
-        typename Array_t::device_type(), alpha_view_host );
+        typename Array_t::memory_space(), alpha_view_host );
 
     auto array_view = array.view();
     Kokkos::parallel_for(

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -19,6 +19,8 @@
 #include <Cajita_Array.hpp>
 #include <Cajita_Types.hpp>
 
+#include <Cabana_Utils.hpp>
+
 #include <Kokkos_Core.hpp>
 
 #include <heffte_fft3d.h>
@@ -153,10 +155,14 @@ class FastFourierTransform
     using mesh_type = MeshType;
     //! Scalar value type.
     using value_type = Scalar;
+
     // FIXME: extracting the self type for backwards compatibility with previous
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Kokkos memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Cabana::Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Kokkos execution space.
     using execution_space = typename memory_space::execution_space;
     //! Kokkos execution space.
@@ -479,10 +485,14 @@ class HeffteFastFourierTransform
   public:
     //! Scalar value type.
     using value_type = Scalar;
+
     // FIXME: extracting the self type for backwards compatibility with previous
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Kokkos memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Cabana::Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Kokkos execution space.
     using execution_space = ExecSpace;
     //! Kokkos execution space.

--- a/cajita/src/Cajita_FastFourierTransform.hpp
+++ b/cajita/src/Cajita_FastFourierTransform.hpp
@@ -75,7 +75,7 @@ struct is_matching_array : public std::false_type
     static_assert( std::is_same<ArrayMesh, Mesh>::value,
                    "Array mesh type mush match FFT mesh type." );
     static_assert( std::is_same<ArrayMemorySpace, MemorySpace>::value,
-                   "Array device type must match FFT device type." );
+                   "Array memory space must match FFT memory space." );
 };
 
 //! Matching Array static type checker.
@@ -550,10 +550,10 @@ class HeffteFastFourierTransform
             throw std::logic_error( "Expected FFT allocation size smaller "
                                     "than local grid size" );
 
-        _fft_work = Kokkos::View<Scalar*, MemorySpace>(
+        _fft_work = Kokkos::View<Scalar*, memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "fft_work" ),
             2 * fftsize );
-        _workspace = Kokkos::View<Scalar* [2], MemorySpace>(
+        _workspace = Kokkos::View<Scalar* [2], memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "workspace" ),
             4 * fftsize );
     }
@@ -593,7 +593,7 @@ class HeffteFastFourierTransform
         auto own_space =
             x.layout()->localGrid()->indexSpace( Own(), EntityType(), Local() );
         auto local_view_space = appendDimension( own_space, 2 );
-        auto local_view = createView<Scalar, Kokkos::LayoutRight, MemorySpace>(
+        auto local_view = createView<Scalar, Kokkos::LayoutRight, memory_space>(
             local_view_space, _fft_work.data() );
 
         // TODO: pull this out to template function

--- a/cajita/src/Cajita_Halo.hpp
+++ b/cajita/src/Cajita_Halo.hpp
@@ -987,17 +987,16 @@ struct LayoutAdapter
   \param pattern The pattern to build the halo from.
   \param width Must be less than or equal to the width of the array
   halo. Defaults to the width of the array halo.
-  \note The scalar type and device type must be specified so the proper
+  \note The scalar type and memory space must be specified so the proper
   buffers may be allocated. This means a halo constructed via this method is
-  only compatible with arrays that have the same scalar and device type.
+  only compatible with arrays that have the same scalar and memory space.
 */
-template <class Scalar, class Device, class EntityType, class MeshType,
+template <class Scalar, class MemorySpace, class EntityType, class MeshType,
           class Pattern>
 [[deprecated]] auto createHalo( const ArrayLayout<EntityType, MeshType>& layout,
                                 const Pattern& pattern, const int width = -1 )
 {
-    LayoutAdapter<Scalar, typename Device::memory_space,
-                  ArrayLayout<EntityType, MeshType>>
+    LayoutAdapter<Scalar, MemorySpace, ArrayLayout<EntityType, MeshType>>
         adapter{ layout };
     return createHalo( pattern, width, adapter );
 }
@@ -1009,7 +1008,7 @@ template <class Scalar, class Device, class EntityType, class MeshType,
   \param pattern The pattern to build the halo from.
   \param width Must be less than or equal to the width of the array
   halo. Defaults to the width of the array halo.
-  \note The scalar type and device type are specified via the input arrays so
+  \note The scalar type and memory space are specified via the input arrays so
   the proper buffers may be allocated. This means a halo constructed via this
   method is only compatible with arrays that have the same scalar and device
   type as the input array.

--- a/cajita/src/Cajita_HypreStructuredSolver.hpp
+++ b/cajita/src/Cajita_HypreStructuredSolver.hpp
@@ -230,7 +230,7 @@ class HypreStructuredSolver
             "Array entity type mush match solver entity type" );
         static_assert(
             std::is_same<typename Array_t::memory_space, MemorySpace>::value,
-            "Array device type and solver device type are different." );
+            "Array memory space and solver memory space are different." );
 
         static_assert(
             std::is_same<typename Array_t::value_type, value_type>::value,
@@ -363,7 +363,7 @@ class HypreStructuredSolver
             "Array entity type mush match solver entity type" );
         static_assert(
             std::is_same<typename Array_t::memory_space, MemorySpace>::value,
-            "Array device type and solver device type are different." );
+            "Array memory space and solver memory space are different." );
 
         static_assert(
             std::is_same<typename Array_t::value_type, value_type>::value,

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -19,6 +19,8 @@
 #include <Cajita_LocalGrid.hpp>
 #include <Cajita_Types.hpp>
 
+#include <Cabana_Utils.hpp>
+
 #include <Kokkos_Core.hpp>
 
 namespace Cajita
@@ -313,6 +315,9 @@ class LocalMesh<MemorySpace, NonUniformMesh<Scalar, NumSpaceDim>>
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Cabana::Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;
     //! Default execution space.

--- a/cajita/src/Cajita_LocalMesh.hpp
+++ b/cajita/src/Cajita_LocalMesh.hpp
@@ -25,13 +25,13 @@ namespace Cajita
 {
 //---------------------------------------------------------------------------//
 // Forward decalaration of local mesh.
-template <class Device, class MeshType>
+template <class MemorySpace, class MeshType>
 class LocalMesh;
 
 //---------------------------------------------------------------------------//
 //! Local mesh partial specialization for uniform mesh.
-template <class Scalar, class Device, std::size_t NumSpaceDim>
-class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
+template <class Scalar, class MemorySpace, std::size_t NumSpaceDim>
+class LocalMesh<MemorySpace, UniformMesh<Scalar, NumSpaceDim>>
 {
   public:
     //! Mesh type.
@@ -43,12 +43,17 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
     //! Spatial dimension.
     static constexpr std::size_t num_space_dim = NumSpaceDim;
 
-    //! Kokkos device type.
-    using device_type = Device;
-    //! Kokkos memory space.
-    using memory_space = typename Device::memory_space;
-    //! Kokkos execution space.
-    using execution_space = typename Device::execution_space;
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
+    //! Memory space.
+    using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Cabana::Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     //! Default constructor.
     LocalMesh() = default;
@@ -291,8 +296,8 @@ class LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>
 
 //---------------------------------------------------------------------------//
 //! Global mesh partial specialization for non-uniform mesh.
-template <class Scalar, class Device, std::size_t NumSpaceDim>
-class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
+template <class Scalar, class MemorySpace, std::size_t NumSpaceDim>
+class LocalMesh<MemorySpace, NonUniformMesh<Scalar, NumSpaceDim>>
 {
   public:
     //! Mesh type.
@@ -304,12 +309,14 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
     //! Spatial dimension.
     static constexpr std::size_t num_space_dim = NumSpaceDim;
 
-    //! Device type.
-    using device_type = Device;
-    //! Kokkos memory space.
-    using memory_space = typename Device::memory_space;
-    //! Kokkos execution space.
-    using execution_space = typename Device::execution_space;
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
+    //! Memory space.
+    using memory_space = typename MemorySpace::memory_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     //! Constructor.
     LocalMesh(
@@ -411,7 +418,7 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
             const auto& global_edge = global_mesh.nonUniformEdge( d );
             int nedge = ghosted_nodes_local.extent( d );
             int nedge_global = global_edge.size();
-            _local_edges[d] = Kokkos::View<Scalar*, Device>(
+            _local_edges[d] = Kokkos::View<Scalar*, MemorySpace>(
                 Kokkos::ViewAllocateWithoutInitializing( "local_edges" ),
                 nedge );
 
@@ -758,7 +765,8 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
     Kokkos::Array<Scalar, num_space_dim> _own_high_corner;
     Kokkos::Array<Scalar, num_space_dim> _ghost_low_corner;
     Kokkos::Array<Scalar, num_space_dim> _ghost_high_corner;
-    Kokkos::Array<Kokkos::View<Scalar*, Device>, num_space_dim> _local_edges;
+    Kokkos::Array<Kokkos::View<Scalar*, MemorySpace>, num_space_dim>
+        _local_edges;
     Kokkos::Array<bool, num_space_dim> _periodic;
     Kokkos::Array<bool, num_space_dim> _boundary_lo;
     Kokkos::Array<bool, num_space_dim> _boundary_hi;
@@ -769,11 +777,11 @@ class LocalMesh<Device, NonUniformMesh<Scalar, NumSpaceDim>>
   \brief Creation function for local mesh.
   \return Shared pointer to a LocalMesh.
 */
-template <class Device, class MeshType>
-LocalMesh<Device, MeshType>
+template <class MemorySpace, class MeshType>
+LocalMesh<MemorySpace, MeshType>
 createLocalMesh( const LocalGrid<MeshType>& local_grid )
 {
-    return LocalMesh<Device, MeshType>( local_grid );
+    return LocalMesh<MemorySpace, MeshType>( local_grid );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/src/Cajita_ParticleGridDistributor.hpp
+++ b/cajita/src/Cajita_ParticleGridDistributor.hpp
@@ -237,11 +237,11 @@ int migrateCount( const LocalGridType& local_grid,
   \return Distributor for later migration.
 */
 template <class LocalGridType, class PositionSliceType>
-Cabana::Distributor<typename PositionSliceType::device_type>
+Cabana::Distributor<typename PositionSliceType::memory_space>
 createParticleGridDistributor( const LocalGridType& local_grid,
                                PositionSliceType& positions )
 {
-    using device_type = typename PositionSliceType::device_type;
+    using memory_space = typename PositionSliceType::memory_space;
 
     // Get all 26 neighbor ranks.
     auto topology = getTopology( local_grid );
@@ -249,8 +249,8 @@ createParticleGridDistributor( const LocalGridType& local_grid,
     Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
         topology_host( topology.data(), topology.size() );
     auto topology_mirror =
-        Kokkos::create_mirror_view_and_copy( device_type(), topology_host );
-    Kokkos::View<int*, device_type> destinations(
+        Kokkos::create_mirror_view_and_copy( memory_space(), topology_host );
+    Kokkos::View<int*, memory_space> destinations(
         Kokkos::ViewAllocateWithoutInitializing( "destinations" ),
         positions.size() );
 
@@ -260,7 +260,7 @@ createParticleGridDistributor( const LocalGridType& local_grid,
                                   positions );
 
     // Create the Cabana distributor.
-    Cabana::Distributor<device_type> distributor(
+    Cabana::Distributor<memory_space> distributor(
         local_grid.globalGrid().comm(), destinations, topology );
     return distributor;
 }

--- a/cajita/src/Cajita_SparseDimPartitioner.hpp
+++ b/cajita/src/Cajita_SparseDimPartitioner.hpp
@@ -18,6 +18,9 @@
 
 #include <Cajita_Partitioner.hpp>
 #include <Cajita_SparseIndexSpace.hpp>
+
+#include <Cabana_Utils.hpp>
+
 #include <Kokkos_Core.hpp>
 
 #include <array>
@@ -30,11 +33,11 @@ namespace Cajita
 //---------------------------------------------------------------------------//
 /*!
   Sparse mesh block partitioner. (Current Version: Support 3D only)
-  \tparam Device Kokkos device type.
+  \tparam MemorySpace Kokkos memory space.
   \tparam CellPerTileDim Cells per tile per dimension.
   \tparam NumSpaceDim Dimemsion (The current version support 3D only)
 */
-template <typename Device, unsigned long long CellPerTileDim = 4,
+template <typename MemorySpace, unsigned long long CellPerTileDim = 4,
           std::size_t NumSpaceDim = 3>
 class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
 {
@@ -42,12 +45,17 @@ class SparseDimPartitioner : public BlockPartitioner<NumSpaceDim>
     //! dimension
     static constexpr std::size_t num_space_dim = NumSpaceDim;
 
-    //! Kokkos device type.
-    using device_type = Device;
-    //! Kokkos memory space.
-    using memory_space = typename Device::memory_space;
-    //! Kokkos execution space.
-    using execution_space = typename Device::execution_space;
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
+    //! Memory space.
+    using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Cabana::Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     //! Workload device view.
     using workload_view = Kokkos::View<int***, memory_space>;

--- a/cajita/src/Cajita_SparseHalo.hpp
+++ b/cajita/src/Cajita_SparseHalo.hpp
@@ -1291,18 +1291,18 @@ class SparseHalo
   \param pattern The pattern to build the sparse halo from.
   \param array The sparse array over which to build the halo.
 */
-template <class DeviceType, unsigned long long cellBitsPerTileDim,
+template <class MemorySpace, unsigned long long cellBitsPerTileDim,
           class DataTypes, class EntityType, class MeshType,
           class SparseMapType, class Pattern, typename Value = int,
           typename Key = uint64_t>
 auto createSparseHalo(
     const Pattern& pattern,
-    const std::shared_ptr<
-        SparseArray<DataTypes, DeviceType, EntityType, MeshType, SparseMapType>>
+    const std::shared_ptr<SparseArray<DataTypes, MemorySpace, EntityType,
+                                      MeshType, SparseMapType>>
         array )
 {
-    using array_type =
-        SparseArray<DataTypes, DeviceType, EntityType, MeshType, SparseMapType>;
+    using array_type = SparseArray<DataTypes, MemorySpace, EntityType, MeshType,
+                                   SparseMapType>;
     using memory_space = typename array_type::memory_space;
     static constexpr std::size_t num_space_dim = array_type::num_space_dim;
     return std::make_shared<

--- a/cajita/src/Cajita_Splines.hpp
+++ b/cajita/src/Cajita_Splines.hpp
@@ -791,10 +791,10 @@ setSplineData( SplinePhysicalDistance,
 
 //---------------------------------------------------------------------------//
 //! Evaluate spline data at a point in a uniform mesh.
-template <typename Scalar, int Order, std::size_t NumSpaceDim, class Device,
-          class EntityType, class DataTags>
+template <typename Scalar, int Order, std::size_t NumSpaceDim,
+          class MemorySpace, class EntityType, class DataTags>
 KOKKOS_INLINE_FUNCTION void evaluateSpline(
-    const LocalMesh<Device, UniformMesh<Scalar, NumSpaceDim>>& local_mesh,
+    const LocalMesh<MemorySpace, UniformMesh<Scalar, NumSpaceDim>>& local_mesh,
     const Scalar p[NumSpaceDim],
     SplineData<Scalar, Order, NumSpaceDim, EntityType, DataTags>& data )
 {

--- a/cajita/unit_test/tstArray2d.hpp
+++ b/cajita/unit_test/tstArray2d.hpp
@@ -208,7 +208,7 @@ void arrayTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, cell_layout );
 
     // Check the array.
     EXPECT_EQ( label, array->label() );
@@ -249,7 +249,7 @@ void arrayOpTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, cell_layout );
 
     // Assign a value to the entire the array.
     ArrayOp::assign( *array, 2.0, Ghost() );
@@ -279,7 +279,7 @@ void arrayOpTest()
                 EXPECT_DOUBLE_EQ( host_view( i, j, l ), scales[l] );
 
     // Create another array and update.
-    auto array_2 = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array_2 = createArray<double, TEST_MEMSPACE>( label, cell_layout );
     ArrayOp::assign( *array_2, 0.5, Ghost() );
     ArrayOp::update( *array, 3.0, *array_2, 2.0, Ghost() );
     Kokkos::deep_copy( host_view, array->view() );
@@ -419,7 +419,7 @@ void arrayBoundaryTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, node_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, node_layout );
 
     // Assign a value to the entire the array.
     // This test is simply to ensure the boundary index space is valid for the

--- a/cajita/unit_test/tstArray3d.hpp
+++ b/cajita/unit_test/tstArray3d.hpp
@@ -210,7 +210,7 @@ void arrayTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, cell_layout );
 
     // Check the array.
     EXPECT_EQ( label, array->label() );
@@ -252,7 +252,7 @@ void arrayOpTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, cell_layout );
 
     // Assign a value to the entire the array.
     ArrayOp::assign( *array, 2.0, Ghost() );
@@ -285,7 +285,7 @@ void arrayOpTest()
                     EXPECT_DOUBLE_EQ( host_view( i, j, k, l ), scales[l] );
 
     // Create another array and update.
-    auto array_2 = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array_2 = createArray<double, TEST_MEMSPACE>( label, cell_layout );
     ArrayOp::assign( *array_2, 0.5, Ghost() );
     ArrayOp::update( *array, 3.0, *array_2, 2.0, Ghost() );
     Kokkos::deep_copy( host_view, array->view() );
@@ -440,7 +440,7 @@ void arrayBoundaryTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, node_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, node_layout );
 
     // Assign a value to the entire the array.
     // This test is simply to ensure the boundary index space is valid for the

--- a/cajita/unit_test/tstBovWriter.hpp
+++ b/cajita/unit_test/tstBovWriter.hpp
@@ -68,7 +68,7 @@ void writeTest3d()
         // Create a scalar cell field and fill it with data.
         auto cell_layout = createArrayLayout( global_grid, 0, 1, Cell() );
         auto cell_field =
-            createArray<double, TEST_DEVICE>( "cell_field_3d", cell_layout );
+            createArray<double, TEST_MEMSPACE>( "cell_field_3d", cell_layout );
         auto cell_data = cell_field->view();
 
         // FIXME_SYCL (remove ifdef when newest Kokkos is required)
@@ -94,7 +94,7 @@ void writeTest3d()
         // Create a vector node field and fill it with data.
         auto node_layout = createArrayLayout( global_grid, 0, 3, Node() );
         auto node_field =
-            createArray<double, TEST_DEVICE>( "node_field_3d", node_layout );
+            createArray<double, TEST_MEMSPACE>( "node_field_3d", node_layout );
         auto node_data = node_field->view();
         Kokkos::parallel_for(
             "fill_node_field",
@@ -233,7 +233,7 @@ void writeTest2d()
         // Create a scalar cell field and fill it with data.
         auto cell_layout = createArrayLayout( global_grid, 0, 1, Cell() );
         auto cell_field =
-            createArray<double, TEST_DEVICE>( "cell_field_2d", cell_layout );
+            createArray<double, TEST_MEMSPACE>( "cell_field_2d", cell_layout );
         auto cell_data = cell_field->view();
 
         // FIXME_SYCL (remove ifdef when newest Kokkos is required)
@@ -256,7 +256,7 @@ void writeTest2d()
         // Create a vector node field and fill it with data.
         auto node_layout = createArrayLayout( global_grid, 0, 2, Node() );
         auto node_field =
-            createArray<double, TEST_DEVICE>( "node_field_2d", node_layout );
+            createArray<double, TEST_MEMSPACE>( "node_field_2d", node_layout );
         auto node_data = node_field->view();
         Kokkos::parallel_for(
             "fill_node_field",

--- a/cajita/unit_test/tstFastFourierTransform.hpp
+++ b/cajita/unit_test/tstFastFourierTransform.hpp
@@ -107,7 +107,7 @@ void forwardReverseTest3d( bool use_default, bool use_params )
 
     // Create a random vector to transform..
     auto vector_layout = createArrayLayout( local_grid, 2, Cell() );
-    auto lhs = createArray<double, TEST_DEVICE>( "lhs", vector_layout );
+    auto lhs = createArray<double, TEST_MEMSPACE>( "lhs", vector_layout );
     auto lhs_view = lhs->view();
     auto lhs_host =
         createArray<double, typename decltype( lhs_view )::array_layout,
@@ -182,7 +182,7 @@ void forwardReverseTest2d( bool use_default, bool use_params )
 
     // Create a random vector to transform..
     auto vector_layout = createArrayLayout( local_grid, 2, Cell() );
-    auto lhs = createArray<double, TEST_DEVICE>( "lhs", vector_layout );
+    auto lhs = createArray<double, TEST_MEMSPACE>( "lhs", vector_layout );
     auto lhs_view = lhs->view();
     auto lhs_host =
         createArray<double, typename decltype( lhs_view )::array_layout,

--- a/cajita/unit_test/tstFastFourierTransform.hpp
+++ b/cajita/unit_test/tstFastFourierTransform.hpp
@@ -50,9 +50,8 @@ void calculateFFT( bool use_default, bool use_params,
 
     if ( use_default && use_params )
     {
-        auto fft =
-            Experimental::createHeffteFastFourierTransform<double, TEST_DEVICE>(
-                *vector_layout, params );
+        auto fft = Experimental::createHeffteFastFourierTransform<
+            double, TEST_MEMSPACE>( *vector_layout, params );
         // Forward transform
         fft->forward( *lhs, Experimental::FFTScaleFull() );
         // Reverse transform
@@ -60,9 +59,8 @@ void calculateFFT( bool use_default, bool use_params,
     }
     else if ( use_default )
     {
-        auto fft =
-            Experimental::createHeffteFastFourierTransform<double, TEST_DEVICE>(
-                *vector_layout );
+        auto fft = Experimental::createHeffteFastFourierTransform<
+            double, TEST_MEMSPACE>( *vector_layout );
         fft->forward( *lhs, Experimental::FFTScaleFull() );
         fft->reverse( *lhs, Experimental::FFTScaleNone() );
     }
@@ -71,14 +69,14 @@ void calculateFFT( bool use_default, bool use_params,
     else if ( use_params )
     {
         auto fft = Experimental::createHeffteFastFourierTransform<
-            double, TEST_DEVICE, HostBackendType>( *vector_layout, params );
+            double, TEST_MEMSPACE, HostBackendType>( *vector_layout, params );
         fft->forward( *lhs, Experimental::FFTScaleFull() );
         fft->reverse( *lhs, Experimental::FFTScaleNone() );
     }
     else
     {
         auto fft = Experimental::createHeffteFastFourierTransform<
-            double, TEST_DEVICE, HostBackendType>( *vector_layout );
+            double, TEST_MEMSPACE, HostBackendType>( *vector_layout );
         fft->forward( *lhs, Experimental::FFTScaleFull() );
         fft->reverse( *lhs, Experimental::FFTScaleNone() );
     }

--- a/cajita/unit_test/tstGlobalGrid.hpp
+++ b/cajita/unit_test/tstGlobalGrid.hpp
@@ -431,7 +431,7 @@ void sparseGridTest3d()
     int num_step_rebalance = 100;
     int max_optimize_iteration = 10;
 
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
         global_num_cell, max_optimize_iteration );
 

--- a/cajita/unit_test/tstHalo2d.hpp
+++ b/cajita/unit_test/tstHalo2d.hpp
@@ -180,7 +180,7 @@ void gatherScatterTest( const ManualBlockPartitioner<2>& partitioner,
         // Create a cell array.
         auto layout =
             createArrayLayout( global_grid, array_halo_width, 4, Cell() );
-        auto array = createArray<double, TEST_DEVICE>( "array", layout );
+        auto array = createArray<double, TEST_MEMSPACE>( "array", layout );
 
         // Assign the owned cells a value of 1 and the rest 0.
         ArrayOp::assign( *array, 0.0, Ghost() );
@@ -210,22 +210,22 @@ void gatherScatterTest( const ManualBlockPartitioner<2>& partitioner,
         auto cell_layout =
             createArrayLayout( global_grid, array_halo_width, 4, Cell() );
         auto cell_array =
-            createArray<double, TEST_DEVICE>( "cell_array", cell_layout );
+            createArray<double, TEST_MEMSPACE>( "cell_array", cell_layout );
 
         auto node_layout =
             createArrayLayout( global_grid, array_halo_width, 3, Node() );
         auto node_array =
-            createArray<float, TEST_DEVICE>( "node_array", node_layout );
+            createArray<float, TEST_MEMSPACE>( "node_array", node_layout );
 
         auto face_i_layout = createArrayLayout( global_grid, array_halo_width,
                                                 4, Face<Dim::I>() );
         auto face_i_array =
-            createArray<double, TEST_DEVICE>( "face_i_array", face_i_layout );
+            createArray<double, TEST_MEMSPACE>( "face_i_array", face_i_layout );
 
         auto face_j_layout = createArrayLayout( global_grid, array_halo_width,
                                                 1, Face<Dim::J>() );
         auto face_j_array =
-            createArray<double, TEST_DEVICE>( "face_j_array", face_j_layout );
+            createArray<double, TEST_MEMSPACE>( "face_j_array", face_j_layout );
 
         // Assign the owned cells a value of 1 and the rest 0.
         ArrayOp::assign( *cell_array, 0.0, Ghost() );
@@ -333,7 +333,7 @@ void scatterReduceTest( const ReduceFunc& reduce )
     int dofs_per_cell = 4;
     auto cell_layout = createArrayLayout( global_grid, array_halo_width,
                                           dofs_per_cell, Cell() );
-    auto array = createArray<double, TEST_DEVICE>( "array", cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( "array", cell_layout );
 
     // Assign the rank to the array.
     int comm_rank;

--- a/cajita/unit_test/tstHalo3d.hpp
+++ b/cajita/unit_test/tstHalo3d.hpp
@@ -203,7 +203,7 @@ void gatherScatterTest( const ManualBlockPartitioner<3>& partitioner,
         // Create a cell array.
         auto layout =
             createArrayLayout( global_grid, array_halo_width, 4, Cell() );
-        auto array = createArray<double, TEST_DEVICE>( "array", layout );
+        auto array = createArray<double, TEST_MEMSPACE>( "array", layout );
 
         // Assign the owned cells a value of 1 and the rest 0.
         ArrayOp::assign( *array, 0.0, Ghost() );
@@ -233,42 +233,42 @@ void gatherScatterTest( const ManualBlockPartitioner<3>& partitioner,
         auto cell_layout =
             createArrayLayout( global_grid, array_halo_width, 4, Cell() );
         auto cell_array =
-            createArray<double, TEST_DEVICE>( "cell_array", cell_layout );
+            createArray<double, TEST_MEMSPACE>( "cell_array", cell_layout );
 
         auto node_layout =
             createArrayLayout( global_grid, array_halo_width, 3, Node() );
         auto node_array =
-            createArray<float, TEST_DEVICE>( "node_array", node_layout );
+            createArray<float, TEST_MEMSPACE>( "node_array", node_layout );
 
         auto face_i_layout = createArrayLayout( global_grid, array_halo_width,
                                                 4, Face<Dim::I>() );
         auto face_i_array =
-            createArray<double, TEST_DEVICE>( "face_i_array", face_i_layout );
+            createArray<double, TEST_MEMSPACE>( "face_i_array", face_i_layout );
 
         auto face_j_layout = createArrayLayout( global_grid, array_halo_width,
                                                 1, Face<Dim::J>() );
         auto face_j_array =
-            createArray<double, TEST_DEVICE>( "face_j_array", face_j_layout );
+            createArray<double, TEST_MEMSPACE>( "face_j_array", face_j_layout );
 
         auto face_k_layout = createArrayLayout( global_grid, array_halo_width,
                                                 2, Face<Dim::K>() );
         auto face_k_array =
-            createArray<float, TEST_DEVICE>( "face_k_array", face_k_layout );
+            createArray<float, TEST_MEMSPACE>( "face_k_array", face_k_layout );
 
         auto edge_i_layout = createArrayLayout( global_grid, array_halo_width,
                                                 3, Edge<Dim::I>() );
         auto edge_i_array =
-            createArray<float, TEST_DEVICE>( "edge_i_array", edge_i_layout );
+            createArray<float, TEST_MEMSPACE>( "edge_i_array", edge_i_layout );
 
         auto edge_j_layout = createArrayLayout( global_grid, array_halo_width,
                                                 2, Edge<Dim::J>() );
         auto edge_j_array =
-            createArray<float, TEST_DEVICE>( "edge_j_array", edge_j_layout );
+            createArray<float, TEST_MEMSPACE>( "edge_j_array", edge_j_layout );
 
         auto edge_k_layout = createArrayLayout( global_grid, array_halo_width,
                                                 1, Edge<Dim::K>() );
         auto edge_k_array =
-            createArray<double, TEST_DEVICE>( "edge_k_array", edge_k_layout );
+            createArray<double, TEST_MEMSPACE>( "edge_k_array", edge_k_layout );
 
         // Assign the owned cells a value of 1 and the rest 0.
         ArrayOp::assign( *cell_array, 0.0, Ghost() );
@@ -401,7 +401,7 @@ void scatterReduceTest( const ReduceFunc& reduce )
     int dofs_per_cell = 4;
     auto cell_layout = createArrayLayout( global_grid, array_halo_width,
                                           dofs_per_cell, Cell() );
-    auto array = createArray<double, TEST_DEVICE>( "array", cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( "array", cell_layout );
 
     // Assign the rank to the array.
     int comm_rank;

--- a/cajita/unit_test/tstIndexConversion.hpp
+++ b/cajita/unit_test/tstIndexConversion.hpp
@@ -60,7 +60,7 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
     // Create an array for global node indices.
     auto array_layout = createArrayLayout( local_grid, 3, EntityType() );
     auto global_index_array =
-        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+        createArray<int, TEST_MEMSPACE>( "global_indices", array_layout );
     auto index_view = global_index_array->view();
 
     // Fill the owned array with global indices.
@@ -91,7 +91,7 @@ void testConversion3d( const std::array<bool, 3>& is_dim_periodic )
     // Do a loop over ghosted local indices and fill with the index
     // conversion.
     auto global_l2g_array =
-        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+        createArray<int, TEST_MEMSPACE>( "global_indices", array_layout );
     auto l2g_view = global_l2g_array->view();
     auto ghost_local_space =
         local_grid->indexSpace( Ghost(), EntityType(), Local() );
@@ -159,7 +159,7 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
     // Create an array for global node indices.
     auto array_layout = createArrayLayout( local_grid, 2, EntityType() );
     auto global_index_array =
-        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+        createArray<int, TEST_MEMSPACE>( "global_indices", array_layout );
     auto index_view = global_index_array->view();
 
     // Fill the owned array with global indices.
@@ -187,7 +187,7 @@ void testConversion2d( const std::array<bool, 2>& is_dim_periodic )
     // Do a loop over ghosted local indices and fill with the index
     // conversion.
     auto global_l2g_array =
-        createArray<int, TEST_DEVICE>( "global_indices", array_layout );
+        createArray<int, TEST_MEMSPACE>( "global_indices", array_layout );
     auto l2g_view = global_l2g_array->view();
     auto ghost_local_space =
         local_grid->indexSpace( Ghost(), EntityType(), Local() );

--- a/cajita/unit_test/tstIndexSpace.hpp
+++ b/cajita/unit_test/tstIndexSpace.hpp
@@ -275,7 +275,7 @@ void executionTest()
     int max_i = 8;
     int size_i = 12;
     IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
+    Kokkos::View<double*, TEST_MEMSPACE> v1( "v1", size_i );
     Kokkos::parallel_for(
         "fill_rank_1", createExecutionPolicy( is1, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
@@ -294,7 +294,7 @@ void executionTest()
     int max_j = 9;
     int size_j = 18;
     IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
+    Kokkos::View<double**, TEST_MEMSPACE> v2( "v2", size_i, size_j );
     Kokkos::parallel_for(
         "fill_rank_2", createExecutionPolicy( is2, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
@@ -315,7 +315,7 @@ void executionTest()
     int max_k = 11;
     int size_k = 13;
     IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
-    Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
+    Kokkos::View<double***, TEST_MEMSPACE> v3( "v3", size_i, size_j, size_k );
     Kokkos::parallel_for(
         "fill_rank_3", createExecutionPolicy( is3, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ) {
@@ -341,8 +341,8 @@ void executionTest()
     int size_l = 14;
     IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
                        { max_i, max_j, max_k, max_l } );
-    Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
-                                              size_l );
+    Kokkos::View<double****, TEST_MEMSPACE> v4( "v4", size_i, size_j, size_k,
+                                                size_l );
     Kokkos::parallel_for(
         "fill_rank_4", createExecutionPolicy( is4, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k, const int l ) {
@@ -373,7 +373,7 @@ void subviewTest()
     int max_i = 8;
     int size_i = 12;
     IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
+    Kokkos::View<double*, TEST_MEMSPACE> v1( "v1", size_i );
     auto sv1 = createSubview( v1, is1 );
     Kokkos::deep_copy( sv1, 1.0 );
     auto v1_mirror =
@@ -391,7 +391,7 @@ void subviewTest()
     int max_j = 9;
     int size_j = 18;
     IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
+    Kokkos::View<double**, TEST_MEMSPACE> v2( "v2", size_i, size_j );
     auto sv2 = createSubview( v2, is2 );
     Kokkos::deep_copy( sv2, 1.0 );
     auto v2_mirror =
@@ -411,7 +411,7 @@ void subviewTest()
     int max_k = 11;
     int size_k = 13;
     IndexSpace<3> is3( { min_i, min_j, min_k }, { max_i, max_j, max_k } );
-    Kokkos::View<double***, TEST_DEVICE> v3( "v3", size_i, size_j, size_k );
+    Kokkos::View<double***, TEST_MEMSPACE> v3( "v3", size_i, size_j, size_k );
     auto sv3 = createSubview( v3, is3 );
     Kokkos::deep_copy( sv3, 1.0 );
     auto v3_mirror =
@@ -434,8 +434,8 @@ void subviewTest()
     int size_l = 14;
     IndexSpace<4> is4( { min_i, min_j, min_k, min_l },
                        { max_i, max_j, max_k, max_l } );
-    Kokkos::View<double****, TEST_DEVICE> v4( "v4", size_i, size_j, size_k,
-                                              size_l );
+    Kokkos::View<double****, TEST_MEMSPACE> v4( "v4", size_i, size_j, size_k,
+                                                size_l );
     auto sv4 = createSubview( v4, is4 );
     Kokkos::deep_copy( sv4, 1.0 );
     auto v4_mirror =

--- a/cajita/unit_test/tstInterpolation2d.hpp
+++ b/cajita/unit_test/tstInterpolation2d.hpp
@@ -53,12 +53,12 @@ void interpolationTest()
     // Create a  grid local_grid.
     int halo_width = 1;
     auto local_grid = createLocalGrid( global_grid, halo_width );
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Create a point in the center of every cell.
     auto cell_space = local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
-    Kokkos::View<double* [2], TEST_DEVICE> points(
+    Kokkos::View<double* [2], TEST_MEMSPACE> points(
         Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
     Kokkos::parallel_for(
         "fill_points", createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -78,8 +78,8 @@ void interpolationTest()
 
     // Create a scalar field on the grid.
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
-    auto scalar_grid_field =
-        createArray<double, TEST_DEVICE>( "scalar_grid_field", scalar_layout );
+    auto scalar_grid_field = createArray<double, TEST_MEMSPACE>(
+        "scalar_grid_field", scalar_layout );
     auto scalar_halo =
         createHalo( NodeHaloPattern<2>(), halo_width, *scalar_grid_field );
     auto scalar_grid_host =
@@ -87,27 +87,27 @@ void interpolationTest()
 
     // Create a vector field on the grid.
     auto vector_layout = createArrayLayout( local_grid, 2, Node() );
-    auto vector_grid_field =
-        createArray<double, TEST_DEVICE>( "vector_grid_field", vector_layout );
+    auto vector_grid_field = createArray<double, TEST_MEMSPACE>(
+        "vector_grid_field", vector_layout );
     auto vector_halo =
         createHalo( NodeHaloPattern<2>(), halo_width, *vector_grid_field );
     auto vector_grid_host =
         Kokkos::create_mirror_view( vector_grid_field->view() );
 
     // Create a scalar point field.
-    Kokkos::View<double*, TEST_DEVICE> scalar_point_field(
+    Kokkos::View<double*, TEST_MEMSPACE> scalar_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "scalar_point_field" ),
         num_point );
     auto scalar_point_host = Kokkos::create_mirror_view( scalar_point_field );
 
     // Create a vector point field.
-    Kokkos::View<double* [2], TEST_DEVICE> vector_point_field(
+    Kokkos::View<double* [2], TEST_MEMSPACE> vector_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "vector_point_field" ),
         num_point );
     auto vector_point_host = Kokkos::create_mirror_view( vector_point_field );
 
     // Create a tensor point field.
-    Kokkos::View<double* [2][2], TEST_DEVICE> tensor_point_field(
+    Kokkos::View<double* [2][2], TEST_MEMSPACE> tensor_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "tensor_point_field" ),
         num_point );
     auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );

--- a/cajita/unit_test/tstInterpolation3d.hpp
+++ b/cajita/unit_test/tstInterpolation3d.hpp
@@ -53,12 +53,12 @@ void interpolationTest()
     // Create a  grid local_grid.
     int halo_width = 1;
     auto local_grid = createLocalGrid( global_grid, halo_width );
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Create a point in the center of every cell.
     auto cell_space = local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
-    Kokkos::View<double* [3], TEST_DEVICE> points(
+    Kokkos::View<double* [3], TEST_MEMSPACE> points(
         Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
     Kokkos::parallel_for(
         "fill_points", createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -81,8 +81,8 @@ void interpolationTest()
 
     // Create a scalar field on the grid.
     auto scalar_layout = createArrayLayout( local_grid, 1, Node() );
-    auto scalar_grid_field =
-        createArray<double, TEST_DEVICE>( "scalar_grid_field", scalar_layout );
+    auto scalar_grid_field = createArray<double, TEST_MEMSPACE>(
+        "scalar_grid_field", scalar_layout );
     auto scalar_halo =
         createHalo( NodeHaloPattern<3>(), halo_width, *scalar_grid_field );
     auto scalar_grid_host =
@@ -90,27 +90,27 @@ void interpolationTest()
 
     // Create a vector field on the grid.
     auto vector_layout = createArrayLayout( local_grid, 3, Node() );
-    auto vector_grid_field =
-        createArray<double, TEST_DEVICE>( "vector_grid_field", vector_layout );
+    auto vector_grid_field = createArray<double, TEST_MEMSPACE>(
+        "vector_grid_field", vector_layout );
     auto vector_halo =
         createHalo( NodeHaloPattern<3>(), halo_width, *vector_grid_field );
     auto vector_grid_host =
         Kokkos::create_mirror_view( vector_grid_field->view() );
 
     // Create a scalar point field.
-    Kokkos::View<double*, TEST_DEVICE> scalar_point_field(
+    Kokkos::View<double*, TEST_MEMSPACE> scalar_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "scalar_point_field" ),
         num_point );
     auto scalar_point_host = Kokkos::create_mirror_view( scalar_point_field );
 
     // Create a vector point field.
-    Kokkos::View<double* [3], TEST_DEVICE> vector_point_field(
+    Kokkos::View<double* [3], TEST_MEMSPACE> vector_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "vector_point_field" ),
         num_point );
     auto vector_point_host = Kokkos::create_mirror_view( vector_point_field );
 
     // Create a tensor point field.
-    Kokkos::View<double* [3][3], TEST_DEVICE> tensor_point_field(
+    Kokkos::View<double* [3][3], TEST_MEMSPACE> tensor_point_field(
         Kokkos::ViewAllocateWithoutInitializing( "tensor_point_field" ),
         num_point );
     auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );

--- a/cajita/unit_test/tstLocalMesh2d.hpp
+++ b/cajita/unit_test/tstLocalMesh2d.hpp
@@ -42,12 +42,12 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
     const auto& global_grid = local_grid.globalGrid();
 
     // Check the low and high corners.
-    Kokkos::View<double[2], TEST_DEVICE> own_lc( "own_lc" );
-    Kokkos::View<double[2], TEST_DEVICE> own_hc( "own_hc" );
-    Kokkos::View<double[2], TEST_DEVICE> own_ext( "own_extent" );
-    Kokkos::View<double[2], TEST_DEVICE> ghost_lc( "ghost_lc" );
-    Kokkos::View<double[2], TEST_DEVICE> ghost_hc( "ghost_hc" );
-    Kokkos::View<double[2], TEST_DEVICE> ghost_ext( "ghost_extent" );
+    Kokkos::View<double[2], TEST_MEMSPACE> own_lc( "own_lc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> own_hc( "own_hc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> own_ext( "own_extent" );
+    Kokkos::View<double[2], TEST_MEMSPACE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> ghost_hc( "ghost_hc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> ghost_ext( "ghost_extent" );
 
     Kokkos::parallel_for(
         "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 2 ),
@@ -109,9 +109,10 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
     // Check the cell locations and measures.
     auto cell_space = local_grid.indexSpace( Ghost(), Cell(), Local() );
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", cell_space );
         Kokkos::parallel_for(
             "get_cell_coord",
             createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -143,9 +144,10 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
     // Check the node locations and measures.
     auto node_space = local_grid.indexSpace( Ghost(), Node(), Local() );
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", node_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", node_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", node_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", node_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", node_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", node_space );
         Kokkos::parallel_for(
             "get_node_coord",
             createExecutionPolicy( node_space, TEST_EXECSPACE() ),
@@ -179,9 +181,9 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Face<Dim::I>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", face_i_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_i_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_i_space );
+            createView<double, TEST_MEMSPACE>( "measure", face_i_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", face_i_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", face_i_space );
         Kokkos::parallel_for(
             "get_face_i_coord",
             createExecutionPolicy( face_i_space, TEST_EXECSPACE() ),
@@ -215,9 +217,9 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Face<Dim::J>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", face_j_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_j_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_j_space );
+            createView<double, TEST_MEMSPACE>( "measure", face_j_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", face_j_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", face_j_space );
         Kokkos::parallel_for(
             "get_face_j_coord",
             createExecutionPolicy( face_j_space, TEST_EXECSPACE() ),
@@ -252,9 +254,10 @@ void uniformLocalMeshTest2d( const LocalMeshType& local_mesh,
     std::cout << shared_cell_space.extent( 0 ) << " "
               << shared_cell_space.extent( 1 ) << std::endl;
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", cell_space );
         std::cout << loc_x.extent( 0 ) << " " << loc_x.extent( 1 ) << std::endl;
         Kokkos::parallel_for(
             "get_cell_coord",
@@ -312,7 +315,7 @@ void uniformTest2d( const std::array<int, 2>& ranks_per_dim,
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Test the local mesh.
     uniformLocalMeshTest2d( local_mesh, *local_grid, low_corner, cell_size,
@@ -344,7 +347,7 @@ void nonUniformTest2d( const std::array<int, 2>& ranks_per_dim,
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Test the local mesh.
     uniformLocalMeshTest2d( local_mesh, *local_grid, low_corner, cell_size,
@@ -387,7 +390,7 @@ void irregularTest2d( const std::array<int, 2>& ranks_per_dim )
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Get index spaces
     auto ghost_cell_local_space =
@@ -398,10 +401,10 @@ void irregularTest2d( const std::array<int, 2>& ranks_per_dim )
         local_grid->indexSpace( Own(), Cell(), Local() );
 
     // Check the low and high corners.
-    Kokkos::View<double[2], TEST_DEVICE> own_lc( "own_lc" );
-    Kokkos::View<double[2], TEST_DEVICE> own_hc( "own_hc" );
-    Kokkos::View<double[2], TEST_DEVICE> ghost_lc( "ghost_lc" );
-    Kokkos::View<double[2], TEST_DEVICE> ghost_hc( "ghost_hc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> own_lc( "own_lc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> own_hc( "own_hc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[2], TEST_MEMSPACE> ghost_hc( "ghost_hc" );
 
     Kokkos::parallel_for(
         "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 2 ),
@@ -446,11 +449,11 @@ void irregularTest2d( const std::array<int, 2>& ranks_per_dim )
                              own_cell_local_space.min( Dim::J ) ) );
 
     // Check the cell locations and measures.
-    auto cell_measure = createView<double, TEST_DEVICE>(
+    auto cell_measure = createView<double, TEST_MEMSPACE>(
         "cell_measures", ghost_cell_local_space );
-    auto cell_location_x = createView<double, TEST_DEVICE>(
+    auto cell_location_x = createView<double, TEST_MEMSPACE>(
         "cell_locations_x", ghost_cell_local_space );
-    auto cell_location_y = createView<double, TEST_DEVICE>(
+    auto cell_location_y = createView<double, TEST_MEMSPACE>(
         "cell_locations_y", ghost_cell_local_space );
     Kokkos::parallel_for(
         "get_cell_data",

--- a/cajita/unit_test/tstLocalMesh3d.hpp
+++ b/cajita/unit_test/tstLocalMesh3d.hpp
@@ -42,12 +42,12 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
     const auto& global_grid = local_grid.globalGrid();
 
     // Check the low and high corners.
-    Kokkos::View<double[3], TEST_DEVICE> own_lc( "own_lc" );
-    Kokkos::View<double[3], TEST_DEVICE> own_hc( "own_hc" );
-    Kokkos::View<double[3], TEST_DEVICE> own_ext( "own_extent" );
-    Kokkos::View<double[3], TEST_DEVICE> ghost_lc( "ghost_lc" );
-    Kokkos::View<double[3], TEST_DEVICE> ghost_hc( "ghost_hc" );
-    Kokkos::View<double[3], TEST_DEVICE> ghost_ext( "ghost_extent" );
+    Kokkos::View<double[3], TEST_MEMSPACE> own_lc( "own_lc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> own_hc( "own_hc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> own_ext( "own_extent" );
+    Kokkos::View<double[3], TEST_MEMSPACE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> ghost_hc( "ghost_hc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> ghost_ext( "ghost_extent" );
 
     Kokkos::parallel_for(
         "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 3 ),
@@ -109,10 +109,11 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
     // Check the cell locations and measures.
     auto cell_space = local_grid.indexSpace( Ghost(), Cell(), Local() );
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", cell_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", cell_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", cell_space );
         Kokkos::parallel_for(
             "get_cell_coord",
             createExecutionPolicy( cell_space, TEST_EXECSPACE() ),
@@ -154,10 +155,11 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
     // Check the node locations and measures.
     auto node_space = local_grid.indexSpace( Ghost(), Node(), Local() );
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", node_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", node_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", node_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", node_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", node_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", node_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", node_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", node_space );
         Kokkos::parallel_for(
             "get_node_coord",
             createExecutionPolicy( node_space, TEST_EXECSPACE() ),
@@ -197,10 +199,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Face<Dim::I>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", face_i_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_i_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_i_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", face_i_space );
+            createView<double, TEST_MEMSPACE>( "measure", face_i_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", face_i_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", face_i_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", face_i_space );
         Kokkos::parallel_for(
             "get_face_i_coord",
             createExecutionPolicy( face_i_space, TEST_EXECSPACE() ),
@@ -243,10 +245,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Face<Dim::J>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", face_j_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_j_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_j_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", face_j_space );
+            createView<double, TEST_MEMSPACE>( "measure", face_j_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", face_j_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", face_j_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", face_j_space );
         Kokkos::parallel_for(
             "get_face_j_coord",
             createExecutionPolicy( face_j_space, TEST_EXECSPACE() ),
@@ -289,10 +291,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Face<Dim::K>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", face_k_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", face_k_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", face_k_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", face_k_space );
+            createView<double, TEST_MEMSPACE>( "measure", face_k_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", face_k_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", face_k_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", face_k_space );
         Kokkos::parallel_for(
             "get_face_k_coord",
             createExecutionPolicy( face_k_space, TEST_EXECSPACE() ),
@@ -335,10 +337,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Edge<Dim::I>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", edge_i_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", edge_i_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", edge_i_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", edge_i_space );
+            createView<double, TEST_MEMSPACE>( "measure", edge_i_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", edge_i_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", edge_i_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", edge_i_space );
         Kokkos::parallel_for(
             "get_edge_i_coord",
             createExecutionPolicy( edge_i_space, TEST_EXECSPACE() ),
@@ -379,10 +381,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Edge<Dim::J>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", edge_j_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", edge_j_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", edge_j_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", edge_j_space );
+            createView<double, TEST_MEMSPACE>( "measure", edge_j_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", edge_j_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", edge_j_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", edge_j_space );
         Kokkos::parallel_for(
             "get_edge_j_coord",
             createExecutionPolicy( edge_j_space, TEST_EXECSPACE() ),
@@ -423,10 +425,10 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
         local_grid.indexSpace( Ghost(), Edge<Dim::K>(), Local() );
     {
         auto measure =
-            createView<double, TEST_DEVICE>( "measure", edge_k_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", edge_k_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", edge_k_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", edge_k_space );
+            createView<double, TEST_MEMSPACE>( "measure", edge_k_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", edge_k_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", edge_k_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", edge_k_space );
         Kokkos::parallel_for(
             "get_edge_k_coord",
             createExecutionPolicy( edge_k_space, TEST_EXECSPACE() ),
@@ -466,10 +468,11 @@ void uniformLocalMeshTest3d( const LocalMeshType& local_mesh,
     auto shared_cell_space =
         local_grid.sharedIndexSpace( Cajita::Own(), Cajita::Cell(), 0, 1, 0 );
     {
-        auto measure = createView<double, TEST_DEVICE>( "measure", cell_space );
-        auto loc_x = createView<double, TEST_DEVICE>( "loc_x", cell_space );
-        auto loc_y = createView<double, TEST_DEVICE>( "loc_y", cell_space );
-        auto loc_z = createView<double, TEST_DEVICE>( "loc_z", cell_space );
+        auto measure =
+            createView<double, TEST_MEMSPACE>( "measure", cell_space );
+        auto loc_x = createView<double, TEST_MEMSPACE>( "loc_x", cell_space );
+        auto loc_y = createView<double, TEST_MEMSPACE>( "loc_y", cell_space );
+        auto loc_z = createView<double, TEST_MEMSPACE>( "loc_z", cell_space );
         Kokkos::parallel_for(
             "get_cell_coord",
             createExecutionPolicy( shared_cell_space, TEST_EXECSPACE() ),
@@ -533,7 +536,7 @@ void uniformTest3d( const std::array<int, 3>& ranks_per_dim,
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Test the local mesh.
     uniformLocalMeshTest3d( local_mesh, *local_grid, low_corner, cell_size,
@@ -565,7 +568,7 @@ void nonUniformTest3d( const std::array<int, 3>& ranks_per_dim,
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Test the local mesh.
     uniformLocalMeshTest3d( local_mesh, *local_grid, low_corner, cell_size,
@@ -612,7 +615,7 @@ void irregularTest3d( const std::array<int, 3>& ranks_per_dim )
     auto local_grid = createLocalGrid( global_grid, halo_width );
 
     // Create the local mesh.
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Get index spaces
     auto ghost_cell_local_space =
@@ -623,10 +626,10 @@ void irregularTest3d( const std::array<int, 3>& ranks_per_dim )
         local_grid->indexSpace( Own(), Cell(), Local() );
 
     // Check the low and high corners.
-    Kokkos::View<double[3], TEST_DEVICE> own_lc( "own_lc" );
-    Kokkos::View<double[3], TEST_DEVICE> own_hc( "own_hc" );
-    Kokkos::View<double[3], TEST_DEVICE> ghost_lc( "ghost_lc" );
-    Kokkos::View<double[3], TEST_DEVICE> ghost_hc( "ghost_hc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> own_lc( "own_lc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> own_hc( "own_hc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> ghost_lc( "ghost_lc" );
+    Kokkos::View<double[3], TEST_MEMSPACE> ghost_hc( "ghost_hc" );
 
     Kokkos::parallel_for(
         "get_corners", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, 3 ),
@@ -681,13 +684,13 @@ void irregularTest3d( const std::array<int, 3>& ranks_per_dim )
                              own_cell_local_space.min( Dim::K ) ) );
 
     // Check the cell locations and measures.
-    auto cell_measure = createView<double, TEST_DEVICE>(
+    auto cell_measure = createView<double, TEST_MEMSPACE>(
         "cell_measures", ghost_cell_local_space );
-    auto cell_location_x = createView<double, TEST_DEVICE>(
+    auto cell_location_x = createView<double, TEST_MEMSPACE>(
         "cell_locations_x", ghost_cell_local_space );
-    auto cell_location_y = createView<double, TEST_DEVICE>(
+    auto cell_location_y = createView<double, TEST_MEMSPACE>(
         "cell_locations_y", ghost_cell_local_space );
-    auto cell_location_z = createView<double, TEST_DEVICE>(
+    auto cell_location_z = createView<double, TEST_MEMSPACE>(
         "cell_locations_z", ghost_cell_local_space );
     Kokkos::parallel_for(
         "get_cell_data",

--- a/cajita/unit_test/tstParallel.hpp
+++ b/cajita/unit_test/tstParallel.hpp
@@ -38,7 +38,7 @@ struct ReduceTag
 
 struct TestFunctor1
 {
-    Kokkos::View<double*, TEST_DEVICE> v;
+    Kokkos::View<double*, TEST_MEMSPACE> v;
 
     KOKKOS_INLINE_FUNCTION
     void operator()( const ForTag&, const int i ) const { v( i ) = 2.0; }
@@ -52,7 +52,7 @@ struct TestFunctor1
 
 struct TestFunctor2
 {
-    Kokkos::View<double**, TEST_DEVICE> v;
+    Kokkos::View<double**, TEST_MEMSPACE> v;
 
     KOKKOS_INLINE_FUNCTION
     void operator()( const ForTag&, const int i, const int j ) const
@@ -70,7 +70,7 @@ struct TestFunctor2
 
 struct TestFunctorArray
 {
-    Kokkos::View<double****, TEST_DEVICE> v;
+    Kokkos::View<double****, TEST_MEMSPACE> v;
 
     KOKKOS_INLINE_FUNCTION
     void operator()( const ForTag&, const int i, const int j,
@@ -97,7 +97,7 @@ void parallelIndexSpaceTest()
     int max_i = 8;
     int size_i = 12;
     IndexSpace<1> is1( { min_i }, { max_i } );
-    Kokkos::View<double*, TEST_DEVICE> v1( "v1", size_i );
+    Kokkos::View<double*, TEST_MEMSPACE> v1( "v1", size_i );
     grid_parallel_for(
         "fill_rank_1", TEST_EXECSPACE(), is1,
         KOKKOS_LAMBDA( const int i ) { v1( i ) = 1.0; } );
@@ -143,7 +143,7 @@ void parallelIndexSpaceTest()
     int max_j = 9;
     int size_j = 18;
     IndexSpace<2> is2( { min_i, min_j }, { max_i, max_j } );
-    Kokkos::View<double**, TEST_DEVICE> v2( "v2", size_i, size_j );
+    Kokkos::View<double**, TEST_MEMSPACE> v2( "v2", size_i, size_j );
     grid_parallel_for(
         "fill_rank_2", TEST_EXECSPACE(), is2,
         KOKKOS_LAMBDA( const int i, const int j ) { v2( i, j ) = 1.0; } );
@@ -222,7 +222,7 @@ void parallelLocalGridTest()
 
     // Create an array.
     std::string label( "test_array" );
-    auto array = createArray<double, TEST_DEVICE>( label, cell_layout );
+    auto array = createArray<double, TEST_MEMSPACE>( label, cell_layout );
 
     // Assign a value to the entire the array.
     auto array_view = array->view();

--- a/cajita/unit_test/tstParticleGridDistributor2d.hpp
+++ b/cajita/unit_test/tstParticleGridDistributor2d.hpp
@@ -100,7 +100,7 @@ void migrateTest( const GridType global_grid, const double cell_size,
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
     auto coords_mirror = Cabana::slice<0>( particles_mirror, "coords" );
 
     // Redistribute the particle AoSoA in place.
@@ -211,7 +211,7 @@ void localOnlyTest( const GridType global_grid, const double cell_size )
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
 
     // Redistribute the particles.
     auto coords_mirror = Cabana::slice<0>( particles_mirror, "coords" );
@@ -303,7 +303,7 @@ void removeOutsideTest( const GridType global_grid )
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
 
     // Check particles were created.
     EXPECT_GT( particles_mirror.size(), 0 );

--- a/cajita/unit_test/tstParticleGridDistributor3d.hpp
+++ b/cajita/unit_test/tstParticleGridDistributor3d.hpp
@@ -109,7 +109,7 @@ void migrateTest( const GridType global_grid, const double cell_size,
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
     auto coords_mirror = Cabana::slice<0>( particles_mirror, "coords" );
 
     // Redistribute the particle AoSoA in place.
@@ -226,7 +226,7 @@ void localOnlyTest( const GridType global_grid, const double cell_size )
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
 
     // Redistribute the particles.
     auto coords_mirror = Cabana::slice<0>( particles_mirror, "coords" );
@@ -321,7 +321,7 @@ void removeOutsideTest( const GridType global_grid )
 
     // Copy to the device space.
     auto particles_mirror =
-        Cabana::create_mirror_view_and_copy( TEST_DEVICE(), particles );
+        Cabana::create_mirror_view_and_copy( TEST_MEMSPACE(), particles );
 
     // Check particles were created.
     EXPECT_GT( particles_mirror.size(), 0 );

--- a/cajita/unit_test/tstSparseArray.hpp
+++ b/cajita/unit_test/tstSparseArray.hpp
@@ -185,7 +185,7 @@ void sparse_array_test( int par_num, EntityType entity )
     int workload_num = size_per_dim * size_per_dim * size_per_dim;
     int num_step_rebalance = 200;
     int max_optimize_iteration = 10;
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
         global_num_cell, max_optimize_iteration );
 
@@ -243,7 +243,7 @@ void sparse_array_test( int par_num, EntityType entity )
     using DataTypes = Cabana::MemberTypes<int[3], float, double[3], int[2]>;
     auto test_layout =
         createSparseArrayLayout<DataTypes>( local_grid, sparse_map, entity );
-    auto test_array = createSparseArray<TEST_DEVICE>(
+    auto test_array = createSparseArray<TEST_MEMSPACE>(
         std::string( "test_sparse_grid" ), *test_layout );
 
     // insert particles
@@ -261,7 +261,7 @@ void sparse_array_test( int par_num, EntityType entity )
 
     // check particle insertion results
     int cell_num = par_view.extent( 0 ) * 27;
-    Kokkos::View<int*, TEST_DEVICE> qtid_res(
+    Kokkos::View<int*, TEST_MEMSPACE> qtid_res(
         Kokkos::ViewAllocateWithoutInitializing( "query_tile_id" ), cell_num );
 
     T dx_inv = 1.0f / cell_size;
@@ -303,7 +303,7 @@ void sparse_array_test( int par_num, EntityType entity )
     // assign value
     auto& map = test_layout->sparseMap();
     // tile ijk, cell ijk, tile key
-    Kokkos::View<int* [7], TEST_DEVICE> info(
+    Kokkos::View<int* [7], TEST_MEMSPACE> info(
         Kokkos::ViewAllocateWithoutInitializing( "tile_cell_info" ),
         test_array->size() );
     auto array = *test_array;
@@ -430,7 +430,7 @@ void full_occupy_test( EntityType entity )
     int workload_num = size_per_dim * size_per_dim * size_per_dim;
     int num_step_rebalance = 200;
     int max_optimize_iteration = 10;
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
         global_num_cell, max_optimize_iteration );
 
@@ -474,7 +474,7 @@ void full_occupy_test( EntityType entity )
     using DataTypes = Cabana::MemberTypes<int[3], float[3], int[2]>;
     auto test_layout =
         createSparseArrayLayout<DataTypes>( local_grid, sparse_map, entity );
-    auto test_array = createSparseArray<TEST_DEVICE>(
+    auto test_array = createSparseArray<TEST_MEMSPACE>(
         std::string( "test_sparse_grid" ), *test_layout );
 
     // valid tile range
@@ -498,7 +498,7 @@ void full_occupy_test( EntityType entity )
     test_array->resize( map.sizeCell() );
 
     // assign value
-    Kokkos::View<int*** [2], TEST_DEVICE> info(
+    Kokkos::View<int*** [2], TEST_MEMSPACE> info(
         Kokkos::ViewAllocateWithoutInitializing( "tile_cell_info" ),
         size_tile_per_dim, size_tile_per_dim, size_tile_per_dim );
 

--- a/cajita/unit_test/tstSparseDimPartitioner.hpp
+++ b/cajita/unit_test/tstSparseDimPartitioner.hpp
@@ -47,7 +47,7 @@ void uniform_distribution_automatic_rank()
         size_tile_per_dim * cell_per_tile_dim };
 
     // partitioner
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
         global_cells_per_dim, max_optimize_iteration );
 
@@ -309,7 +309,7 @@ void random_distribution_automatic_rank( int occupy_num_per_rank,
                                                 size_per_dim };
 
     // partitioner
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, particle_num, num_step_rebalance,
         global_cells_per_dim, max_optimize_iteration );
 

--- a/cajita/unit_test/tstSparseHalo.hpp
+++ b/cajita/unit_test/tstSparseHalo.hpp
@@ -418,7 +418,7 @@ void haloScatterAndGatherTest( ReduceOp reduce_op, EntityType entity )
         size_cell_per_dim * size_cell_per_dim * size_cell_per_dim;
     int num_step_rebalance = 200;
     int max_optimize_iteration = 10;
-    SparseDimPartitioner<TEST_DEVICE, cell_per_tile_dim> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, cell_per_tile_dim> partitioner(
         MPI_COMM_WORLD, max_workload_coeff, workload_num, num_step_rebalance,
         global_num_cell, max_optimize_iteration );
 
@@ -461,10 +461,10 @@ void haloScatterAndGatherTest( ReduceOp reduce_op, EntityType entity )
     using DataTypes = Cabana::MemberTypes<double[3], float>;
     auto sparse_layout =
         createSparseArrayLayout<DataTypes>( local_grid, sparse_map, entity );
-    auto sparse_array = createSparseArray<TEST_DEVICE>(
+    auto sparse_array = createSparseArray<TEST_MEMSPACE>(
         std::string( "test_sparse_grid" ), *sparse_layout );
 
-    auto halo = createSparseHalo<TEST_DEVICE, cell_bits_per_tile_dim>(
+    auto halo = createSparseHalo<TEST_MEMSPACE, cell_bits_per_tile_dim>(
         NodeHaloPattern<3>(), sparse_array );
 
     // sample valid halos on rank 0 and broadcast to other ranks
@@ -525,7 +525,7 @@ void haloScatterAndGatherTest( ReduceOp reduce_op, EntityType entity )
     /// every valid ghosted halo would have value 0.1x
     /// no other grids will be registered
 
-    Kokkos::View<int* [3], TEST_DEVICE> info(
+    Kokkos::View<int* [3], TEST_MEMSPACE> info(
         Kokkos::ViewAllocateWithoutInitializing( "tile_cell_info" ),
         sparse_array->size() );
     {

--- a/cajita/unit_test/tstSparseIndexSpace.hpp
+++ b/cajita/unit_test/tstSparseIndexSpace.hpp
@@ -40,7 +40,7 @@ void testAtomicOr()
                 }
     Kokkos::deep_copy( tile_insert_record, tile_insert_record_mirror );
 
-    Kokkos::View<bool[size][size][size], TEST_DEVICE> tile_label( "label" );
+    Kokkos::View<bool[size][size][size], TEST_MEMSPACE> tile_label( "label" );
 
     TEST_EXECSPACE().fence();
     Kokkos::parallel_for(
@@ -89,7 +89,7 @@ void testAtomicOrPro()
                 }
     Kokkos::deep_copy( tile_insert_record, tile_insert_record_mirror );
 
-    Kokkos::View<bool[size][size][size], TEST_DEVICE> tile_label( "label" );
+    Kokkos::View<bool[size][size][size], TEST_MEMSPACE> tile_label( "label" );
 
     TEST_EXECSPACE().fence();
     Kokkos::parallel_for(
@@ -128,10 +128,10 @@ void testTileSpace()
     constexpr int size_bit = SizeBit;
     constexpr int size = Size;
     using TIS = TileMap<size_bit, size, size * size>;
-    Kokkos::View<int[size][size][size], TEST_DEVICE> offset_res( "offset" );
-    Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
-    Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
-    Kokkos::View<int[size][size][size], TEST_DEVICE> k_res( "k" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> offset_res( "offset" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> i_res( "i" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> j_res( "j" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> k_res( "k" );
     TIS tis;
     Kokkos::parallel_for(
         Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ),
@@ -183,9 +183,9 @@ void testBlockSpace()
              cell_num_per_tile, HashType, key_type, value_type>
         bis( size, size, size, pre_alloc_size );
 
-    Kokkos::View<int[size][size][size], TEST_DEVICE> i_res( "i" );
-    Kokkos::View<int[size][size][size], TEST_DEVICE> j_res( "j" );
-    Kokkos::View<int[size][size][size], TEST_DEVICE> k_res( "k" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> i_res( "i" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> j_res( "j" );
+    Kokkos::View<int[size][size][size], TEST_MEMSPACE> k_res( "k" );
     TEST_EXECSPACE().fence();
     Kokkos::parallel_for(
         Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ), KOKKOS_LAMBDA( int i ) {
@@ -218,7 +218,8 @@ void testBlockSpace()
             }
     bool test[size * size * size];
 
-    Kokkos::View<int[size * size * size], TEST_DEVICE> id_find_res( "id_find" );
+    Kokkos::View<int[size * size * size], TEST_MEMSPACE> id_find_res(
+        "id_find" );
     Kokkos::parallel_for(
         Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size ), KOKKOS_LAMBDA( int i ) {
             for ( int j = 0; j < size; j++ )
@@ -286,8 +287,8 @@ void testSparseMapFullInsert()
     auto cnt = sis.cell_num_per_tile;
     EXPECT_EQ( cnt, 64 );
 
-    Kokkos::View<int***, TEST_DEVICE> qid_res( "query_id", size[0], size[1],
-                                               size[2] );
+    Kokkos::View<int***, TEST_MEMSPACE> qid_res( "query_id", size[0], size[1],
+                                                 size[2] );
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<TEST_EXECSPACE>( 0, size_per_dim ),
@@ -403,14 +404,14 @@ void testSparseMapSparseInsert()
                       tile_j * size_tile_per_dim + tile_k] = 1;
     }
     int valid_cell_num = cell_register.size();
-    Kokkos::View<int*, TEST_DEVICE> dev_cell_1did( "cell_ids_1d_dev",
-                                                   insert_cell_num );
+    Kokkos::View<int*, TEST_MEMSPACE> dev_cell_1did( "cell_ids_1d_dev",
+                                                     insert_cell_num );
     Kokkos::deep_copy( dev_cell_1did, host_cell_1did );
 
-    Kokkos::View<int*, TEST_DEVICE> qtkey_res( "query_tile_key",
-                                               insert_cell_num );
-    Kokkos::View<int*, TEST_DEVICE> qtid_res( "query_tile_id",
-                                              insert_cell_num );
+    Kokkos::View<int*, TEST_MEMSPACE> qtkey_res( "query_tile_key",
+                                                 insert_cell_num );
+    Kokkos::View<int*, TEST_MEMSPACE> qtid_res( "query_tile_id",
+                                                insert_cell_num );
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy<TEST_EXECSPACE>( 0, insert_cell_num ),
@@ -515,7 +516,7 @@ void testSparseMapReinsert()
     auto sis = createSparseMap<TEST_EXECSPACE>( global_mesh, pre_alloc_size );
 
     constexpr int insert_cell_num = 50;
-    Kokkos::View<int*, TEST_DEVICE> qid_res( "query_id", insert_cell_num );
+    Kokkos::View<int*, TEST_MEMSPACE> qid_res( "query_id", insert_cell_num );
     Kokkos::View<int*, Kokkos::HostSpace> host_cell_1did( "cell_ids_1d",
                                                           insert_cell_num );
     std::map<int, int> cell_register;
@@ -532,8 +533,8 @@ void testSparseMapReinsert()
                       tile_j * size_tile_per_dim + tile_k] = 1;
     }
     int valid_cell_num = cell_register.size();
-    Kokkos::View<int*, TEST_DEVICE> dev_cell_1did( "cell_ids_1d_dev",
-                                                   insert_cell_num );
+    Kokkos::View<int*, TEST_MEMSPACE> dev_cell_1did( "cell_ids_1d_dev",
+                                                     insert_cell_num );
     Kokkos::deep_copy( dev_cell_1did, host_cell_1did );
 
     Kokkos::parallel_for(

--- a/cajita/unit_test/tstSparseLocalGrid.hpp
+++ b/cajita/unit_test/tstSparseLocalGrid.hpp
@@ -46,7 +46,7 @@ void sparseLocalGridTest( EntityType t2 )
 
     // Create and initialize sparse partitioner
     std::array<bool, 3> periodic = { false, false, false };
-    SparseDimPartitioner<TEST_DEVICE, 4> partitioner(
+    SparseDimPartitioner<TEST_MEMSPACE, 4> partitioner(
         MPI_COMM_WORLD, 1.5, 16 * 32, 100, global_num_cell, 10 );
     auto ranks_per_dim =
         partitioner.ranksPerDimension( MPI_COMM_WORLD, global_num_cell );

--- a/cajita/unit_test/tstSplineEvaluation2d.hpp
+++ b/cajita/unit_test/tstSplineEvaluation2d.hpp
@@ -32,7 +32,7 @@ using namespace Cajita;
 namespace Test
 {
 //---------------------------------------------------------------------------//
-template <class Scalar, class EntityType, int SplineOrder, class DeviceType,
+template <class Scalar, class EntityType, int SplineOrder, class MemorySpace,
           class DataTags>
 struct PointSet
 {
@@ -53,9 +53,8 @@ struct PointSet
     using spline_data_tags = DataTags;
 
     // Kokkos types.
-    using device_type = DeviceType;
-    using execution_space = typename device_type::execution_space;
-    using memory_space = typename device_type::memory_space;
+    using memory_space = MemorySpace;
+    using execution_space = typename memory_space::execution_space;
 
     // Number of points.
     std::size_t num_point;
@@ -64,24 +63,24 @@ struct PointSet
     std::size_t num_alloc;
 
     // Physical cell size. (point,dim)
-    Kokkos::View<Scalar* [2], device_type> cell_size;
+    Kokkos::View<Scalar* [2], memory_space> cell_size;
 
     // Point logical position. (point,dim)
-    Kokkos::View<Scalar* [2], device_type> logical_coords;
+    Kokkos::View<Scalar* [2], memory_space> logical_coords;
 
     // Point mesh stencil. (point,ns,dim)
-    Kokkos::View<int* [ns][2], device_type> stencil;
+    Kokkos::View<int* [ns][2], memory_space> stencil;
 
     // Point basis values at entities in stencil. (point,ns,dim)
-    Kokkos::View<Scalar* [ns][2], device_type> value;
+    Kokkos::View<Scalar* [ns][2], memory_space> value;
 
     // Point basis gradient values at entities in stencil
     // (point,ni,nj,dim)
-    Kokkos::View<Scalar* [ns][ns][2], device_type> gradient;
+    Kokkos::View<Scalar* [ns][ns][2], memory_space> gradient;
 
     // Point basis distance values at entities in stencil
     // (point,ns,dim)
-    Kokkos::View<Scalar* [ns][2], device_type> distance;
+    Kokkos::View<Scalar* [ns][2], memory_space> distance;
 
     // Mesh uniform cell size.
     Scalar dx;
@@ -190,9 +189,7 @@ void updatePointSet( const LocalMeshType& local_mesh, EntityType,
 //---------------------------------------------------------------------------//
 template <class DataTags, class PointCoordinates, class EntityType,
           int SplineOrder>
-PointSet<typename PointCoordinates::value_type, EntityType, SplineOrder,
-         typename PointCoordinates::device_type, DataTags>
-createPointSet(
+auto createPointSet(
     const PointCoordinates& points, const std::size_t num_point,
     const std::size_t num_alloc,
     const LocalGrid<UniformMesh<typename PointCoordinates::value_type, 2>>&
@@ -201,10 +198,10 @@ createPointSet(
 {
     using scalar_type = typename PointCoordinates::value_type;
 
-    using device_type = typename PointCoordinates::device_type;
+    using memory_space = typename PointCoordinates::memory_space;
 
     using set_type =
-        PointSet<scalar_type, EntityType, SplineOrder, device_type, DataTags>;
+        PointSet<scalar_type, EntityType, SplineOrder, memory_space, DataTags>;
 
     set_type point_set;
 
@@ -216,27 +213,27 @@ createPointSet(
     point_set.num_point = num_point;
     point_set.num_alloc = num_alloc;
 
-    point_set.cell_size = Kokkos::View<scalar_type* [2], device_type>(
+    point_set.cell_size = Kokkos::View<scalar_type* [2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::cell_size" ),
         num_alloc );
 
-    point_set.logical_coords = Kokkos::View<scalar_type* [2], device_type>(
+    point_set.logical_coords = Kokkos::View<scalar_type* [2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::logical_coords" ),
         num_alloc );
 
-    point_set.stencil = Kokkos::View<int* [ns][2], device_type>(
+    point_set.stencil = Kokkos::View<int* [ns][2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::stencil" ),
         num_alloc );
 
-    point_set.value = Kokkos::View<scalar_type* [ns][2], device_type>(
+    point_set.value = Kokkos::View<scalar_type* [ns][2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::value" ),
         num_alloc );
 
-    point_set.gradient = Kokkos::View<scalar_type* [ns][ns][2], device_type>(
+    point_set.gradient = Kokkos::View<scalar_type* [ns][ns][2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::gradients" ),
         num_alloc );
 
-    point_set.distance = Kokkos::View<scalar_type* [ns][2], device_type>(
+    point_set.distance = Kokkos::View<scalar_type* [ns][2], memory_space>(
         Kokkos::ViewAllocateWithoutInitializing( "PointSet::distance" ),
         num_alloc );
 
@@ -280,12 +277,12 @@ void splineEvaluationTest()
     // Create a local grid.
     int halo_width = 1;
     auto local_grid = createLocalGrid( global_grid, halo_width );
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh = createLocalMesh<TEST_MEMSPACE>( *local_grid );
 
     // Create a point in the center of every cell.
     auto cell_space = local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
-    Kokkos::View<double* [2], TEST_DEVICE> points(
+    Kokkos::View<double* [2], TEST_MEMSPACE> points(
         Kokkos::ViewAllocateWithoutInitializing( "points" ), num_point );
     Kokkos::parallel_for(
         "fill_points", createExecutionPolicy( cell_space, TEST_EXECSPACE() ),

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(HEADERS_PUBLIC
   Cabana_Sort.hpp
   Cabana_Tuple.hpp
   Cabana_Types.hpp
+  Cabana_Utils.hpp
   Cabana_VerletList.hpp
   Cabana_Version.hpp
   )

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -21,6 +21,7 @@
 #include <Cabana_SoA.hpp>
 #include <Cabana_Tuple.hpp>
 #include <Cabana_Types.hpp>
+#include <Cabana_Utils.hpp>
 #include <impl/Cabana_Index.hpp>
 #include <impl/Cabana_PerformanceTraits.hpp>
 
@@ -137,6 +138,9 @@ class AoSoA
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;
     //! Default execution space.

--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -35,7 +35,7 @@ namespace Cabana
 {
 //---------------------------------------------------------------------------//
 // AoSoA forward declaration.
-template <class DataTypes, class DeviceType, int VectorLength,
+template <class DataTypes, class MemorySpace, int VectorLength,
           class MemoryTraits>
 class AoSoA;
 
@@ -46,9 +46,9 @@ struct is_aosoa_impl : public std::false_type
 {
 };
 
-template <class DataTypes, class DeviceType, int VectorLength,
+template <class DataTypes, class MemorySpace, int VectorLength,
           class MemoryTraits>
-struct is_aosoa_impl<AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>>
+struct is_aosoa_impl<AoSoA<DataTypes, MemorySpace, VectorLength, MemoryTraits>>
     : public std::true_type
 {
 };
@@ -103,24 +103,25 @@ slice( const AoSoA_t& aosoa, const std::string& slice_label = "" )
   of the same type together to achieve the smallest possible memory footprint
   based on compiler-generated padding.
 
-  \tparam DeviceType (required) The device type.
+  \tparam MemorySpace (required) The Kokkos memory space.
 
   \tparam VectorLength (optional) The vector length within the structs of
   the AoSoA. If not specified, this defaults to the preferred layout for the
-  <tt>DeviceType</tt>.
+  <tt>MemorySpace</tt>.
 
   \tparam MemoryTraits (optional) Memory traits for the AoSoA data. Can be
   used to indicate managed memory, unmanaged memory, etc.
  */
-template <class DataTypes, class DeviceType,
+template <class DataTypes, class MemorySpace,
           int VectorLength = Impl::PerformanceTraits<
-              typename DeviceType::execution_space>::vector_length,
+              typename MemorySpace::execution_space>::vector_length,
           class MemoryTraits = Kokkos::MemoryManaged>
 class AoSoA
 {
   public:
     //! AoSoA type.
-    using aosoa_type = AoSoA<DataTypes, DeviceType, VectorLength, MemoryTraits>;
+    using aosoa_type =
+        AoSoA<DataTypes, MemorySpace, VectorLength, MemoryTraits>;
 
     //! Host mirror type.
     using host_mirror_type = AoSoA<DataTypes, Kokkos::HostSpace, VectorLength>;
@@ -132,14 +133,14 @@ class AoSoA
     //! Member data types.
     using member_types = DataTypes;
 
-    //! Device type.
-    using device_type = DeviceType;
-
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
-    using memory_space = typename device_type::memory_space;
-
-    //! Execution space.
-    using execution_space = typename device_type::execution_space;
+    using memory_space = typename MemorySpace::memory_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     static_assert( Impl::IsVectorLengthValid<VectorLength>::value,
                    "Vector length must be valid" );
@@ -156,7 +157,7 @@ class AoSoA
     using soa_type = SoA<member_types, vector_length>;
 
     //! Managed data view.
-    using soa_view = Kokkos::View<soa_type*, device_type, memory_traits>;
+    using soa_view = Kokkos::View<soa_type*, memory_space, memory_traits>;
 
     //! Number of member types.
     static constexpr std::size_t number_of_members = member_types::size;
@@ -189,7 +190,7 @@ class AoSoA
     //! Member slice type at a given member index M.
     template <std::size_t M>
     using member_slice_type =
-        Slice<member_data_type<M>, device_type, DefaultAccessMemory,
+        Slice<member_data_type<M>, memory_space, DefaultAccessMemory,
               vector_length,
               sizeof( soa_type ) / sizeof( member_value_type<M> )>;
 

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -17,6 +17,7 @@
 #define CABANA_COMMUNICATIONPLAN_HPP
 
 #include <CabanaCore_config.hpp>
+#include <Cabana_Utils.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_ScatterView.hpp>
@@ -423,6 +424,8 @@ class CommunicationPlan
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Impl::warn( Kokkos::is_device<MemorySpace>() ) );
 
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -88,22 +88,22 @@ struct CountSendsAndCreateSteeringAlgorithm
 
 //---------------------------------------------------------------------------//
 // Count sends and generate the steering vector. Atomic version.
-template <class ExportRankView>
-auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
+template <class ExecutionSpace, class ExportRankView>
+auto countSendsAndCreateSteering( ExecutionSpace,
+                                  const ExportRankView element_export_ranks,
                                   const int comm_size,
                                   CountSendsAndCreateSteeringAtomic )
-    -> std::pair<Kokkos::View<int*, typename ExportRankView::device_type>,
+    -> std::pair<Kokkos::View<int*, typename ExportRankView::memory_space>,
                  Kokkos::View<typename ExportRankView::size_type*,
-                              typename ExportRankView::device_type>>
+                              typename ExportRankView::memory_space>>
 {
-    using device_type = typename ExportRankView::device_type;
-    using execution_space = typename ExportRankView::execution_space;
+    using memory_space = typename ExportRankView::memory_space;
     using size_type = typename ExportRankView::size_type;
 
     // Create views.
-    Kokkos::View<int*, device_type> neighbor_counts( "neighbor_counts",
-                                                     comm_size );
-    Kokkos::View<size_type*, device_type> neighbor_ids(
+    Kokkos::View<int*, memory_space> neighbor_counts( "neighbor_counts",
+                                                      comm_size );
+    Kokkos::View<size_type*, memory_space> neighbor_ids(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_ids" ),
         element_export_ranks.size() );
 
@@ -114,7 +114,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
     if ( comm_size <= 64 )
     {
         constexpr int team_size = 256;
-        Kokkos::TeamPolicy<execution_space> team_policy(
+        Kokkos::TeamPolicy<ExecutionSpace> team_policy(
             ( element_export_ranks.size() + team_size - 1 ) / team_size,
             team_size );
         team_policy = team_policy.set_scratch_size(
@@ -124,7 +124,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
             "Cabana::CommunicationPlan::countSendsAndCreateSteeringShared",
             team_policy,
             KOKKOS_LAMBDA(
-                const typename Kokkos::TeamPolicy<execution_space>::member_type&
+                const typename Kokkos::TeamPolicy<ExecutionSpace>::member_type&
                     team ) {
                 // NOTE: `get_shmem` returns shared memory pointers *aligned to
                 // 8 bytes*, so if `comm_size` is odd we can get erroneously
@@ -205,8 +205,8 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
 
         Kokkos::parallel_for(
             "Cabana::CommunicationPlan::countSendsAndCreateSteering",
-            Kokkos::RangePolicy<execution_space>( 0,
-                                                  element_export_ranks.size() ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0,
+                                                 element_export_ranks.size() ),
             KOKKOS_LAMBDA( const size_type i ) {
                 if ( element_export_ranks( i ) >= 0 )
                     neighbor_ids( i ) = Kokkos::atomic_fetch_add(
@@ -218,41 +218,42 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
     // Return the counts and ids.
     return std::make_pair( neighbor_counts, neighbor_ids );
 }
+
 //---------------------------------------------------------------------------//
 // Count sends and generate the steering vector. Duplicated version.
-template <class ExportRankView>
-auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
+template <class ExecutionSpace, class ExportRankView>
+auto countSendsAndCreateSteering( ExecutionSpace,
+                                  const ExportRankView element_export_ranks,
                                   const int comm_size,
                                   CountSendsAndCreateSteeringDuplicated )
-    -> std::pair<Kokkos::View<int*, typename ExportRankView::device_type>,
+    -> std::pair<Kokkos::View<int*, typename ExportRankView::memory_space>,
                  Kokkos::View<typename ExportRankView::size_type*,
-                              typename ExportRankView::device_type>>
+                              typename ExportRankView::memory_space>>
 {
-    using device_type = typename ExportRankView::device_type;
-    using execution_space = typename ExportRankView::execution_space;
+    using memory_space = typename ExportRankView::memory_space;
     using size_type = typename ExportRankView::size_type;
 
     // Create a unique thread token.
     Kokkos::Experimental::UniqueToken<
-        execution_space, Kokkos::Experimental::UniqueTokenScope::Global>
+        ExecutionSpace, Kokkos::Experimental::UniqueTokenScope::Global>
         unique_token;
 
     // Create views.
-    Kokkos::View<int*, device_type> neighbor_counts(
+    Kokkos::View<int*, memory_space> neighbor_counts(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_counts" ),
         comm_size );
-    Kokkos::View<size_type*, device_type> neighbor_ids(
+    Kokkos::View<size_type*, memory_space> neighbor_ids(
         Kokkos::ViewAllocateWithoutInitializing( "neighbor_ids" ),
         element_export_ranks.size() );
-    Kokkos::View<int**, device_type> neighbor_counts_dup(
+    Kokkos::View<int**, memory_space> neighbor_counts_dup(
         "neighbor_counts", unique_token.size(), comm_size );
-    Kokkos::View<size_type**, device_type> neighbor_ids_dup(
+    Kokkos::View<size_type**, memory_space> neighbor_ids_dup(
         "neighbor_ids", unique_token.size(), element_export_ranks.size() );
 
     // Compute initial duplicated sends and steering.
     Kokkos::parallel_for(
         "Cabana::CommunicationPlan::intialCount",
-        Kokkos::RangePolicy<execution_space>( 0, element_export_ranks.size() ),
+        Kokkos::RangePolicy<ExecutionSpace>( 0, element_export_ranks.size() ),
         KOKKOS_LAMBDA( const size_type i ) {
             if ( element_export_ranks( i ) >= 0 )
             {
@@ -278,7 +279,7 @@ auto countSendsAndCreateSteering( const ExportRankView element_export_ranks,
 
     // Team policy
     using team_policy =
-        Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
+        Kokkos::TeamPolicy<ExecutionSpace, Kokkos::Schedule<Kokkos::Dynamic>>;
     using index_type = typename team_policy::index_type;
 
     // Compute the send counts for each neighbor rank by reducing across
@@ -414,21 +415,26 @@ inline std::vector<int> getUniqueTopology( MPI_Comm comm,
   means is that neighbor 0 is the local rank and the data for that rank that
   is being exported will appear first in the steering vector.
 */
-template <class DeviceType>
+template <class MemorySpace>
 class CommunicationPlan
 {
   public:
-    //! Device type.
-    using device_type = DeviceType;
-
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
-    using memory_space = typename device_type::memory_space;
+    using memory_space = typename MemorySpace::memory_space;
 
-    //! Execution space.
-    using execution_space = typename device_type::execution_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
 
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
+
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be memory_space::size_type after
+    // next release.
     //! Size type.
-    using size_type = typename memory_space::size_type;
+    using size_type = typename memory_space::memory_space::size_type;
 
     /*!
       \brief Constructor.
@@ -537,7 +543,7 @@ class CommunicationPlan
       (i.e. all elements going to neighbor with local id 0 first, then all
       elements going to neighbor with local id 1, etc.).
     */
-    Kokkos::View<std::size_t*, device_type> getExportSteering() const
+    Kokkos::View<std::size_t*, memory_space> getExportSteering() const
     {
         return _export_steering;
     }
@@ -553,6 +559,8 @@ class CommunicationPlan
       this case you already know the topology of the point-to-point
       communication but not how much data to send to and receive from the
       neighbors.
+
+      \param exec_space Kokkos execution space.
 
       \param element_export_ranks The destination rank in the target
       decomposition of each locally owned element in the source
@@ -581,11 +589,14 @@ class CommunicationPlan
       this rank, just use this rank as the export destination and the data
       will be efficiently migrated.
     */
-    template <class ViewType>
-    Kokkos::View<size_type*, device_type>
-    createFromExportsAndTopology( const ViewType& element_export_ranks,
+    template <class ExecutionSpace, class ViewType>
+    Kokkos::View<size_type*, memory_space>
+    createFromExportsAndTopology( ExecutionSpace exec_space,
+                                  const ViewType& element_export_ranks,
                                   const std::vector<int>& neighbor_ranks )
     {
+        static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
         // Store the number of export elements.
         _num_export_element = element_export_ranks.size();
 
@@ -612,9 +623,9 @@ class CommunicationPlan
         // Count the number of sends this rank will do to other ranks. Keep
         // track of which slot we get in our neighbor's send buffer.
         auto counts_and_ids = Impl::countSendsAndCreateSteering(
-            element_export_ranks, comm_size,
+            exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
-                execution_space>::type() );
+                ExecutionSpace>::type() );
 
         // Copy the counts to the host.
         auto neighbor_counts_host = Kokkos::create_mirror_view_and_copy(
@@ -664,10 +675,57 @@ class CommunicationPlan
     }
 
     /*!
+      \brief Neighbor and export rank creator. Use this when you already know
+      which ranks neighbor each other (i.e. every rank already knows who they
+      will be sending and receiving from) as it will be more efficient. In
+      this case you already know the topology of the point-to-point
+      communication but not how much data to send to and receive from the
+      neighbors.
+
+      \param element_export_ranks The destination rank in the target
+      decomposition of each locally owned element in the source
+      decomposition. Each element will have one unique destination to which it
+      will be exported. This export rank may be any one of the listed neighbor
+      ranks which can include the calling rank. An export rank of -1 will
+      signal that this element is *not* to be exported and will be ignored in
+      the data migration. The input is expected to be a Kokkos view or Cabana
+      slice in the same memory space as the communication plan.
+
+      \param neighbor_ranks List of ranks this rank will send to and receive
+      from. This list can include the calling rank. This is effectively a
+      description of the topology of the point-to-point communication
+      plan. Only the unique elements in this list are used.
+
+      \return The location of each export element in the send buffer for its
+      given neighbor.
+
+      \note Calling this function completely updates the state of this object
+      and invalidates the previous state.
+
+      \note For elements that you do not wish to export, use an export rank of
+      -1 to signal that this element is *not* to be exported and will be
+      ignored in the data migration. In other words, this element will be
+      *completely* removed in the new decomposition. If the data is staying on
+      this rank, just use this rank as the export destination and the data
+      will be efficiently migrated.
+    */
+    template <class ViewType>
+    Kokkos::View<size_type*, memory_space>
+    createFromExportsAndTopology( const ViewType& element_export_ranks,
+                                  const std::vector<int>& neighbor_ranks )
+    {
+        // Use the default execution space.
+        return createFromExportsAndTopology(
+            execution_space{}, element_export_ranks, neighbor_ranks );
+    }
+
+    /*!
       \brief Export rank creator. Use this when you don't know who you will
       receiving from - only who you are sending to. This is less efficient
       than if we already knew who our neighbors were because we have to
       determine the topology of the point-to-point communication first.
+
+      \param exec_space Kokkos execution space.
 
       \param element_export_ranks The destination rank in the target
       decomposition of each locally owned element in the source
@@ -691,10 +749,13 @@ class CommunicationPlan
       this rank, just use this rank as the export destination and the data
       will be efficiently migrated.
     */
-    template <class ViewType>
-    Kokkos::View<size_type*, device_type>
-    createFromExportsOnly( const ViewType& element_export_ranks )
+    template <class ExecutionSpace, class ViewType>
+    Kokkos::View<size_type*, memory_space>
+    createFromExportsOnly( ExecutionSpace exec_space,
+                           const ViewType& element_export_ranks )
     {
+        static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
         // Store the number of export elements.
         _num_export_element = element_export_ranks.size();
 
@@ -713,9 +774,9 @@ class CommunicationPlan
         // Count the number of sends this rank will do to other ranks. Keep
         // track of which slot we get in our neighbor's send buffer.
         auto counts_and_ids = Impl::countSendsAndCreateSteering(
-            element_export_ranks, comm_size,
+            exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
-                execution_space>::type() );
+                ExecutionSpace>::type() );
 
         // Copy the counts to the host.
         auto neighbor_counts_host = Kokkos::create_mirror_view_and_copy(
@@ -826,6 +887,42 @@ class CommunicationPlan
     }
 
     /*!
+      \brief Export rank creator. Use this when you don't know who you will
+      receiving from - only who you are sending to. This is less efficient
+      than if we already knew who our neighbors were because we have to
+      determine the topology of the point-to-point communication first.
+
+      \param element_export_ranks The destination rank in the target
+      decomposition of each locally owned element in the source
+      decomposition. Each element will have one unique destination to which it
+      will be exported. This export rank may any one of the listed neighbor
+      ranks which can include the calling rank. An export rank of -1 will
+      signal that this element is *not* to be exported and will be ignored in
+      the data migration. The input is expected to be a Kokkos view or Cabana
+      slice in the same memory space as the communication plan.
+
+      \return The location of each export element in the send buffer for its
+      given neighbor.
+
+      \note Calling this function completely updates the state of this object
+      and invalidates the previous state.
+
+      \note For elements that you do not wish to export, use an export rank of
+      -1 to signal that this element is *not* to be exported and will be
+      ignored in the data migration. In other words, this element will be
+      *completely* removed in the new decomposition. If the data is staying on
+      this rank, just use this rank as the export destination and the data
+      will be efficiently migrated.
+    */
+    template <class ViewType>
+    Kokkos::View<size_type*, memory_space>
+    createFromExportsOnly( const ViewType& element_export_ranks )
+    {
+        // Use the default execution space.
+        return createFromExportsOnly( execution_space{}, element_export_ranks );
+    }
+
+    /*!
       \brief Create the export steering vector.
 
       Creates an array describing which export element ids are moved to which
@@ -878,11 +975,15 @@ class CommunicationPlan
 
     //! \cond Impl
     // Create the export steering vector.
-    template <class PackViewType, class RankViewType, class IdViewType>
-    void createSteering( const bool use_iota, const PackViewType& neighbor_ids,
+    template <class ExecutionSpace, class PackViewType, class RankViewType,
+              class IdViewType>
+    void createSteering( ExecutionSpace, const bool use_iota,
+                         const PackViewType& neighbor_ids,
                          const RankViewType& element_export_ranks,
                          const IdViewType& element_export_ids )
     {
+        static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
         if ( !use_iota &&
              ( element_export_ids.size() != element_export_ranks.size() ) )
             throw std::runtime_error( "Export ids and ranks different sizes!" );
@@ -915,7 +1016,7 @@ class CommunicationPlan
         auto steer_vec = _export_steering;
         Kokkos::parallel_for(
             "Cabana::createSteering",
-            Kokkos::RangePolicy<execution_space>( 0, _num_export_element ),
+            Kokkos::RangePolicy<ExecutionSpace>( 0, _num_export_element ),
             KOKKOS_LAMBDA( const int i ) {
                 if ( element_export_ranks( i ) >= 0 )
                     steer_vec( rank_offsets( element_export_ranks( i ) ) +
@@ -923,6 +1024,16 @@ class CommunicationPlan
                         ( use_iota ) ? i : element_export_ids( i );
             } );
         Kokkos::fence();
+    }
+
+    template <class PackViewType, class RankViewType, class IdViewType>
+    void createSteering( const bool use_iota, const PackViewType& neighbor_ids,
+                         const RankViewType& element_export_ranks,
+                         const IdViewType& element_export_ids )
+    {
+        // Use the default execution space.
+        createSteering( execution_space{}, use_iota, neighbor_ids,
+                        element_export_ranks, element_export_ids );
     }
     //! \endcond
 
@@ -934,7 +1045,7 @@ class CommunicationPlan
     std::vector<std::size_t> _num_export;
     std::vector<std::size_t> _num_import;
     std::size_t _num_export_element;
-    Kokkos::View<std::size_t*, device_type> _export_steering;
+    Kokkos::View<std::size_t*, memory_space> _export_steering;
 };
 
 //---------------------------------------------------------------------------//
@@ -1141,6 +1252,10 @@ class CommunicationData
     //! Perform the communication (migrate, gather, scatter).
     virtual void apply() = 0;
 
+    //! Perform the communication (migrate, gather, scatter).
+    template <class ExecutionSpace>
+    void apply( ExecutionSpace );
+
     //! \cond Impl
     void reserveImpl( const CommPlanType& comm_plan,
                       const particle_data_type particles,
@@ -1175,29 +1290,15 @@ class CommunicationData
 
         _send_size = total_send;
         _recv_size = total_recv;
-
-        // Update policies with new sizes.
-        updateRangePolicy();
     }
     //! \endcond
 
   protected:
-    //! Update range policy based on new communication plan.
-    void updateRangePolicy()
-    {
-        _send_policy = policy_type( 0, _send_size );
-        _recv_policy = policy_type( 0, _recv_size );
-    }
-
     //! Get the total number of components in the slice.
     auto getSliceComponents() { return _comm_data._num_comp; };
 
     //! Communication plan.
     plan_type _comm_plan;
-    //! Send range policy.
-    policy_type _send_policy;
-    //! Receive range policy.
-    policy_type _recv_policy;
     //! Communication plan.
     comm_data_type _comm_data;
     //! Overallocation factor.

--- a/core/src/Cabana_Core.hpp
+++ b/core/src/Cabana_Core.hpp
@@ -33,6 +33,7 @@
 #include <Cabana_Sort.hpp>
 #include <Cabana_Tuple.hpp>
 #include <Cabana_Types.hpp>
+#include <Cabana_Utils.hpp>
 #include <Cabana_VerletList.hpp>
 #include <Cabana_Version.hpp>
 

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -18,6 +18,7 @@
 
 #include <Cabana_Slice.hpp>
 #include <Cabana_Sort.hpp>
+#include <Cabana_Utils.hpp>
 #include <impl/Cabana_CartesianGrid.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -42,6 +43,9 @@ class LinkedCellList
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;
     //! Default execution space.

--- a/core/src/Cabana_LinkedCellList.hpp
+++ b/core/src/Cabana_LinkedCellList.hpp
@@ -32,22 +32,27 @@ namespace Cabana
   \brief Data describing the bin sizes and offsets resulting from a binning
   operation on a 3d regular Cartesian grid.
 */
-template <class DeviceType>
+template <class MemorySpace>
 class LinkedCellList
 {
   public:
-    //! Kokkos device_type.
-    using device_type = DeviceType;
-    //! Kokkos memory space.
-    using memory_space = typename device_type::memory_space;
-    //! Kokkos execution space.
-    using execution_space = typename device_type::execution_space;
+    // FIXME: add static_assert that this is a valid MemorySpace.
+
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
+    //! Memory space.
+    using memory_space = typename MemorySpace::memory_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
     //! Memory space size type.
     using size_type = typename memory_space::size_type;
+
     //! Binning view type.
-    using CountView = Kokkos::View<int*, device_type>;
+    using CountView = Kokkos::View<int*, memory_space>;
     //! Offset view type.
-    using OffsetView = Kokkos::View<size_type*, device_type>;
+    using OffsetView = Kokkos::View<size_type*, memory_space>;
 
     /*!
       \brief Default constructor.
@@ -217,25 +222,25 @@ class LinkedCellList
       \brief Get the 1d bin data.
       \return The 1d bin data.
     */
-    BinningData<DeviceType> binningData() const { return _bin_data; }
+    BinningData<MemorySpace> binningData() const { return _bin_data; }
 
     /*!
       \brief Build the linked cell list with a subset of particles.
 
+      \tparam ExecutionSpace Kokkos execution space.
       \tparam SliceType Slice type for positions.
 
       \param positions Slice of positions.
-
       \param begin The beginning index of the slice range to sort.
-
       \param end The end index of the slice range to sort.
     */
-    template <class SliceType>
-    void build( SliceType positions, const std::size_t begin,
+    template <class ExecutionSpace, class SliceType>
+    void build( ExecutionSpace, SliceType positions, const std::size_t begin,
                 const std::size_t end )
     {
         Kokkos::Profiling::pushRegion( "Cabana::LinkedCellList::build" );
 
+        static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
         assert( end >= begin );
         assert( end <= positions.size() );
 
@@ -260,7 +265,7 @@ class LinkedCellList
         auto permutes = _permutes;
 
         // Count.
-        Kokkos::RangePolicy<execution_space> particle_range( begin, end );
+        Kokkos::RangePolicy<ExecutionSpace> particle_range( begin, end );
         Kokkos::deep_copy( _counts, 0 );
         auto counts_sv = Kokkos::Experimental::create_scatter_view( _counts );
         auto cell_count = KOKKOS_LAMBDA( const std::size_t p )
@@ -277,7 +282,7 @@ class LinkedCellList
         Kokkos::Experimental::contribute( _counts, counts_sv );
 
         // Compute offsets.
-        Kokkos::RangePolicy<execution_space> cell_range( 0, ncell );
+        Kokkos::RangePolicy<ExecutionSpace> cell_range( 0, ncell );
         auto offset_scan = KOKKOS_LAMBDA( const std::size_t c, int& update,
                                           const bool final_pass )
         {
@@ -307,10 +312,27 @@ class LinkedCellList
         Kokkos::fence();
 
         // Create the binning data.
-        _bin_data =
-            BinningData<DeviceType>( begin, end, _counts, _offsets, _permutes );
+        _bin_data = BinningData<MemorySpace>( begin, end, _counts, _offsets,
+                                              _permutes );
 
         Kokkos::Profiling::popRegion();
+    }
+
+    /*!
+      \brief Build the linked cell list with a subset of particles.
+
+      \tparam SliceType Slice type for positions.
+
+      \param positions Slice of positions.
+      \param begin The beginning index of the slice range to sort.
+      \param end The end index of the slice range to sort.
+    */
+    template <class SliceType>
+    void build( SliceType positions, const std::size_t begin,
+                const std::size_t end )
+    {
+        // Use the default execution space.
+        build( execution_space{}, positions, begin, end );
     }
 
     /*!
@@ -327,7 +349,7 @@ class LinkedCellList
     }
 
   private:
-    BinningData<DeviceType> _bin_data;
+    BinningData<MemorySpace> _bin_data;
     Impl::CartesianGrid<double> _grid;
 
     CountView _counts;
@@ -355,8 +377,8 @@ struct is_linked_cell_list_impl : public std::false_type
 {
 };
 
-template <typename DeviceType>
-struct is_linked_cell_list_impl<LinkedCellList<DeviceType>>
+template <typename MemorySpace>
+struct is_linked_cell_list_impl<LinkedCellList<MemorySpace>>
     : public std::true_type
 {
 };

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -17,6 +17,7 @@
 #define CABANA_SLICE_HPP
 
 #include <Cabana_Types.hpp>
+#include <Cabana_Utils.hpp>
 #include <impl/Cabana_Index.hpp>
 #include <impl/Cabana_TypeTraits.hpp>
 
@@ -512,6 +513,9 @@ class Slice
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;
     //! Default execution space.

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -495,7 +495,7 @@ struct KokkosViewWrapper
   multidimensional member.
 */
 //---------------------------------------------------------------------------//
-template <typename DataType, typename DeviceType, typename MemoryAccessType,
+template <typename DataType, typename MemorySpace, typename MemoryAccessType,
           int VectorLength, int Stride>
 class Slice
 {
@@ -506,16 +506,16 @@ class Slice
 
     //! Slice type.
     using slice_type =
-        Slice<DataType, DeviceType, MemoryAccessType, VectorLength, Stride>;
+        Slice<DataType, MemorySpace, MemoryAccessType, VectorLength, Stride>;
 
-    //! Device type
-    using device_type = DeviceType;
-
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
-    using memory_space = typename device_type::memory_space;
-
-    //! Execution space.
-    using execution_space = typename device_type::execution_space;
+    using memory_space = typename MemorySpace::memory_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
 
     static_assert( is_memory_access_tag<MemoryAccessType>::value,
                    "Slice memory access type must be a Cabana access type" );
@@ -528,7 +528,7 @@ class Slice
     //! SoA stride.
     static constexpr int soa_stride = Stride;
 
-    //! Size type.
+    //! Memory space size type.
     using size_type = typename memory_space::size_type;
 
     //! Index type.
@@ -547,7 +547,7 @@ class Slice
     //! Kokkos view type.
     using kokkos_view =
         Kokkos::View<typename view_wrapper::data_type,
-                     typename view_wrapper::cabana_layout, DeviceType,
+                     typename view_wrapper::cabana_layout, MemorySpace,
                      typename MemoryAccessType::kokkos_memory_traits>;
 
     //! View reference type alias.
@@ -561,20 +561,20 @@ class Slice
 
     //! Default memory access slice type.
     using default_access_slice =
-        Slice<DataType, DeviceType, DefaultAccessMemory, VectorLength, Stride>;
+        Slice<DataType, MemorySpace, DefaultAccessMemory, VectorLength, Stride>;
     //! Atomic memory access slice type.
     using atomic_access_slice =
-        Slice<DataType, DeviceType, AtomicAccessMemory, VectorLength, Stride>;
+        Slice<DataType, MemorySpace, AtomicAccessMemory, VectorLength, Stride>;
     //! Random memory access slice type.
     using random_access_slice =
-        Slice<DataType, DeviceType, RandomAccessMemory, VectorLength, Stride>;
+        Slice<DataType, MemorySpace, RandomAccessMemory, VectorLength, Stride>;
 
     // Declare slices of different memory access types to be friends.
-    friend class Slice<DataType, DeviceType, DefaultAccessMemory, VectorLength,
+    friend class Slice<DataType, MemorySpace, DefaultAccessMemory, VectorLength,
                        Stride>;
-    friend class Slice<DataType, DeviceType, AtomicAccessMemory, VectorLength,
+    friend class Slice<DataType, MemorySpace, AtomicAccessMemory, VectorLength,
                        Stride>;
-    friend class Slice<DataType, DeviceType, RandomAccessMemory, VectorLength,
+    friend class Slice<DataType, MemorySpace, RandomAccessMemory, VectorLength,
                        Stride>;
 
     // Equivalent Kokkos view rank. This rank assumes that the struct and
@@ -619,7 +619,7 @@ class Slice
       space.
     */
     template <class MAT>
-    Slice( const Slice<DataType, DeviceType, MAT, VectorLength, Stride>& rhs )
+    Slice( const Slice<DataType, MemorySpace, MAT, VectorLength, Stride>& rhs )
         : _view( rhs._view )
         , _size( rhs._size )
     {
@@ -637,7 +637,7 @@ class Slice
      */
     template <class MAT>
     Slice& operator=(
-        const Slice<DataType, DeviceType, MAT, VectorLength, Stride>& rhs )
+        const Slice<DataType, MemorySpace, MAT, VectorLength, Stride>& rhs )
     {
         _view = rhs._view;
         _size = rhs._size;
@@ -842,10 +842,10 @@ struct is_slice_impl : public std::false_type
 
 // True only if the type is a member slice *AND* the member slice is templated
 // on an AoSoA type.
-template <typename DataType, typename DeviceType, typename MemoryAccessType,
+template <typename DataType, typename MemorySpace, typename MemoryAccessType,
           int VectorLength, int Stride>
 struct is_slice_impl<
-    Slice<DataType, DeviceType, MemoryAccessType, VectorLength, Stride>>
+    Slice<DataType, MemorySpace, MemoryAccessType, VectorLength, Stride>>
     : public std::true_type
 {
 };

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -19,6 +19,7 @@
 #include <Cabana_AoSoA.hpp>
 #include <Cabana_DeepCopy.hpp>
 #include <Cabana_Slice.hpp>
+#include <Cabana_Utils.hpp>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Sort.hpp>
@@ -36,12 +37,13 @@ template <class MemorySpace>
 class BinningData
 {
   public:
-    // FIXME: add static_assert that this is a valid MemorySpace.
-
     // FIXME: extracting the self type for backwards compatibility with previous
     // template on DeviceType. Should simply be MemorySpace after next release.
     //! Memory space.
     using memory_space = typename MemorySpace::memory_space;
+    // FIXME: replace warning with memory space assert after next release.
+    static_assert( Impl::warn( Kokkos::is_device<MemorySpace>() ) );
+
     //! Default device type.
     using device_type [[deprecated]] = typename memory_space::device_type;
     //! Default execution space.

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -163,22 +163,22 @@ namespace Impl
 //! given Kokkos View of keys.
 template <class KeyViewType, class Comparator,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-kokkosBinSort( KeyViewType keys, Comparator comp, const bool sort_within_bins,
-               const std::size_t begin, const std::size_t end )
+auto kokkosBinSort( KeyViewType keys, Comparator comp,
+                    const bool sort_within_bins, const std::size_t begin,
+                    const std::size_t end )
 {
     Kokkos::Profiling::pushRegion( "Cabana::BinSort" );
     using memory_space = typename KeyViewType::memory_space;
     static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
 
-    Kokkos::BinSort<KeyViewType, Comparator, ExecutionSpace> bin_sort(
-        keys, begin, end, comp, sort_within_bins );
+    Kokkos::BinSort<KeyViewType, Comparator> bin_sort( keys, begin, end, comp,
+                                                       sort_within_bins );
     bin_sort.create_permute_vector();
     Kokkos::Profiling::popRegion();
 
-    return BinningData<typename KeyViewType::memory_space>(
-        begin, end, bin_sort.get_bin_count(), bin_sort.get_bin_offsets(),
-        bin_sort.get_permute_vector() );
+    return BinningData<memory_space>( begin, end, bin_sort.get_bin_count(),
+                                      bin_sort.get_bin_offsets(),
+                                      bin_sort.get_permute_vector() );
 }
 
 //---------------------------------------------------------------------------//
@@ -222,9 +222,9 @@ keyMinMax( KeyViewType keys, const std::size_t begin, const std::size_t end )
 //! keys.
 template <class KeyViewType,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-kokkosBinSort1d( KeyViewType keys, const int nbin, const bool sort_within_bins,
-                 const std::size_t begin, const std::size_t end )
+auto kokkosBinSort1d( KeyViewType keys, const int nbin,
+                      const bool sort_within_bins, const std::size_t begin,
+                      const std::size_t end )
 {
     // Find the minimum and maximum key values.
     auto key_bounds =
@@ -261,7 +261,7 @@ kokkosBinSort1d( KeyViewType keys, const int nbin, const bool sort_within_bins,
 */
 template <class KeyViewType, class Comparator,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
+auto sortByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
@@ -288,7 +288,7 @@ BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
 */
 template <class KeyViewType, class Comparator,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
+auto sortByKeyWithComparator(
     KeyViewType keys, Comparator comp,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
@@ -315,7 +315,7 @@ BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
 */
 template <class KeyViewType, class Comparator,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
+auto binByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
@@ -344,7 +344,7 @@ BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
 */
 template <class KeyViewType, class Comparator,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
+auto binByKeyWithComparator(
     KeyViewType keys, Comparator comp,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
@@ -368,10 +368,10 @@ BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
 */
 template <class KeyViewType,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-sortByKey( KeyViewType keys, const std::size_t begin, const std::size_t end,
-           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                   int>::type* = 0 )
+auto sortByKey( KeyViewType keys, const std::size_t begin,
+                const std::size_t end,
+                typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                                        int>::type* = 0 )
 {
     int nbin = ( end - begin ) / 2;
     return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>( keys, nbin, true,
@@ -387,14 +387,12 @@ sortByKey( KeyViewType keys, const std::size_t begin, const std::size_t end,
   \param keys The key values to use for sorting. A key value is needed for
   every element of the AoSoA.
   \return The permutation vector associated with the sorting.
-
 */
 template <class KeyViewType,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-sortByKey( KeyViewType keys,
-           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                   int>::type* = 0 )
+auto sortByKey( KeyViewType keys,
+                typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                                        int>::type* = 0 )
 {
     return sortByKey<KeyViewType, ExecutionSpace>( keys, 0, keys.extent( 0 ) );
 }
@@ -417,11 +415,10 @@ sortByKey( KeyViewType keys,
 */
 template <class KeyViewType,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
-          const std::size_t end,
-          typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                  int>::type* = 0 )
+auto binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
+               const std::size_t end,
+               typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                                       int>::type* = 0 )
 {
     return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>(
         keys, nbin, false, begin, end );
@@ -442,10 +439,9 @@ binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
 */
 template <class KeyViewType,
           class ExecutionSpace = typename KeyViewType::execution_space>
-BinningData<typename KeyViewType::memory_space>
-binByKey( KeyViewType keys, const int nbin,
-          typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
-                                  int>::type* = 0 )
+auto binByKey( KeyViewType keys, const int nbin,
+               typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
+                                       int>::type* = 0 )
 {
     return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>(
         keys, nbin, false, 0, keys.extent( 0 ) );
@@ -465,7 +461,7 @@ binByKey( KeyViewType keys, const int nbin,
 */
 template <class SliceType,
           class ExecutionSpace = typename SliceType::execution_space>
-BinningData<typename SliceType::memory_space> sortByKey(
+auto sortByKey(
     SliceType slice, const std::size_t begin, const std::size_t end,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
@@ -489,7 +485,7 @@ BinningData<typename SliceType::memory_space> sortByKey(
 */
 template <class SliceType,
           class ExecutionSpace = typename SliceType::execution_space>
-BinningData<typename SliceType::memory_space> sortByKey(
+auto sortByKey(
     SliceType slice,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
@@ -512,7 +508,7 @@ BinningData<typename SliceType::memory_space> sortByKey(
 */
 template <class SliceType,
           class ExecutionSpace = typename SliceType::execution_space>
-BinningData<typename SliceType::memory_space> binByKey(
+auto binByKey(
     SliceType slice, const int nbin, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
@@ -539,7 +535,7 @@ BinningData<typename SliceType::memory_space> binByKey(
 */
 template <class SliceType,
           class ExecutionSpace = typename SliceType::execution_space>
-BinningData<typename SliceType::memory_space> binByKey(
+auto binByKey(
     SliceType slice, const int nbin,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -32,22 +32,26 @@ namespace Cabana
   \brief Data describing the bin sizes and offsets resulting from a binning
   operation.
 */
-template <class DeviceType>
+template <class MemorySpace>
 class BinningData
 {
   public:
-    //! Kokkos device_type.
-    using device_type = DeviceType;
-    //! Kokkos memory space.
-    using memory_space = typename device_type::memory_space;
-    //! Kokkos execution space.
-    using execution_space = typename device_type::execution_space;
+    // FIXME: add static_assert that this is a valid MemorySpace.
+
+    // FIXME: extracting the self type for backwards compatibility with previous
+    // template on DeviceType. Should simply be MemorySpace after next release.
+    //! Memory space.
+    using memory_space = typename MemorySpace::memory_space;
+    //! Default device type.
+    using device_type [[deprecated]] = typename memory_space::device_type;
+    //! Default execution space.
+    using execution_space = typename memory_space::execution_space;
     //! Memory space size type.
     using size_type = typename memory_space::size_type;
     //! Binning view type.
-    using CountView = Kokkos::View<const int*, device_type>;
+    using CountView = Kokkos::View<const int*, memory_space>;
     //! Offset view type.
-    using OffsetView = Kokkos::View<size_type*, device_type>;
+    using OffsetView = Kokkos::View<size_type*, memory_space>;
 
     //! Default constructor.
     BinningData()
@@ -140,15 +144,15 @@ struct is_binning_data : public std::false_type
 {
 };
 
-template <typename DeviceType>
-struct is_binning_data<BinningData<DeviceType>> : public std::true_type
+template <typename MemorySpace>
+struct is_binning_data<BinningData<MemorySpace>> : public std::true_type
 {
 };
 //! \endcond
 
 //! BinningData static type checker.
-template <typename DeviceType>
-struct is_binning_data<const BinningData<DeviceType>> : public std::true_type
+template <typename MemorySpace>
+struct is_binning_data<const BinningData<MemorySpace>> : public std::true_type
 {
 };
 
@@ -158,37 +162,42 @@ namespace Impl
 //! Create a permutation vector over a range subset using a comparator over the
 //! given Kokkos View of keys.
 template <class KeyViewType, class Comparator,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 kokkosBinSort( KeyViewType keys, Comparator comp, const bool sort_within_bins,
                const std::size_t begin, const std::size_t end )
 {
     Kokkos::Profiling::pushRegion( "Cabana::BinSort" );
-    Kokkos::BinSort<KeyViewType, Comparator, DeviceType> bin_sort(
+    using memory_space = typename KeyViewType::memory_space;
+    static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
+    Kokkos::BinSort<KeyViewType, Comparator, ExecutionSpace> bin_sort(
         keys, begin, end, comp, sort_within_bins );
     bin_sort.create_permute_vector();
     Kokkos::Profiling::popRegion();
 
-    return BinningData<DeviceType>( begin, end, bin_sort.get_bin_count(),
-                                    bin_sort.get_bin_offsets(),
-                                    bin_sort.get_permute_vector() );
+    return BinningData<typename KeyViewType::memory_space>(
+        begin, end, bin_sort.get_bin_count(), bin_sort.get_bin_offsets(),
+        bin_sort.get_permute_vector() );
 }
 
 //---------------------------------------------------------------------------//
 //! Given a set of keys, find the minimum and maximum over the given range.
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
+          class ExecutionSpace = typename KeyViewType::execution_space>
 Kokkos::MinMaxScalar<typename KeyViewType::non_const_value_type>
 keyMinMax( KeyViewType keys, const std::size_t begin, const std::size_t end )
 {
     Kokkos::Profiling::pushRegion( "Cabana::keyMinMax" );
 
+    using memory_space = typename KeyViewType::memory_space;
+    static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
     using KeyValueType = typename KeyViewType::non_const_value_type;
     Kokkos::MinMaxScalar<KeyValueType> result;
     Kokkos::MinMax<KeyValueType> reducer( result );
     Kokkos::parallel_reduce(
-        "Cabana::keyMinMax",
-        Kokkos::RangePolicy<typename DeviceType::execution_space>( begin, end ),
+        "Cabana::keyMinMax", Kokkos::RangePolicy<ExecutionSpace>( begin, end ),
         KOKKOS_LAMBDA( std::size_t i, decltype( result )& local_minmax ) {
             auto const val = keys( i );
             if ( val < local_minmax.min_val )
@@ -212,21 +221,21 @@ keyMinMax( KeyViewType keys, const std::size_t begin, const std::size_t end )
 //! Sort an AoSoA over a subset of its range using the given Kokkos View of
 //! keys.
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 kokkosBinSort1d( KeyViewType keys, const int nbin, const bool sort_within_bins,
                  const std::size_t begin, const std::size_t end )
 {
     // Find the minimum and maximum key values.
     auto key_bounds =
-        Impl::keyMinMax<KeyViewType, DeviceType>( keys, begin, end );
+        Impl::keyMinMax<KeyViewType, ExecutionSpace>( keys, begin, end );
 
     // Create a sorting comparator.
     Kokkos::BinOp1D<KeyViewType> comp( nbin, key_bounds.min_val,
                                        key_bounds.max_val );
 
     // BinSort
-    return kokkosBinSort<KeyViewType, decltype( comp ), DeviceType>(
+    return kokkosBinSort<KeyViewType, decltype( comp ), ExecutionSpace>(
         keys, comp, sort_within_bins, begin, end );
 }
 
@@ -251,14 +260,14 @@ kokkosBinSort1d( KeyViewType keys, const int nbin, const bool sort_within_bins,
   \return The permutation vector associated with the sorting.
 */
 template <class KeyViewType, class Comparator,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType> sortByKeyWithComparator(
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
 {
-    auto bin_data = Impl::kokkosBinSort<KeyViewType, DeviceType>(
+    auto bin_data = Impl::kokkosBinSort<KeyViewType, ExecutionSpace>(
         keys, comp, true, begin, end );
     return bin_data.permuteVector();
 }
@@ -278,14 +287,14 @@ BinningData<DeviceType> sortByKeyWithComparator(
   \return The permutation vector associated with the sorting.
 */
 template <class KeyViewType, class Comparator,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType> sortByKeyWithComparator(
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space> sortByKeyWithComparator(
     KeyViewType keys, Comparator comp,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
 {
-    Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, true, 0,
-                                                  keys.extent( 0 ) );
+    Impl::kokkosBinSort<KeyViewType, ExecutionSpace>( keys, comp, true, 0,
+                                                      keys.extent( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -305,15 +314,15 @@ BinningData<DeviceType> sortByKeyWithComparator(
   \return The binning data (e.g. bin sizes and offsets).
 */
 template <class KeyViewType, class Comparator,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType> binByKeyWithComparator(
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
     KeyViewType keys, Comparator comp, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
 {
-    return Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, false,
-                                                         begin, end );
+    return Impl::kokkosBinSort<KeyViewType, ExecutionSpace>( keys, comp, false,
+                                                             begin, end );
 }
 
 //---------------------------------------------------------------------------//
@@ -334,14 +343,14 @@ BinningData<DeviceType> binByKeyWithComparator(
   \return The binning data (e.g. bin sizes and offsets).
 */
 template <class KeyViewType, class Comparator,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType> binByKeyWithComparator(
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space> binByKeyWithComparator(
     KeyViewType keys, Comparator comp,
     typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                             int>::type* = 0 )
 {
-    return Impl::kokkosBinSort<KeyViewType, DeviceType>( keys, comp, false, 0,
-                                                         keys.extent( 0 ) );
+    return Impl::kokkosBinSort<KeyViewType, ExecutionSpace>(
+        keys, comp, false, 0, keys.extent( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -358,15 +367,15 @@ BinningData<DeviceType> binByKeyWithComparator(
   \return The permutation vector associated with the sorting.
 */
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 sortByKey( KeyViewType keys, const std::size_t begin, const std::size_t end,
            typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                                    int>::type* = 0 )
 {
     int nbin = ( end - begin ) / 2;
-    return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, true,
-                                                           begin, end );
+    return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>( keys, nbin, true,
+                                                               begin, end );
 }
 
 //---------------------------------------------------------------------------//
@@ -381,13 +390,13 @@ sortByKey( KeyViewType keys, const std::size_t begin, const std::size_t end,
 
 */
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 sortByKey( KeyViewType keys,
            typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                                    int>::type* = 0 )
 {
-    return sortByKey<KeyViewType, DeviceType>( keys, 0, keys.extent( 0 ) );
+    return sortByKey<KeyViewType, ExecutionSpace>( keys, 0, keys.extent( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -407,15 +416,15 @@ sortByKey( KeyViewType keys,
   \return The binning data (e.g. bin sizes and offsets).
 */
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
           const std::size_t end,
           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                                   int>::type* = 0 )
 {
-    return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, false,
-                                                           begin, end );
+    return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>(
+        keys, nbin, false, begin, end );
 }
 
 //---------------------------------------------------------------------------//
@@ -432,14 +441,14 @@ binByKey( KeyViewType keys, const int nbin, const std::size_t begin,
   \return The binning data (e.g. bin sizes and offsets).
 */
 template <class KeyViewType,
-          class DeviceType = typename KeyViewType::device_type>
-BinningData<DeviceType>
+          class ExecutionSpace = typename KeyViewType::execution_space>
+BinningData<typename KeyViewType::memory_space>
 binByKey( KeyViewType keys, const int nbin,
           typename std::enable_if<( Kokkos::is_view<KeyViewType>::value ),
                                   int>::type* = 0 )
 {
-    return Impl::kokkosBinSort1d<KeyViewType, DeviceType>( keys, nbin, false, 0,
-                                                           keys.extent( 0 ) );
+    return Impl::kokkosBinSort1d<KeyViewType, ExecutionSpace>(
+        keys, nbin, false, 0, keys.extent( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -454,16 +463,19 @@ binByKey( KeyViewType keys, const int nbin,
   \param end The end index of the AoSoA range to sort.
   \return The permutation vector associated with the sorting.
 */
-template <class SliceType, class DeviceType = typename SliceType::device_type>
-BinningData<DeviceType> sortByKey(
+template <class SliceType,
+          class ExecutionSpace = typename SliceType::execution_space>
+BinningData<typename SliceType::memory_space> sortByKey(
     SliceType slice, const std::size_t begin, const std::size_t end,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
-    Kokkos::View<typename SliceType::value_type*, DeviceType> keys(
-        Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ), slice.size() );
+    Kokkos::View<typename SliceType::value_type*,
+                 typename SliceType::memory_space>
+        keys( Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ),
+              slice.size() );
 
     copySliceToView( keys, slice, 0, slice.size() );
-    return sortByKey<decltype( keys ), DeviceType>( keys, begin, end );
+    return sortByKey<decltype( keys ), ExecutionSpace>( keys, begin, end );
 }
 
 //---------------------------------------------------------------------------//
@@ -475,12 +487,13 @@ BinningData<DeviceType> sortByKey(
   \param slice Slice of keys.
   \return The permutation vector associated with the sorting.
 */
-template <class SliceType, class DeviceType = typename SliceType::device_type>
-BinningData<DeviceType> sortByKey(
+template <class SliceType,
+          class ExecutionSpace = typename SliceType::execution_space>
+BinningData<typename SliceType::memory_space> sortByKey(
     SliceType slice,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
-    return sortByKey<SliceType, DeviceType>( slice, 0, slice.size() );
+    return sortByKey<SliceType, ExecutionSpace>( slice, 0, slice.size() );
 }
 
 //---------------------------------------------------------------------------//
@@ -497,17 +510,20 @@ BinningData<DeviceType> sortByKey(
   \param end The end index of the AoSoA range to bin.
   \return The binning data (e.g. bin sizes and offsets).
 */
-template <class SliceType, class DeviceType = typename SliceType::device_type>
-BinningData<DeviceType> binByKey(
+template <class SliceType,
+          class ExecutionSpace = typename SliceType::execution_space>
+BinningData<typename SliceType::memory_space> binByKey(
     SliceType slice, const int nbin, const std::size_t begin,
     const std::size_t end,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
-    Kokkos::View<typename SliceType::value_type*, DeviceType> keys(
-        Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ), slice.size() );
+    Kokkos::View<typename SliceType::value_type*,
+                 typename SliceType::memory_space>
+        keys( Kokkos::ViewAllocateWithoutInitializing( "slice_keys" ),
+              slice.size() );
 
     copySliceToView( keys, slice, 0, slice.size() );
-    return binByKey<decltype( keys ), DeviceType>( keys, nbin, begin, end );
+    return binByKey<decltype( keys ), ExecutionSpace>( keys, nbin, begin, end );
 }
 
 //---------------------------------------------------------------------------//
@@ -521,12 +537,13 @@ BinningData<DeviceType> binByKey(
   will subdivided equally by the number of bins.
   \return The binning data (e.g. bin sizes and offsets).
 */
-template <class SliceType, class DeviceType = typename SliceType::device_type>
-BinningData<DeviceType> binByKey(
+template <class SliceType,
+          class ExecutionSpace = typename SliceType::execution_space>
+BinningData<typename SliceType::memory_space> binByKey(
     SliceType slice, const int nbin,
     typename std::enable_if<( is_slice<SliceType>::value ), int>::type* = 0 )
 {
-    return binByKey<SliceType, DeviceType>( slice, nbin, 0, slice.size() );
+    return binByKey<SliceType, ExecutionSpace>( slice, nbin, 0, slice.size() );
 }
 
 //---------------------------------------------------------------------------//
@@ -539,7 +556,7 @@ BinningData<DeviceType> binByKey(
   \param aosoa The AoSoA to permute.
  */
 template <class BinningDataType, class AoSoA_t,
-          class DeviceType = typename BinningDataType::device_type>
+          class ExecutionSpace = typename BinningDataType::execution_space>
 void permute(
     const BinningDataType& binning_data, AoSoA_t& aosoa,
     typename std::enable_if<( is_binning_data<BinningDataType>::value &&
@@ -548,10 +565,14 @@ void permute(
 {
     Kokkos::Profiling::pushRegion( "Cabana::permute" );
 
+    using memory_space = typename BinningDataType::memory_space;
+    static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
+
     auto begin = binning_data.rangeBegin();
     auto end = binning_data.rangeEnd();
 
-    Kokkos::View<typename AoSoA_t::tuple_type*, DeviceType> scratch_tuples(
+    using memory_space = typename BinningDataType::memory_space;
+    Kokkos::View<typename AoSoA_t::tuple_type*, memory_space> scratch_tuples(
         Kokkos::ViewAllocateWithoutInitializing( "scratch_tuples" ),
         end - begin );
 
@@ -560,20 +581,18 @@ void permute(
         scratch_tuples( i - begin ) =
             aosoa.getTuple( binning_data.permutation( i - begin ) );
     };
-    Kokkos::parallel_for(
-        "Cabana::kokkosBinSort::permute_to_scratch",
-        Kokkos::RangePolicy<typename DeviceType::execution_space>( begin, end ),
-        permute_to_scratch );
+    Kokkos::parallel_for( "Cabana::kokkosBinSort::permute_to_scratch",
+                          Kokkos::RangePolicy<ExecutionSpace>( begin, end ),
+                          permute_to_scratch );
     Kokkos::fence();
 
     auto copy_back = KOKKOS_LAMBDA( const std::size_t i )
     {
         aosoa.setTuple( i, scratch_tuples( i - begin ) );
     };
-    Kokkos::parallel_for(
-        "Cabana::kokkosBinSort::copy_back",
-        Kokkos::RangePolicy<typename DeviceType::execution_space>( begin, end ),
-        copy_back );
+    Kokkos::parallel_for( "Cabana::kokkosBinSort::copy_back",
+                          Kokkos::RangePolicy<ExecutionSpace>( begin, end ),
+                          copy_back );
     Kokkos::fence();
 
     Kokkos::Profiling::popRegion();
@@ -590,7 +609,7 @@ void permute(
   \param slice The slice to permute.
  */
 template <class BinningDataType, class SliceType,
-          class DeviceType = typename BinningDataType::device_type>
+          class ExecutionSpace = typename BinningDataType::execution_space>
 void permute(
     const BinningDataType& binning_data, SliceType& slice,
     typename std::enable_if<( is_binning_data<BinningDataType>::value &&
@@ -598,6 +617,9 @@ void permute(
                             int>::type* = 0 )
 {
     Kokkos::Profiling::pushRegion( "Cabana::permute" );
+
+    using memory_space = typename BinningDataType::memory_space;
+    static_assert( is_accessible_from<memory_space, ExecutionSpace>{}, "" );
 
     auto begin = binning_data.rangeBegin();
     auto end = binning_data.rangeEnd();
@@ -610,7 +632,7 @@ void permute(
     // Get the raw slice data.
     auto slice_data = slice.data();
 
-    Kokkos::View<typename SliceType::value_type**, DeviceType> scratch_array(
+    Kokkos::View<typename SliceType::value_type**, memory_space> scratch_array(
         Kokkos::ViewAllocateWithoutInitializing( "scratch_array" ), end - begin,
         num_comp );
 
@@ -624,10 +646,9 @@ void permute(
             scratch_array( i - begin, n ) =
                 slice_data[slice_offset + SliceType::vector_length * n];
     };
-    Kokkos::parallel_for(
-        "Cabana::kokkosBinSort::permute_to_scratch",
-        Kokkos::RangePolicy<typename DeviceType::execution_space>( begin, end ),
-        permute_to_scratch );
+    Kokkos::parallel_for( "Cabana::kokkosBinSort::permute_to_scratch",
+                          Kokkos::RangePolicy<ExecutionSpace>( begin, end ),
+                          permute_to_scratch );
     Kokkos::fence();
 
     auto copy_back = KOKKOS_LAMBDA( const std::size_t i )
@@ -639,10 +660,9 @@ void permute(
             slice_data[slice_offset + SliceType::vector_length * n] =
                 scratch_array( i - begin, n );
     };
-    Kokkos::parallel_for(
-        "Cabana::kokkosBinSort::copy_back",
-        Kokkos::RangePolicy<typename DeviceType::execution_space>( begin, end ),
-        copy_back );
+    Kokkos::parallel_for( "Cabana::kokkosBinSort::copy_back",
+                          Kokkos::RangePolicy<ExecutionSpace>( begin, end ),
+                          copy_back );
     Kokkos::fence();
 
     Kokkos::Profiling::popRegion();

--- a/core/src/Cabana_Utils.hpp
+++ b/core/src/Cabana_Utils.hpp
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+/*!
+  \file Cabana_Utils.hpp
+  \brief Cabana utilities.
+*/
+#ifndef CABANA_UTILS_HPP
+#define CABANA_UTILS_HPP
+
+namespace Cabana
+{
+namespace Impl
+{
+//! \cond Impl
+
+// Custom warning for switch from device_type to memory_space.
+constexpr bool warn( std::false_type ) { return true; }
+
+[[deprecated( "Template parameter should be converted from device type to "
+              "memory space." )]] constexpr bool
+warn( std::true_type )
+{
+    return true;
+}
+//! \endcond
+
+} // namespace Impl
+} // namespace Cabana
+
+#endif

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -234,8 +234,8 @@ struct VerletListBuilder
     std::size_t pid_begin, pid_end;
 
     // Binning Data.
-    BinningData<device> bin_data_1d;
-    LinkedCellList<device> linked_cell_list;
+    BinningData<memory_space> bin_data_1d;
+    LinkedCellList<memory_space> linked_cell_list;
 
     // Cell stencil.
     LinkedCellStencil<PositionValueType> cell_stencil;
@@ -280,8 +280,8 @@ struct VerletListBuilder
         // treated as candidates for neighbors.
         double grid_size = cell_size_ratio * neighborhood_radius;
         PositionValueType grid_delta[3] = { grid_size, grid_size, grid_size };
-        linked_cell_list =
-            LinkedCellList<device>( position, grid_delta, grid_min, grid_max );
+        linked_cell_list = LinkedCellList<memory_space>( position, grid_delta,
+                                                         grid_min, grid_max );
         bin_data_1d = linked_cell_list.binningData();
 
         // We will use the square of the distance for neighbor determination.

--- a/core/unit_test/tstCommunicationPlan.hpp
+++ b/core/unit_test/tstCommunicationPlan.hpp
@@ -25,20 +25,19 @@
 namespace Test
 {
 //---------------------------------------------------------------------------//
-class CommPlanTester : public Cabana::CommunicationPlan<
-                           Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>>
+class CommPlanTester : public Cabana::CommunicationPlan<TEST_MEMSPACE>
 {
   public:
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
+    using memory_space = TEST_MEMSPACE;
     using size_type = typename TEST_MEMSPACE::size_type;
 
     CommPlanTester( MPI_Comm comm )
-        : Cabana::CommunicationPlan<device_type>( comm )
+        : Cabana::CommunicationPlan<memory_space>( comm )
     {
     }
 
     template <class ViewType>
-    Kokkos::View<size_type*, device_type>
+    Kokkos::View<size_type*, memory_space>
     createFromExportsAndNeighbors( const ViewType& element_export_ranks,
                                    const std::vector<int>& neighbor_ranks )
     {
@@ -47,21 +46,21 @@ class CommPlanTester : public Cabana::CommunicationPlan<
     }
 
     template <class ViewType>
-    Kokkos::View<size_type*, device_type>
+    Kokkos::View<size_type*, memory_space>
     createFromExports( const ViewType& element_export_ranks )
     {
         return this->createFromExportsOnly( element_export_ranks );
     }
 
     template <class ViewType>
-    void createSteering( Kokkos::View<size_type*, device_type> neighbor_ids,
+    void createSteering( Kokkos::View<size_type*, memory_space> neighbor_ids,
                          const ViewType& element_export_ranks )
     {
         this->createExportSteering( neighbor_ids, element_export_ranks );
     }
 
     template <class RankViewType, class IdViewType>
-    void createSteering( Kokkos::View<size_type*, device_type> neighbor_ids,
+    void createSteering( Kokkos::View<size_type*, memory_space> neighbor_ids,
                          const RankViewType& element_export_ranks,
                          const IdViewType& element_export_ids )
     {
@@ -88,9 +87,8 @@ void test1( const bool use_topology )
     std::vector<int> neighbor_ranks( 1, my_rank );
 
     // Create the plan.
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -145,9 +143,8 @@ void test2( const bool use_topology )
     std::vector<int> neighbor_ranks( 1, my_rank );
 
     // Create the plan
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -210,9 +207,8 @@ void test3( const bool use_topology )
     std::vector<int> neighbor_ranks( 1, inverse_rank );
 
     // Create the plan with both export ranks and the topology.
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -273,9 +269,8 @@ void test4( const bool use_topology )
         TEST_MEMSPACE(), export_ranks_host );
 
     // Create the plan
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -393,9 +388,8 @@ void test5( const bool use_topology )
         TEST_MEMSPACE(), export_ranks_host );
 
     // Create the plan
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -479,9 +473,8 @@ void test6( const bool use_topology )
     }
 
     // Create the plan.
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );
@@ -541,9 +534,8 @@ void test7( const bool use_topology )
     std::vector<int> neighbor_ranks( 1, my_rank );
 
     // Create the plan.
-    using device_type = Kokkos::Device<TEST_EXECSPACE, TEST_MEMSPACE>;
     using size_type = typename TEST_MEMSPACE::size_type;
-    Kokkos::View<size_type*, device_type> neighbor_ids;
+    Kokkos::View<size_type*, TEST_MEMSPACE> neighbor_ids;
     if ( use_topology )
         neighbor_ids = comm_plan.createFromExportsAndNeighbors(
             export_ranks, neighbor_ranks );

--- a/core/unit_test/tstNeighborListArborX.hpp
+++ b/core/unit_test/tstNeighborListArborX.hpp
@@ -29,12 +29,10 @@ void testArborXListFull()
     NeighborListTestData test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
-    using device_type = TEST_MEMSPACE; // sigh...
-
     // Check CSR neighbor lists.
     {
         // Create the neighbor list.
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius );
 
@@ -44,7 +42,7 @@ void testArborXListFull()
     }
     // Check CSR again, building with a large array allocation guess.
     {
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius, 100 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
@@ -52,7 +50,7 @@ void testArborXListFull()
     }
     // Check CSR again, building with a small array allocation guess.
     {
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius, 2 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
@@ -61,28 +59,25 @@ void testArborXListFull()
 
     // Check 2D neighbor lists.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
     // Check 2D again, building with a large array allocation guess.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius, 100 );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius, 100 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
     // Check 2D again, building with a small array allocation guess.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius, 2 );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius, 2 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
@@ -95,12 +90,10 @@ void testArborXListHalf()
     NeighborListTestData test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
-    using device_type = TEST_MEMSPACE; // sigh...
-
     // Check CSR neighbor lists.
     {
         // Create the neighbor list.
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::HalfNeighborTag{}, position, 0, position.size(),
             test_data.test_radius );
 
@@ -110,7 +103,7 @@ void testArborXListHalf()
     }
     // Check CSR again, building with a large array allocation guess.
     {
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius, 100 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
@@ -118,7 +111,7 @@ void testArborXListHalf()
     }
     // Check CSR again, building with a small array allocation guess.
     {
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius, 2 );
         checkFullNeighborList( nlist, test_data.N2_list_copy,
@@ -127,28 +120,25 @@ void testArborXListHalf()
 
     // Check 2D neighbor lists.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::HalfNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::HalfNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius );
         checkHalfNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
     // Check 2D again, building with a large array allocation guess.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::HalfNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius, 100 );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::HalfNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius, 100 );
         checkHalfNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
     // Check 2D again, building with a small array allocation guess.
     {
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::HalfNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius, 2 );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::HalfNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius, 2 );
         checkHalfNeighborList( nlist, test_data.N2_list_copy,
                                test_data.num_particle );
     }
@@ -163,8 +153,7 @@ void testArborXListFullPartialRange()
 
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, test_data.num_ignore,
             test_data.test_radius );
 
@@ -175,11 +164,9 @@ void testArborXListFullPartialRange()
     }
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, test_data.num_ignore,
-                test_data.test_radius );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, test_data.num_ignore,
+            test_data.test_radius );
 
         // Check the neighbor list.
         checkFullNeighborListPartialRange( nlist, test_data.N2_list_copy,
@@ -197,8 +184,7 @@ void testNeighborArborXParallelFor()
 
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius );
 
@@ -223,11 +209,9 @@ void testNeighborArborXParallelFor()
     }
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius );
 
         checkFirstNeighborParallelForLambda( nlist, test_data.N2_list_copy,
                                              test_data.num_particle );
@@ -259,8 +243,7 @@ void testNeighborArborXParallelReduce()
 
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist = Cabana::Experimental::makeNeighborList<device_type>(
+        auto const nlist = Cabana::Experimental::makeNeighborList(
             Cabana::FullNeighborTag{}, position, 0, position.size(),
             test_data.test_radius );
 
@@ -282,11 +265,9 @@ void testNeighborArborXParallelReduce()
     }
     {
         // Create the neighbor list.
-        using device_type = TEST_MEMSPACE; // sigh...
-        auto const nlist =
-            Cabana::Experimental::make2DNeighborList<device_type>(
-                Cabana::FullNeighborTag{}, position, 0, position.size(),
-                test_data.test_radius );
+        auto const nlist = Cabana::Experimental::make2DNeighborList(
+            Cabana::FullNeighborTag{}, position, 0, position.size(),
+            test_data.test_radius );
 
         checkFirstNeighborParallelReduceLambda( nlist, test_data.N2_list_copy,
                                                 test_data.aosoa );

--- a/example/cajita_tutorial/07_local_mesh/local_mesh_example.cpp
+++ b/example/cajita_tutorial/07_local_mesh/local_mesh_example.cpp
@@ -32,8 +32,8 @@ void localMeshExample()
       local mesh, including ghost information.
     */
 
-    using exec_space = Kokkos::DefaultHostExecutionSpace;
-    using device_type = exec_space::device_type;
+    using execution_space = Kokkos::DefaultHostExecutionSpace;
+    using memory_space = execution_space::memory_space;
 
     /*
       As with the previous examples, we first create the global mesh and grid,
@@ -73,7 +73,7 @@ void localMeshExample()
       parameter defines both the Kokkos memory and execution spaces that will be
       able to access the resulting local mesh data.
     */
-    auto local_mesh = Cajita::createLocalMesh<device_type>( *local_grid );
+    auto local_mesh = Cajita::createLocalMesh<memory_space>( *local_grid );
 
     /*
       Just like the global mesh, the local mesh holds information about the

--- a/example/cajita_tutorial/10_fft_heffte/heffte_fast_fourier_transform_example.cpp
+++ b/example/cajita_tutorial/10_fft_heffte/heffte_fast_fourier_transform_example.cpp
@@ -42,8 +42,6 @@ void fastFourierTransformHeffteExample()
        host execution space.
     */
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     double cell_size = 0.5;
     std::array<bool, 3> is_dim_periodic = { true, true, true };
@@ -73,7 +71,7 @@ void fastFourierTransformHeffteExample()
     */
     auto vector_layout =
         Cajita::createArrayLayout( local_grid, 2, Cajita::Cell() );
-    auto lhs = Cajita::createArray<double, DeviceType>( "lhs", vector_layout );
+    auto lhs = Cajita::createArray<double, MemorySpace>( "lhs", vector_layout );
     auto lhs_view = lhs->view();
     const uint64_t seed =
         global_grid->blockId() + ( 19383747 % ( global_grid->blockId() + 1 ) );
@@ -136,7 +134,7 @@ void fastFourierTransformHeffteExample()
        (Cajita::Experimental::FFTBackendMKL in this case) to the constructor.
     */
     auto fft = Cajita::Experimental::createHeffteFastFourierTransform<
-        double, DeviceType>( *vector_layout, params );
+        double, MemorySpace>( *vector_layout, params );
 
     /*
       Now forward or reverse transforms can be performed via

--- a/example/core_tutorial/04_aosoa/aosoa_example.cpp
+++ b/example/core_tutorial/04_aosoa/aosoa_example.cpp
@@ -60,8 +60,6 @@ void aosoaExample()
       `Kokkos::HostSpace`.
     */
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA. We define how many tuples the aosoa will
@@ -72,8 +70,8 @@ void aosoaExample()
        allocation tracker.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
        Print the label and size data. In this case we have created an AoSoA

--- a/example/core_tutorial/04_aosoa_advanced_unmanaged/advanced_aosoa_unmanaged.cpp
+++ b/example/core_tutorial/04_aosoa_advanced_unmanaged/advanced_aosoa_unmanaged.cpp
@@ -68,9 +68,8 @@ void unmanagedAoAoAExample()
     Data* local_data = new Data[num_tuple];
 
     // This is equivalent to a Cabana AoSoA of:
-    // using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    // using DeviceType = Kokkos::Device<ExecutionSpace,MemorySpace>;
-    // Cabana::AoSoA<DataTypes,DeviceType,VectorLength> aosoa( "my_aosoa",
+    // using MemorySpace = Kokkos::HostSpace;
+    // Cabana::AoSoA<DataTypes,MemorySpace,VectorLength> aosoa( "my_aosoa",
     // num_tuple );
 
     /*

--- a/example/core_tutorial/05_slice/slice_example.cpp
+++ b/example/core_tutorial/05_slice/slice_example.cpp
@@ -65,8 +65,6 @@ void sliceExample()
       `Kokkos::HostSpace`.
     */
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA. We define how many tuples the aosoa will
@@ -75,8 +73,8 @@ void sliceExample()
        full (although its memory will still be allocated).
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
       Create a slice over each tuple member in the AoSoA. An integer template

--- a/example/core_tutorial/05_slice_advanced_cuda/advanced_slice_cuda.cpp
+++ b/example/core_tutorial/05_slice_advanced_cuda/advanced_slice_cuda.cpp
@@ -50,13 +50,12 @@ void atomicSliceExample()
     const int VectorLength = 32;
     using MemorySpace = Kokkos::CudaUVMSpace;
     using ExecutionSpace = Kokkos::Cuda;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA. Just put a single value to demonstrate the atomic.
     */
     int num_tuple = 1;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A", num_tuple );
 
     /*
       Create a slice over the single value and assign it to zero.

--- a/example/core_tutorial/05_slice_advanced_openmp/advanced_slice_openmp.cpp
+++ b/example/core_tutorial/05_slice_advanced_openmp/advanced_slice_openmp.cpp
@@ -34,14 +34,12 @@ void atomicSliceExample()
     using DataTypes = Cabana::MemberTypes<double>;
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::OpenMP;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA. Just put a single value to demonstrate the atomic.
     */
     int num_tuple = 1;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "X", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "X", num_tuple );
 
     /*
       Create a slice over the single value and assign it to zero.

--- a/example/core_tutorial/06_deep_copy/deep_copy_example.cpp
+++ b/example/core_tutorial/06_deep_copy/deep_copy_example.cpp
@@ -47,8 +47,6 @@ void deepCopyExample()
     */
     const int SrcVectorLength = 8;
     using SrcMemorySpace = Kokkos::HostSpace;
-    using SrcExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using SrcDevice = Kokkos::Device<SrcExecutionSpace, SrcMemorySpace>;
 
     /*
       Declare the vector length and memory space parameters of the destination
@@ -58,16 +56,15 @@ void deepCopyExample()
     const int DstVectorLength = 32;
     using DstExecutionSpace = Kokkos::DefaultExecutionSpace;
     using DstMemorySpace = typename DstExecutionSpace::memory_space;
-    using DstDevice = Kokkos::Device<DstExecutionSpace, DstMemorySpace>;
 
     /*
        Create the source and destination AoSoAs.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes, SrcDevice, SrcVectorLength> src_aosoa( "src",
-                                                                    num_tuple );
-    Cabana::AoSoA<DataTypes, DstDevice, DstVectorLength> dst_aosoa( "dst",
-                                                                    num_tuple );
+    Cabana::AoSoA<DataTypes, SrcMemorySpace, SrcVectorLength> src_aosoa(
+        "src", num_tuple );
+    Cabana::AoSoA<DataTypes, DstMemorySpace, DstVectorLength> dst_aosoa(
+        "dst", num_tuple );
 
     /*
       Put some data in the host source AoSoA.

--- a/example/core_tutorial/07_sorting/sorting_example.cpp
+++ b/example/core_tutorial/07_sorting/sorting_example.cpp
@@ -42,15 +42,13 @@ void sortingExample()
     */
     const int VectorLength = 4;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 5;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
       Fill the AoSoA with data. The integer member of the AoSoA will be

--- a/example/core_tutorial/08_linked_cell_list/linked_cell_list_example.cpp
+++ b/example/core_tutorial/08_linked_cell_list/linked_cell_list_example.cpp
@@ -48,14 +48,12 @@ void linkedCellListExample()
     */
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 54;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A", num_tuple );
 
     /*
       Define the parameters of the Cartesian grid over which we will build the
@@ -107,12 +105,12 @@ void linkedCellListExample()
       exercise, try adding both start and end (int) inputs to define a subset
       range of particles to permute:
 
-      Cabana::LinkedCellList<DeviceType> cell_list( positions, start, end,
+      Cabana::LinkedCellList<MemorySpace> cell_list( positions, start, end,
                                                     grid_delta,
                                                     grid_min, grid_max );
      */
-    Cabana::LinkedCellList<DeviceType> cell_list( positions, grid_delta,
-                                                  grid_min, grid_max );
+    Cabana::LinkedCellList<MemorySpace> cell_list( positions, grid_delta,
+                                                   grid_min, grid_max );
 
     /*
       Now permute the AoSoA (i.e. reorder the data) using the linked cell list.

--- a/example/core_tutorial/09_neighbor_list/verlet_list_example.cpp
+++ b/example/core_tutorial/09_neighbor_list/verlet_list_example.cpp
@@ -42,14 +42,12 @@ void verletListExample()
     */
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 81;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A", num_tuple );
 
     /*
       Define the parameters of the Cartesian grid over which we will build the

--- a/example/core_tutorial/09_neighbor_list_arborx/arborx_neighborlist_example.cpp
+++ b/example/core_tutorial/09_neighbor_list_arborx/arborx_neighborlist_example.cpp
@@ -38,14 +38,12 @@ void arborxNeighborListExample()
     using DataTypes = Cabana::MemberTypes<double[3], int>;
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 81;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A", num_tuple );
 
     /*
       Create the particle ids.

--- a/example/core_tutorial/09_neighbor_list_arborx/arborx_neighborlist_example.cpp
+++ b/example/core_tutorial/09_neighbor_list_arborx/arborx_neighborlist_example.cpp
@@ -87,7 +87,7 @@ void arborxNeighborListExample()
       "make2DNeighborList" is provided.
      */
     double neighborhood_radius = 0.25;
-    auto neighbor_list = Cabana::Experimental::makeNeighborList<DeviceType>(
+    auto neighbor_list = Cabana::Experimental::makeNeighborList(
         Cabana::FullNeighborTag{}, positions, 0, positions.size(),
         neighborhood_radius );
 

--- a/example/core_tutorial/10_neighbor_parallel_for/neighbor_parallel_for_example.cpp
+++ b/example/core_tutorial/10_neighbor_parallel_for/neighbor_parallel_for_example.cpp
@@ -56,14 +56,13 @@ void neighborParallelForExample()
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
     using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     const int num_tuple = 81;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
       Define the Cartesian grid and particle positions within it - this matches

--- a/example/core_tutorial/10_simd_parallel_for/simd_parallel_for_example.cpp
+++ b/example/core_tutorial/10_simd_parallel_for/simd_parallel_for_example.cpp
@@ -53,14 +53,13 @@ void simdParallelForExample()
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
     using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     const int num_tuple = 100;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
       Create slices and assign some data. One might consider using a parallel

--- a/example/core_tutorial/11_migration/migration_example.cpp
+++ b/example/core_tutorial/11_migration/migration_example.cpp
@@ -57,14 +57,12 @@ void migrationExample()
     using DataTypes = Cabana::MemberTypes<int, int>;
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 100;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A", num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A", num_tuple );
 
     /*
       Create slices with the MPI rank and a local ID so we can follow where the
@@ -107,7 +105,7 @@ void migrationExample()
       elements are to be discarded, and the last 80 elements stay on this
       rank.
     */
-    Kokkos::View<int*, DeviceType> export_ranks( "export_ranks", num_tuple );
+    Kokkos::View<int*, MemorySpace> export_ranks( "export_ranks", num_tuple );
 
     // First 10 go to the next rank. Note that this view will most often be
     // filled within a parallel_for but we do so in serial here for
@@ -142,8 +140,8 @@ void migrationExample()
     std::sort( neighbors.begin(), neighbors.end() );
     auto unique_end = std::unique( neighbors.begin(), neighbors.end() );
     neighbors.resize( std::distance( neighbors.begin(), unique_end ) );
-    Cabana::Distributor<DeviceType> distributor( MPI_COMM_WORLD, export_ranks,
-                                                 neighbors );
+    Cabana::Distributor<MemorySpace> distributor( MPI_COMM_WORLD, export_ranks,
+                                                  neighbors );
 
     /*
       There are three choices for applying the distributor: 1) Migrating the
@@ -163,7 +161,7 @@ void migrationExample()
     // Also note how this AoSoA is sized. The distrubutor computes how many
     // imported elements each rank will recieve. We discard 10 elements, get
     // 10 from our neighbor, and keep 80 of our own so this number should be 90.
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> destination(
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> destination(
         "destination", distributor.totalNumImport() );
 
     // Do the migration.

--- a/example/core_tutorial/12_halo_exchange/halo_exchange_example.cpp
+++ b/example/core_tutorial/12_halo_exchange/halo_exchange_example.cpp
@@ -61,15 +61,13 @@ void haloExchangeExample()
     using DataTypes = Cabana::MemberTypes<double, double>;
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
-    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
        Create the AoSoA.
     */
     int num_tuple = 100;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "my_aosoa",
-                                                              num_tuple );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "my_aosoa",
+                                                               num_tuple );
 
     /*
       Create slices with the MPI rank and a local ID so we can follow where the
@@ -110,9 +108,9 @@ void haloExchangeExample()
       Build a halo where the last 10 elements are sent to the next rank.
     */
     int local_num_send = 10;
-    Kokkos::View<int*, DeviceType> export_ranks( "export_ranks",
-                                                 local_num_send );
-    Kokkos::View<int*, DeviceType> export_ids( "export_ids", local_num_send );
+    Kokkos::View<int*, MemorySpace> export_ranks( "export_ranks",
+                                                  local_num_send );
+    Kokkos::View<int*, MemorySpace> export_ids( "export_ids", local_num_send );
 
     // Last 10 elements (elements 90-99) go to the next rank. Note that this
     // view will most often be filled within a parallel_for but we do so in
@@ -141,8 +139,8 @@ void haloExchangeExample()
     std::sort( neighbors.begin(), neighbors.end() );
     auto unique_end = std::unique( neighbors.begin(), neighbors.end() );
     neighbors.resize( std::distance( neighbors.begin(), unique_end ) );
-    Cabana::Halo<DeviceType> halo( MPI_COMM_WORLD, num_tuple, export_ids,
-                                   export_ranks, neighbors );
+    Cabana::Halo<MemorySpace> halo( MPI_COMM_WORLD, num_tuple, export_ids,
+                                    export_ranks, neighbors );
 
     /*
       Resize the AoSoA to allow for additional ghost data. We can get the

--- a/example/core_tutorial/13_hdf5_output/hdf5_output_example.cpp
+++ b/example/core_tutorial/13_hdf5_output/hdf5_output_example.cpp
@@ -50,14 +50,13 @@ void hdf5_output()
     const int VectorLength = 8;
     using MemorySpace = Kokkos::HostSpace;
     using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
-    using DeviceType = Kokkos::Device<ExecutionSpace, MemorySpace>;
 
     /*
       Create the AoSoA.
     */
     int num_particles = 9;
-    Cabana::AoSoA<DataTypes, DeviceType, VectorLength> aosoa( "A",
-                                                              num_particles );
+    Cabana::AoSoA<DataTypes, MemorySpace, VectorLength> aosoa( "A",
+                                                               num_particles );
 
     /*
       Get the particle ids, coordinates, velocity, radius


### PR DESCRIPTION
Convert all class template parameters to memory space rather than device type to close #407. 

- Convert classes
- Add explicit execution space class methods (pass default exec space for existing methods)
- Default device typedefs deprecated. 
- Deprecation warning emitted when device type passed
- Examples and tests updated accordingly (Note only the comm plan used the device type explicitly in tests - the rest already used memory spaces)