### PR TITLE
Improve HDF5 CMake requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ if(Cabana_ENABLE_HDF5)
   endif()
 
   include(CheckSymbolExists)
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES ${HDF5_INCLUDE_DIRS})
   check_symbol_exists(H5_HAVE_PARALLEL "H5pubconf.h" HDF5_IS_PARALLEL)
   if(NOT HDF5_IS_PARALLEL)
     message(FATAL_ERROR "Cabana HDF5 support requires parallel HDF5.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if(SILO_FOUND)
 endif()
 
 # find HDF5 (XDMF)
+# Set this to always get the parallel version in case both serial and parallel are installed.
+# Parallel is required (see below).
+set(HDF5_PREFER_PARALLEL TRUE)
 # FIXME: not automatically finding since we need to enable C to use it (which
 #        would break pure CXX projects downstream) unless CMake is new enough
 if(CMAKE_VERSION VERSION_LESS 3.26)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,16 @@ else()
   Cabana_add_dependency( PACKAGE HDF5 COMPONENTS C )
 endif()
 
-if(Cabana_ENABLE_HDF5 AND NOT Cabana_ENABLE_MPI)
-  message(FATAL_ERROR "Cabana HDF5 support requires MPI.")
+if(Cabana_ENABLE_HDF5)
+  if(NOT Cabana_ENABLE_MPI)
+    message(FATAL_ERROR "Cabana HDF5 support requires MPI.")
+  endif()
+
+  include(CheckSymbolExists)
+  check_symbol_exists(H5_HAVE_PARALLEL "H5pubconf.h" HDF5_IS_PARALLEL)
+  if(NOT HDF5_IS_PARALLEL)
+    message(FATAL_ERROR "Cabana HDF5 support requires parallel HDF5.")
+  endif()
 endif()
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
- Fail if non-MPI HDF5 is enabled
- Prefer parallel over serial HDF5 (since serial isn't supported)