### PR TITLE
Replace `Kokkos::View::{R -> r}ank` and `Slice::{R->r}ank` and `Slice::{rank->viewRank}()`

### DIFF
--- a/cajita/src/Cajita_IndexSpace.hpp
+++ b/cajita/src/Cajita_IndexSpace.hpp
@@ -354,7 +354,7 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
                                            const IndexSpace<1>& index_space )
     -> decltype( Kokkos::subview( view, index_space.range( 0 ) ) )
 {
-    static_assert( 1 == ViewType::Rank, "Incorrect view rank" );
+    static_assert( 1 == ViewType::rank, "Incorrect view rank" );
     return Kokkos::subview( view, index_space.range( 0 ) );
 }
 
@@ -370,7 +370,7 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
     -> decltype( Kokkos::subview( view, index_space.range( 0 ),
                                   index_space.range( 1 ) ) )
 {
-    static_assert( 2 == ViewType::Rank, "Incorrect view rank" );
+    static_assert( 2 == ViewType::rank, "Incorrect view rank" );
     return Kokkos::subview( view, index_space.range( 0 ),
                             index_space.range( 1 ) );
 }
@@ -388,7 +388,7 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
                                   index_space.range( 1 ),
                                   index_space.range( 2 ) ) )
 {
-    static_assert( 3 == ViewType::Rank, "Incorrect view rank" );
+    static_assert( 3 == ViewType::rank, "Incorrect view rank" );
     return Kokkos::subview( view, index_space.range( 0 ),
                             index_space.range( 1 ), index_space.range( 2 ) );
 }
@@ -407,7 +407,7 @@ KOKKOS_INLINE_FUNCTION auto createSubview( const ViewType& view,
                                   index_space.range( 2 ),
                                   index_space.range( 3 ) ) )
 {
-    static_assert( 4 == ViewType::Rank, "Incorrect view rank" );
+    static_assert( 4 == ViewType::rank, "Incorrect view rank" );
     return Kokkos::subview( view, index_space.range( 0 ),
                             index_space.range( 1 ), index_space.range( 2 ),
                             index_space.range( 3 ) );

--- a/cajita/src/Cajita_Interpolation.hpp
+++ b/cajita/src/Cajita_Interpolation.hpp
@@ -912,7 +912,7 @@ struct ScalarValueG2P
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+        static_assert( 1 == ViewType::rank, "View must be of scalars" );
     }
 
     //! Apply spline interplation.
@@ -961,7 +961,7 @@ struct VectorValueG2P
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+        static_assert( 2 == ViewType::rank, "View must be of vectors" );
     }
 
     //! Apply spline interplation.
@@ -1011,7 +1011,7 @@ struct ScalarGradientG2P
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+        static_assert( 2 == ViewType::rank, "View must be of vectors" );
     }
 
     //! Apply spline interplation.
@@ -1061,7 +1061,7 @@ struct VectorGradientG2P
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
+        static_assert( 3 == ViewType::rank, "View must be of tensors" );
     }
 
     //! Apply spline interplation.
@@ -1113,7 +1113,7 @@ struct VectorDivergenceG2P
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+        static_assert( 1 == ViewType::rank, "View must be of scalars" );
     }
 
     //! Apply spline interplation.
@@ -1259,7 +1259,7 @@ struct ScalarValueP2G
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+        static_assert( 1 == ViewType::rank, "View must be of scalars" );
     }
 
     //! Apply spline interplation.
@@ -1307,7 +1307,7 @@ struct VectorValueP2G
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+        static_assert( 2 == ViewType::rank, "View must be of vectors" );
     }
 
     //! Apply spline interplation.
@@ -1357,7 +1357,7 @@ struct ScalarGradientP2G
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+        static_assert( 1 == ViewType::rank, "View must be of scalars" );
     }
 
     //! Apply spline interplation.
@@ -1405,7 +1405,7 @@ struct VectorDivergenceP2G
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+        static_assert( 2 == ViewType::rank, "View must be of vectors" );
     }
 
     //! Apply spline interplation.
