### PR TITLE
Require C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
 
-# Use C++14
-set(CMAKE_CXX_STANDARD 14)
+# Use C++17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
 
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
-
 # Disable verbose makefiles
 option(CMAKE_VERBOSE_MAKEFILE "Generate verbose Makefiles" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 endif(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
 
-# Use C++17
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 

--- a/cajita/src/CMakeLists.txt
+++ b/cajita/src/CMakeLists.txt
@@ -65,6 +65,7 @@ if(Cabana_ENABLE_SILO)
 endif()
 
 add_library(Cajita INTERFACE)
+set_target_properties(Cajita PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
 add_library(Cabana::Cajita ALIAS Cajita)
 
 target_link_libraries(Cajita INTERFACE

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -60,6 +60,9 @@ set(HEADERS_IMPL
 
 add_library(cabanacore INTERFACE)
 
+# Require minimum of C++17
+set_target_properties(cabanacore PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+
 target_link_libraries(cabanacore INTERFACE Kokkos::kokkos)
 
 if(Cabana_ENABLE_ARBORX)


### PR DESCRIPTION
In anticipation of requirement in Kokkos 4. Tracking related future updates in #596 

Removes override of CMake standard and instead uses `INTERFACE_COMPILE_FEATURES` to require a minimum standard 