### PR TITLE
Fixup particle list

### DIFF
--- a/cajita/src/Cajita_ParticleList.hpp
+++ b/cajita/src/Cajita_ParticleList.hpp
@@ -86,10 +86,12 @@ class MeshParticleList
             _aosoa, _mesh->minimumHaloWidth(), force_redistribute );
     }
 
-  private:
+  protected:
+    //! Particle AoSoA.
     using base::_aosoa;
     using base::_label;
 
+    //! Cajita mesh.
     std::shared_ptr<MeshType> _mesh;
 };
 

--- a/cajita/src/Cajita_ParticleList.hpp
+++ b/cajita/src/Cajita_ParticleList.hpp
@@ -89,8 +89,6 @@ class MeshParticleList
   protected:
     //! Particle AoSoA.
     using base::_aosoa;
-    using base::_label;
-
     //! Cajita mesh.
     std::shared_ptr<MeshType> _mesh;
 };

--- a/cajita/unit_test/CMakeLists.txt
+++ b/cajita/unit_test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MPI_TESTS
   BovWriter
   Parallel
   Partitioner
+  ParticleList
   SparseArray
   SparseDimPartitioner
   SparseLocalGrid

--- a/cajita/unit_test/tstParticleList.hpp
+++ b/cajita/unit_test/tstParticleList.hpp
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cabana_Fields.hpp>
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_ParticleList.hpp>
+#include <Cajita_Partitioner.hpp>
+
+#include <../../core/unit_test/particle_list_unit_test.hpp>
+
+#include <gtest/gtest.h>
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, particle_test )
+{
+    // Create the global mesh.
+    std::array<double, 3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double, 3> high_corner = { -0.3, 9.5, 2.3 };
+    double cell_size = 0.05;
+    auto global_mesh =
+        Cajita::createUniformGlobalMesh( low_corner, high_corner, cell_size );
+
+    // Create the global grid.
+    Cajita::DimBlockPartitioner<3> partitioner;
+    std::array<bool, 3> is_dim_periodic = { true, true, true };
+    auto global_grid = Cajita::createGlobalGrid( MPI_COMM_WORLD, global_mesh,
+                                                 is_dim_periodic, partitioner );
+
+    // Create a local mesh.
+    auto local_grid = Cajita::createLocalGrid( global_grid, 1 );
+    auto local_mesh = Cajita::createLocalMesh<TEST_DEVICE>( *local_grid );
+    auto local_mesh_ptr =
+        std::make_shared<decltype( local_mesh )>( local_mesh );
+
+    auto fields = Cabana::ParticleTraits<Cabana::Field::Position<3>, Foo,
+                                         CommRank, Bar>();
+    auto plist = Cajita::createMeshParticleList( "test_particles",
+                                                 local_mesh_ptr, fields );
+
+    particleListTest( *plist );
+
+    particleViewTest( *plist );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/cajita/unit_test/tstParticleList.hpp
+++ b/cajita/unit_test/tstParticleList.hpp
@@ -44,17 +44,15 @@ TEST( TEST_CATEGORY, particle_test )
     // Create a local mesh.
     auto local_grid = Cajita::createLocalGrid( global_grid, 1 );
 
-    auto fields = Cabana::ParticleTraits<Cabana::Field::Position<3>, Foo,
-                                         CommRank, Bar>();
-    auto plist = Cajita::createMeshParticleList<TEST_MEMSPACE>(
-        "test_particles", local_grid, fields );
+    auto plist = Cajita::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>,
+                                      Foo, CommRank, Bar>( "test_particles" );
 
     particleListTest( plist );
 
     particleViewTest( plist );
 
     // Use explicit field tag even though it could be done internally.
-    plist.redistribute( Cabana::Field::Position<3>() );
+    plist.redistribute( *local_grid, Cabana::Field::Position<3>() );
 }
 
 //---------------------------------------------------------------------------//

--- a/cajita/unit_test/tstParticleList.hpp
+++ b/cajita/unit_test/tstParticleList.hpp
@@ -43,18 +43,18 @@ TEST( TEST_CATEGORY, particle_test )
 
     // Create a local mesh.
     auto local_grid = Cajita::createLocalGrid( global_grid, 1 );
