### PR TITLE
Store Cajita comm in shared_ptr following core comm classes

### DIFF
--- a/cajita/src/Cajita_GlobalGrid.hpp
+++ b/cajita/src/Cajita_GlobalGrid.hpp
@@ -170,7 +170,7 @@ class GlobalGrid
                               const std::array<int, num_space_dim>& offset );
 
   private:
-    MPI_Comm _cart_comm;
+    std::shared_ptr<MPI_Comm> _cart_comm_ptr;
     std::shared_ptr<GlobalMesh<MeshType>> _global_mesh;
     std::array<bool, num_space_dim> _periodic;
     std::array<int, num_space_dim> _ranks_per_dim;


### PR DESCRIPTION
Issue with the `LocalGrid` tutorial example found by @dalg24 in Crusher testing, but does not show up in the CI. 

This uses the same strategy as the core `CommunicationPlan` and fixed when I ran on Crusher