### PR TITLE
Fix comands to run the tutorials

### DIFF
--- a/example/cajita_tutorial/02_global_mesh/CMakeLists.txt
+++ b/example/cajita_tutorial/02_global_mesh/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(GlobalMesh global_mesh_example.cpp)
 target_link_libraries(GlobalMesh Cajita)
-add_test(NAME Cajita_tutorial_02 COMMAND ${NONMPI_PRECOMMAND} GlobalMesh)
+add_test(NAME Cajita_tutorial_02 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} GlobalMesh ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_02 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/02_global_mesh/CMakeLists.txt
+++ b/example/cajita_tutorial/02_global_mesh/CMakeLists.txt
@@ -11,5 +11,4 @@
 
 add_executable(GlobalMesh global_mesh_example.cpp)
 target_link_libraries(GlobalMesh Cajita)
-add_test(NAME Cajita_tutorial_02 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} GlobalMesh ${MPIEXEC_POSTFLAGS})
-set_tests_properties(Cajita_tutorial_02 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})
+add_test(NAME Cajita_tutorial_02 COMMAND ${NONMPI_PRECOMMAND} GlobalMesh)

--- a/example/cajita_tutorial/03_partitioner/CMakeLists.txt
+++ b/example/cajita_tutorial/03_partitioner/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Partitioner partitioner_example.cpp)
 target_link_libraries(Partitioner Cajita)
-add_test(NAME Cajita_tutorial_03 COMMAND ${NONMPI_PRECOMMAND} Partitioner)
+add_test(NAME Cajita_tutorial_03 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Partitioner ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_03 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/04_global_grid/CMakeLists.txt
+++ b/example/cajita_tutorial/04_global_grid/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(GlobalGrid global_grid_example.cpp)
 target_link_libraries(GlobalGrid Cajita)
-add_test(NAME Cajita_tutorial_04 COMMAND ${NONMPI_PRECOMMAND} GlobalGrid)
+add_test(NAME Cajita_tutorial_04 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} GlobalGrid ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_04 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/06_local_grid/CMakeLists.txt
+++ b/example/cajita_tutorial/06_local_grid/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(LocalGrid local_grid_example.cpp)
 target_link_libraries(LocalGrid Cajita)
-add_test(NAME Cajita_tutorial_06 COMMAND ${NONMPI_PRECOMMAND} LocalGrid)
+add_test(NAME Cajita_tutorial_06 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} LocalGrid ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_06 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/07_local_mesh/CMakeLists.txt
+++ b/example/cajita_tutorial/07_local_mesh/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(LocalMesh local_mesh_example.cpp)
 target_link_libraries(LocalMesh Cajita)
-add_test(NAME Cajita_tutorial_07 COMMAND ${NONMPI_PRECOMMAND} LocalMesh)
+add_test(NAME Cajita_tutorial_07 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} LocalMesh ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_07 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/08_array/CMakeLists.txt
+++ b/example/cajita_tutorial/08_array/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Array array_example.cpp)
 target_link_libraries(Array Cajita)
-add_test(NAME Cajita_tutorial_08 COMMAND ${NONMPI_PRECOMMAND} Array)
+add_test(NAME Cajita_tutorial_08 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Array ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_08 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/09_grid_parallel/CMakeLists.txt
+++ b/example/cajita_tutorial/09_grid_parallel/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(GridParallel grid_parallel_example.cpp)
 target_link_libraries(GridParallel Cajita)
-add_test(NAME Cajita_tutorial_09 COMMAND ${NONMPI_PRECOMMAND} GridParallel)
+add_test(NAME Cajita_tutorial_09 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} GridParallel ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_09 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/10_fft_heffte/CMakeLists.txt
+++ b/example/cajita_tutorial/10_fft_heffte/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(HeffteFFT heffte_fast_fourier_transform_example.cpp)
 target_link_libraries(HeffteFFT Cajita)
-add_test(NAME Cajita_tutorial_10 COMMAND ${NONMPI_PRECOMMAND} HeffteFFT)
+add_test(NAME Cajita_tutorial_10 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} HeffteFFT ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_10 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/11_structured_solver/CMakeLists.txt
+++ b/example/cajita_tutorial/11_structured_solver/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(StructuredSolver structured_solver_example.cpp)
 target_link_libraries(StructuredSolver Cajita)
-add_test(NAME Cajita_tutorial_11 COMMAND ${NONMPI_PRECOMMAND} StructuredSolver)
+add_test(NAME Cajita_tutorial_11 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} StructuredSolver ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_11 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/11_structured_solver_hypre/CMakeLists.txt
+++ b/example/cajita_tutorial/11_structured_solver_hypre/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(HypreStructuredSolver hypre_structured_solver_example.cpp)
 target_link_libraries(HypreStructuredSolver Cajita)
-add_test(NAME Cajita_tutorial_11_hypre COMMAND ${NONMPI_PRECOMMAND} HypreStructuredSolver)
+add_test(NAME Cajita_tutorial_11_hypre COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} HypreStructuredSolver ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_11_hypre PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/12_halo/CMakeLists.txt
+++ b/example/cajita_tutorial/12_halo/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Halo halo_example.cpp)
 target_link_libraries(Halo Cajita)