-    auto local_mesh = Cajita::createLocalMesh<TEST_DEVICE>( *local_grid );
-    auto local_mesh_ptr =
-        std::make_shared<decltype( local_mesh )>( local_mesh );
 
     auto fields = Cabana::ParticleTraits<Cabana::Field::Position<3>, Foo,
                                          CommRank, Bar>();
-    auto plist = Cajita::createMeshParticleList( "test_particles",
-                                                 local_mesh_ptr, fields );
+    auto plist = Cajita::createMeshParticleList<TEST_MEMSPACE>(
+        "test_particles", local_grid, fields );
 
-    particleListTest( *plist );
+    particleListTest( plist );
 
-    particleViewTest( *plist );
+    particleViewTest( plist );
+
+    // Use explicit field tag even though it could be done internally.
+    plist.redistribute( Cabana::Field::Position<3>() );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -202,7 +202,6 @@ class ParticleList
     //! Default constructor.
     ParticleList( const std::string& label )
         : _aosoa( label )
-        , _label( label )
     {
     }
 
@@ -238,8 +237,8 @@ class ParticleList
         return particle_view_type( _aosoa.access( s ), a );
     }
 
-    //! Get the label.
-    const std::string& label() const { return _label; }
+    //! Get the AoSoA label.
+    const std::string& label() const { return _aosoa.label(); }
 
     //! Get a slice of a given field.
     template <class FieldTag>
@@ -253,7 +252,6 @@ class ParticleList
   protected:
     //! Particle AoSoA.
     aosoa_type _aosoa;
-    std::string _label;
 };
 
 //---------------------------------------------------------------------------//

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -250,7 +250,8 @@ class ParticleList
             _aosoa, FieldTag::label() );
     }
 
-  private:
+  protected:
+    //! Particle AoSoA.
     aosoa_type _aosoa;
     std::string _label;
 };

--- a/core/src/Cabana_ParticleList.hpp
+++ b/core/src/Cabana_ParticleList.hpp
@@ -257,10 +257,10 @@ class ParticleList
 //---------------------------------------------------------------------------//
 //! ParticleList creation function.
 template <class MemorySpace, class... FieldTags>
-std::shared_ptr<ParticleList<MemorySpace, FieldTags...>>
-createParticleList( const std::string& label, ParticleTraits<FieldTags...> )
+auto createParticleList( const std::string& label,
+                         ParticleTraits<FieldTags...> )
 {
-    return std::make_shared<ParticleList<MemorySpace, FieldTags...>>( label );
+    return ParticleList<MemorySpace, FieldTags...>( label );
 }
 
 //---------------------------------------------------------------------------//