@@ -1455,7 +1455,7 @@ struct TensorDivergenceP2G
         : _x( x )
         , _multiplier( multiplier )
     {
-        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
+        static_assert( 3 == ViewType::rank, "View must be of tensors" );
     }
 
     //! Apply spline interplation.

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1043,7 +1043,7 @@ struct CommunicationDataSlice
     void setSliceComponents()
     {
         _num_comp = 1;
-        for ( std::size_t d = 2; d < _particles.rank(); ++d )
+        for ( std::size_t d = 2; d < _particles.viewRank(); ++d )
             _num_comp *= _particles.extent( d );
     }
 

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -327,7 +327,7 @@ deep_copy( DstSlice& dst, const SrcSlice& src,
 
     // Get the number of components in each slice element.
     std::size_t num_comp = 1;
-    for ( std::size_t d = 2; d < dst.rank(); ++d )
+    for ( std::size_t d = 2; d < dst.viewRank(); ++d )
         num_comp *= dst.extent( d );
 
     // Gather the slice data in a flat view in the source space and copy it to

--- a/core/src/Cabana_Distributor.hpp
+++ b/core/src/Cabana_Distributor.hpp
@@ -437,7 +437,7 @@ void migrate( const Distributor_t& distributor, const Slice_t& src,
 
     // Get the number of components in the slices.
     size_t num_comp = 1;
-    for ( size_t d = 2; d < src.rank(); ++d )
+    for ( size_t d = 2; d < src.viewRank(); ++d )
         num_comp *= src.extent( d );
 
     // Get the raw slice data.

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -794,7 +794,7 @@ class Slice
       \return The rank of the data for this slice.
     */
     KOKKOS_INLINE_FUNCTION
-    constexpr size_type rank() const { return _view.Rank; }
+    constexpr size_type rank() const { return _view.rank; }
 
     /*!
       \brief Get the extent of a given raw slice data dimension. This includes

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -584,7 +584,7 @@ class Slice
     // compatibility with Kokkos views.
     enum
     {
-        Rank = std::rank<DataType>::value + 1
+        rank = std::rank<DataType>::value + 1
     };
 
   public:
@@ -794,7 +794,7 @@ class Slice
       \return The rank of the data for this slice.
     */
     KOKKOS_INLINE_FUNCTION
-    constexpr size_type rank() const { return _view.rank; }
+    constexpr size_type viewRank() const { return _view.rank; }
 
     /*!
       \brief Get the extent of a given raw slice data dimension. This includes

--- a/core/src/Cabana_Sort.hpp
+++ b/core/src/Cabana_Sort.hpp
@@ -658,7 +658,7 @@ void permute(
 
     // Get the number of components in the slice.
     std::size_t num_comp = 1;
-    for ( std::size_t d = 2; d < slice.rank(); ++d )
+    for ( std::size_t d = 2; d < slice.viewRank(); ++d )
         num_comp *= slice.extent( d );
 
     // Get the raw slice data.

--- a/core/unit_test/tstSlice.hpp
+++ b/core/unit_test/tstSlice.hpp
@@ -149,23 +149,27 @@ void apiTest()
     checkDataMembers( aosoa, fval, dval, ival, dim_1, dim_2, dim_3 );
 
     // Check the raw pointer interface sizes.
-    EXPECT_EQ( slice_0.rank(), 5 );
+    EXPECT_EQ( slice_0.viewRank(), 5 );
+    EXPECT_EQ( slice_0.rank, 4 );
     EXPECT_EQ( slice_0.extent( 0 ), 3 );
     EXPECT_EQ( slice_0.extent( 1 ), 16 );
     EXPECT_EQ( slice_0.extent( 2 ), dim_1 );
     EXPECT_EQ( slice_0.extent( 3 ), dim_2 );
     EXPECT_EQ( slice_0.extent( 4 ), dim_3 );
 
-    EXPECT_EQ( slice_1.rank(), 2 );
+    EXPECT_EQ( slice_1.viewRank(), 2 );
+    EXPECT_EQ( slice_1.rank, 1 );
     EXPECT_EQ( slice_1.extent( 0 ), 3 );
     EXPECT_EQ( slice_1.extent( 1 ), 16 );
 
-    EXPECT_EQ( slice_2.rank(), 3 );
+    EXPECT_EQ( slice_2.viewRank(), 3 );
+    EXPECT_EQ( slice_2.rank, 2 );
     EXPECT_EQ( slice_2.extent( 0 ), 3 );
     EXPECT_EQ( slice_2.extent( 1 ), 16 );
     EXPECT_EQ( slice_2.extent( 2 ), dim_1 );
 
-    EXPECT_EQ( slice_3.rank(), 4 );
+    EXPECT_EQ( slice_3.viewRank(), 4 );
+    EXPECT_EQ( slice_3.rank, 3 );
     EXPECT_EQ( slice_3.extent( 0 ), 3 );
     EXPECT_EQ( slice_3.extent( 1 ), 16 );
     EXPECT_EQ( slice_3.extent( 2 ), dim_1 );

--- a/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
+++ b/example/cajita_tutorial/15_interpolation/interpolation_example.cpp
@@ -38,8 +38,8 @@ struct P2GExampleFunctor
         : _x( x )
         , _y( y )
     {
-        static_assert( 1 == ScalarView::Rank, "First View must be of scalars" );
-        static_assert( 2 == VectorView::Rank,
+        static_assert( 1 == ScalarView::rank, "First View must be of scalars" );
+        static_assert( 2 == VectorView::rank,
                        "Second View must be of vectors" );
     }
 
@@ -84,8 +84,8 @@ struct G2PExampleFunctor
         : _x( x )
         , _t( t )
     {
-        static_assert( 1 == ScalarView::Rank, "First View must be of scalars" );
-        static_assert( 3 == TensorView::Rank,
+        static_assert( 1 == ScalarView::rank, "First View must be of scalars" );
+        static_assert( 3 == TensorView::rank,
                        "Second View must be of tensors" );
     }
 


### PR DESCRIPTION
Uppercase `Rank` is not documented in Kokkos Core API.

~Even though it is unclear at this time whether it will ever be deprecated or removed, avoid using it to be on the safe side.~
Now deprecated in Kokkos develop

This is a breaking change