### PR TITLE
Disable HDF5 in nightly build for now

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2.2.0
       - name: Build Cabana
         run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/Cabana -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx" -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON -DCabana_REQUIRE_${{ matrix.backend }}=ON -DVALGRIND_EXECUTABLE=False ${{ github.event.inputs.cmake_args }}
+          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/Cabana -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx" -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON -DCabana_REQUIRE_${{ matrix.backend }}=ON -DVALGRIND_EXECUTABLE=False -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON ${{ github.event.inputs.cmake_args }}
           cmake --build build --parallel 2
           CTEST_OUTPUT_ON_FAILURE=yes cmake --build build --target test
           cmake --install build


### PR DESCRIPTION
Issues with consistent hang & timeout: https://github.com/ECP-copa/Cabana/actions/runs/4975748365