--- a/core/unit_test/particle_list_unit_test.hpp
+++ b/core/unit_test/particle_list_unit_test.hpp
@@ -1,0 +1,209 @@
+/****************************************************************************
+ * Copyright (c) 2018-2022 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cabana_DeepCopy.hpp>
+#include <Cabana_Fields.hpp>
+#include <Cabana_ParticleList.hpp>
+
+#include <gtest/gtest.h>
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+// Fields.
+struct CommRank : Cabana::Field::Scalar<int>
+{
+    static std::string label() { return "comm_rank"; }
+};
+
+struct Foo : Cabana::Field::Scalar<double>
+{
+    static std::string label() { return "foo"; }
+};
+
+struct Bar : Cabana::Field::Matrix<double, 3, 3>
+{
+    static std::string label() { return "bar"; }
+};
+
+//---------------------------------------------------------------------------//
+template <class ListType>
+void particleListTest( ListType plist )
+{
+    // Resize the aosoa.
+    auto& aosoa = plist.aosoa();
+    std::size_t num_p = 10;
+    aosoa.resize( num_p );
+    EXPECT_EQ( plist.aosoa().size(), 10 );
+
+    // Populate fields.
+    auto px = plist.slice( Cabana::Field::Position<3>() );
+    auto pm = plist.slice( Foo() );
+    auto pc = plist.slice( CommRank() );
+    auto pf = plist.slice( Bar() );
+
+    Cabana::deep_copy( px, 1.23 );
+    Cabana::deep_copy( pm, 3.3 );
+    Cabana::deep_copy( pc, 5 );
+    Cabana::deep_copy( pf, -1.2 );
+
+    // Check the slices.
+    EXPECT_EQ( px.label(), "position" );
+    EXPECT_EQ( pm.label(), "foo" );
+    EXPECT_EQ( pc.label(), "comm_rank" );
+    EXPECT_EQ( pf.label(), "bar" );
+
+    // Check deep copy.
+    auto aosoa_host =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto px_h = Cabana::slice<0>( aosoa_host );
+    auto pm_h = Cabana::slice<1>( aosoa_host );
+    auto pc_h = Cabana::slice<2>( aosoa_host );
+    auto pf_h = Cabana::slice<3>( aosoa_host );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
+
+        EXPECT_EQ( pc_h( p ), 5 );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
+    }
+
+    // Locally modify.
+    Kokkos::parallel_for(
+        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
+        KOKKOS_LAMBDA( const int p ) {
+            auto particle = plist.getParticle( p );
+
+            for ( int d = 0; d < 3; ++d )
+                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
+
+            get( particle, Foo() ) += p;
+
+            get( particle, CommRank() ) += p;
+
+            for ( int i = 0; i < 3; ++i )
+                for ( int j = 0; j < 3; ++j )
+                    get( particle, Bar(), i, j ) += p + i + j;
+
+            plist.setParticle( particle, p );
+        } );
+
+    // Check the modification.
+    Cabana::deep_copy( aosoa_host, aosoa );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
+
+        EXPECT_EQ( pc_h( p ), 5 + p );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
+    }
+}
+
+//---------------------------------------------------------------------------//
+template <class ListType>
+void particleViewTest( ListType plist )
+{
+    // Resize the aosoa.
+    auto& aosoa = plist.aosoa();
+    std::size_t num_p = 10;
+    aosoa.resize( num_p );
+    EXPECT_EQ( plist.aosoa().size(), 10 );
+
+    // Populate fields.
+    auto px = plist.slice( Cabana::Field::Position<3>() );
+    auto pm = plist.slice( Foo() );
+    auto pc = plist.slice( CommRank() );
+    auto pf = plist.slice( Bar() );
+
+    Cabana::deep_copy( px, 1.23 );
+    Cabana::deep_copy( pm, 3.3 );
+    Cabana::deep_copy( pc, 5 );
+    Cabana::deep_copy( pf, -1.2 );
+
+    // Check the slices.
+    EXPECT_EQ( px.label(), "position" );
+    EXPECT_EQ( pm.label(), "foo" );
+    EXPECT_EQ( pc.label(), "comm_rank" );
+    EXPECT_EQ( pf.label(), "bar" );
+
+    // Check deep copy.
+    auto aosoa_host =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto px_h = Cabana::slice<0>( aosoa_host );
+    auto pm_h = Cabana::slice<1>( aosoa_host );
+    auto pc_h = Cabana::slice<2>( aosoa_host );
+    auto pf_h = Cabana::slice<3>( aosoa_host );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
+
+        EXPECT_EQ( pc_h( p ), 5 );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
+    }
+
+    // Locally modify.
+    Kokkos::parallel_for(
+        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
+        KOKKOS_LAMBDA( const int p ) {
+            auto particle = plist.getParticleView( p );
+
+            for ( int d = 0; d < 3; ++d )
+                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
+
+            get( particle, Foo() ) += p;
+
+            get( particle, CommRank() ) += p;
+
+            for ( int i = 0; i < 3; ++i )
+                for ( int j = 0; j < 3; ++j )
+                    get( particle, Bar(), i, j ) += p + i + j;
+        } );
+
+    // Check the modification.
+    Cabana::deep_copy( aosoa_host, aosoa );
+    for ( std::size_t p = 0; p < num_p; ++p )
+    {
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
+
+        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
+
+        EXPECT_EQ( pc_h( p ), 5 + p );
+
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
+    }
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/core/unit_test/tstParticleList.hpp
+++ b/core/unit_test/tstParticleList.hpp
@@ -11,216 +11,35 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <Cabana_DeepCopy.hpp>
 #include <Cabana_Fields.hpp>
 #include <Cabana_ParticleList.hpp>
+
+#include <particle_list_unit_test.hpp>
 
 #include <gtest/gtest.h>
 
 namespace Test
 {
 //---------------------------------------------------------------------------//
-// Fields.
-struct CommRank : Cabana::Field::Scalar<int>
-{
-    static std::string label() { return "comm_rank"; }
-};
-
-struct Foo : Cabana::Field::Scalar<double>
-{
-    static std::string label() { return "foo"; }
-};
-
-struct Bar : Cabana::Field::Matrix<double, 3, 3>
-{
-    static std::string label() { return "bar"; }
-};
-
-//---------------------------------------------------------------------------//
-void particleListTest()
-{
-    // Make a particle list.
-    using list_type =
-        Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
-                             CommRank, Bar>;
-    list_type plist( "test_particles" );
-
-    // Resize the aosoa.
-    auto& aosoa = plist.aosoa();
-    std::size_t num_p = 10;
-    aosoa.resize( num_p );
-    EXPECT_EQ( plist.aosoa().size(), 10 );
-
-    // Populate fields.
-    auto px = plist.slice( Cabana::Field::Position<3>() );
-    auto pm = plist.slice( Foo() );
-    auto pc = plist.slice( CommRank() );
-    auto pf = plist.slice( Bar() );
-
-    Cabana::deep_copy( px, 1.23 );
-    Cabana::deep_copy( pm, 3.3 );
-    Cabana::deep_copy( pc, 5 );
-    Cabana::deep_copy( pf, -1.2 );
-
-    // Check the slices.
-    EXPECT_EQ( px.label(), "position" );
-    EXPECT_EQ( pm.label(), "foo" );
-    EXPECT_EQ( pc.label(), "comm_rank" );
-    EXPECT_EQ( pf.label(), "bar" );
-
-    // Check deep copy.
-    auto aosoa_host =
-        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
-    auto px_h = Cabana::slice<0>( aosoa_host );
-    auto pm_h = Cabana::slice<1>( aosoa_host );
-    auto pc_h = Cabana::slice<2>( aosoa_host );
-    auto pf_h = Cabana::slice<3>( aosoa_host );
-    for ( std::size_t p = 0; p < num_p; ++p )
-    {
-        for ( int d = 0; d < 3; ++d )
-            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
-
-        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
-
-        EXPECT_EQ( pc_h( p ), 5 );
-
-        for ( int i = 0; i < 3; ++i )
-            for ( int j = 0; j < 3; ++j )
-                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
-    }
-
-    // Locally modify.
-    Kokkos::parallel_for(
-        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
-        KOKKOS_LAMBDA( const int p ) {
-            auto particle = plist.getParticle( p );
-
-            for ( int d = 0; d < 3; ++d )
-                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
-
-            get( particle, Foo() ) += p;
-
-            get( particle, CommRank() ) += p;
-
-            for ( int i = 0; i < 3; ++i )
-                for ( int j = 0; j < 3; ++j )
-                    get( particle, Bar(), i, j ) += p + i + j;
-
-            plist.setParticle( particle, p );
-        } );
-
-    // Check the modification.
-    Cabana::deep_copy( aosoa_host, aosoa );
-    for ( std::size_t p = 0; p < num_p; ++p )
-    {
-        for ( int d = 0; d < 3; ++d )
-            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
-
-        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
-
-        EXPECT_EQ( pc_h( p ), 5 + p );
-
-        for ( int i = 0; i < 3; ++i )
-            for ( int j = 0; j < 3; ++j )
-                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
-    }
-}
-
-//---------------------------------------------------------------------------//
-void particleViewTest()
-{
-    // Make a particle list.
-    using list_type =
-        Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
-                             CommRank, Bar>;
-
-    list_type plist( "test_particles" );
-
-    // Resize the aosoa.
-    auto& aosoa = plist.aosoa();
-    std::size_t num_p = 10;
-    aosoa.resize( num_p );
-    EXPECT_EQ( plist.aosoa().size(), 10 );
-
-    // Populate fields.
-    auto px = plist.slice( Cabana::Field::Position<3>() );
-    auto pm = plist.slice( Foo() );
-    auto pc = plist.slice( CommRank() );
-    auto pf = plist.slice( Bar() );
-
-    Cabana::deep_copy( px, 1.23 );
-    Cabana::deep_copy( pm, 3.3 );
-    Cabana::deep_copy( pc, 5 );
-    Cabana::deep_copy( pf, -1.2 );
-
-    // Check the slices.
-    EXPECT_EQ( px.label(), "position" );
-    EXPECT_EQ( pm.label(), "foo" );
-    EXPECT_EQ( pc.label(), "comm_rank" );
-    EXPECT_EQ( pf.label(), "bar" );
-
-    // Check deep copy.
-    auto aosoa_host =
-        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
-    auto px_h = Cabana::slice<0>( aosoa_host );
-    auto pm_h = Cabana::slice<1>( aosoa_host );
-    auto pc_h = Cabana::slice<2>( aosoa_host );
-    auto pf_h = Cabana::slice<3>( aosoa_host );
-    for ( std::size_t p = 0; p < num_p; ++p )
-    {
-        for ( int d = 0; d < 3; ++d )
-            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 );
-
-        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 );
-
-        EXPECT_EQ( pc_h( p ), 5 );
-
-        for ( int i = 0; i < 3; ++i )
-            for ( int j = 0; j < 3; ++j )
-                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 );
-    }
-
-    // Locally modify.
-    Kokkos::parallel_for(
-        "modify", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_p ),
-        KOKKOS_LAMBDA( const int p ) {
-            auto particle = plist.getParticleView( p );
-
-            for ( int d = 0; d < 3; ++d )
-                get( particle, Cabana::Field::Position<3>(), d ) += p + d;
-
-            get( particle, Foo() ) += p;
-
-            get( particle, CommRank() ) += p;
-
-            for ( int i = 0; i < 3; ++i )
-                for ( int j = 0; j < 3; ++j )
-                    get( particle, Bar(), i, j ) += p + i + j;
-        } );
-
-    // Check the modification.
-    Cabana::deep_copy( aosoa_host, aosoa );
-    for ( std::size_t p = 0; p < num_p; ++p )
-    {
-        for ( int d = 0; d < 3; ++d )
-            EXPECT_DOUBLE_EQ( px_h( p, d ), 1.23 + p + d );
-
-        EXPECT_DOUBLE_EQ( pm_h( p ), 3.3 + p );
-
-        EXPECT_EQ( pc_h( p ), 5 + p );
-
-        for ( int i = 0; i < 3; ++i )
-            for ( int j = 0; j < 3; ++j )
-                EXPECT_DOUBLE_EQ( pf_h( p, i, j ), -1.2 + p + i + j );
-    }
-}
-
-//---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, particle_test ) { particleListTest(); }
+TEST( TEST_CATEGORY, particle_test )
+{
+    Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
+                         CommRank, Bar>
+        plist( "test_particles" );
 
-TEST( TEST_CATEGORY, particle_view_test ) { particleViewTest(); }
+    particleListTest( plist );
+}
+
+TEST( TEST_CATEGORY, particle_view_test )
+{
+    Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
+                         CommRank, Bar>
+        plist( "test_particles" );
+
+    particleViewTest( plist );
+}
 
 //---------------------------------------------------------------------------//
 

--- a/core/unit_test/tstParticleList.hpp
+++ b/core/unit_test/tstParticleList.hpp
@@ -25,18 +25,20 @@ namespace Test
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, particle_test )
 {
-    Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
-                         CommRank, Bar>
-        plist( "test_particles" );
+    auto fields = Cabana::ParticleTraits<Cabana::Field::Position<3>, Foo,
+                                         CommRank, Bar>();
+    auto plist =
+        Cabana::createParticleList<TEST_MEMSPACE>( "test_particles", fields );
 
     particleListTest( plist );
 }
 
 TEST( TEST_CATEGORY, particle_view_test )
 {
-    Cabana::ParticleList<TEST_MEMSPACE, Cabana::Field::Position<3>, Foo,
-                         CommRank, Bar>
-        plist( "test_particles" );
+    auto fields = Cabana::ParticleTraits<Cabana::Field::Position<3>, Foo,
+                                         CommRank, Bar>();
+    auto plist =
+        Cabana::createParticleList<TEST_MEMSPACE>( "test_particles", fields );
 
     particleViewTest( plist );
 }


### PR DESCRIPTION
Overall, these issues stem from not testing the Cajita extension of the core particle list - the initial Caijta version did not compile

- Private class member needs to be protected
- Workaround for device access of string member
~Local grid needs to be stored instead of local mesh~