-add_test(NAME Cajita_tutorial_12 COMMAND ${NONMPI_PRECOMMAND} Halo)
+add_test(NAME Cajita_tutorial_12 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Halo ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_12 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/13_all_loadbalancer/CMakeLists.txt
+++ b/example/cajita_tutorial/13_all_loadbalancer/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Loadbalancer loadbalancer_example.cpp)
 target_link_libraries(Loadbalancer Cajita)
-add_test(NAME Cajita_tutorial_13 COMMAND ${NONMPI_PRECOMMAND} Loadbalancer)
+add_test(NAME Cajita_tutorial_13 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Loadbalancer ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_13 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/14_spline/CMakeLists.txt
+++ b/example/cajita_tutorial/14_spline/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Spline spline_example.cpp)
 target_link_libraries(Spline Cajita)
-add_test(NAME Cajita_tutorial_14 COMMAND ${NONMPI_PRECOMMAND} Spline)
+add_test(NAME Cajita_tutorial_14 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Spline ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_14 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/cajita_tutorial/15_interpolation/CMakeLists.txt
+++ b/example/cajita_tutorial/15_interpolation/CMakeLists.txt
@@ -11,4 +11,5 @@
 
 add_executable(Interpolation interpolation_example.cpp)
 target_link_libraries(Interpolation Cajita)
-add_test(NAME Cajita_tutorial_15 COMMAND ${NONMPI_PRECOMMAND} Interpolation)
+add_test(NAME Cajita_tutorial_15 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Interpolation ${MPIEXEC_POSTFLAGS})
+set_tests_properties(Cajita_tutorial_15 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/core_tutorial/04_aosoa_advanced_unmanaged/CMakeLists.txt
+++ b/example/core_tutorial/04_aosoa_advanced_unmanaged/CMakeLists.txt
@@ -11,4 +11,4 @@
 
 add_executable(AdvancedUnmanagedAoSoA advanced_aosoa_unmanaged.cpp)
 target_link_libraries(AdvancedUnmanagedAoSoA cabanacore)
-add_test(NAME Core_tutorial_04_unmanaged COMMAND AdvancedUnmanagedAoSoA)
+add_test(NAME Core_tutorial_04_unmanaged COMMAND ${NONMPI_PRECOMMAND} AdvancedUnmanagedAoSoA)

--- a/example/core_tutorial/11_migration/CMakeLists.txt
+++ b/example/core_tutorial/11_migration/CMakeLists.txt
@@ -12,5 +12,5 @@
   add_executable(Migration migration_example.cpp)
   target_link_libraries(Migration cabanacore)
   add_test(NAME Core_tutorial_11 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
-    ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/Migration ${MPIEXEC_POSTFLAGS})
+    ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} Migration ${MPIEXEC_POSTFLAGS})
   set_tests_properties(Core_tutorial_11 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/core_tutorial/12_halo_exchange/CMakeLists.txt
+++ b/example/core_tutorial/12_halo_exchange/CMakeLists.txt
@@ -12,5 +12,5 @@
   add_executable(HaloExchange halo_exchange_example.cpp)
   target_link_libraries(HaloExchange cabanacore)
   add_test(NAME Core_tutorial_12 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
-    ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/HaloExchange ${MPIEXEC_POSTFLAGS})
+    ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} HaloExchange ${MPIEXEC_POSTFLAGS})
   set_tests_properties(Core_tutorial_12 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})


### PR DESCRIPTION
Was getting errors on Crusher because the Cajita exe were not launched via `srun`
I assumed the intent was to run with `${MPIEXEC_MAX_NUMPROCS`, similar as for the Cabana Core distributed examples.