### PR TITLE
Add 1d and 2d partitioning options

### DIFF
--- a/cajita/unit_test/tstPartitioner.hpp
+++ b/cajita/unit_test/tstPartitioner.hpp
@@ -72,8 +72,8 @@ void owned_cell_info_test_3d( PartitionerType& partitioner )
     std::array<int, 3> owned_num_cell;
     std::array<int, 3> global_cell_offset;
 
-    // The total global cells are avaragely assgined to all ranks
-    // The remainder is averagely spreaded in the first several ranks
+    // The total global cells are averagely assigned to all ranks
+    // The remainder is averagely spread in the first several ranks
     partitioner.ownedCellInfo( cart_comm, global_num_cell, owned_num_cell,
                                global_cell_offset );
 
@@ -130,8 +130,8 @@ void owned_cell_info_test_2d( PartitionerType& partitioner )
     std::array<int, 2> owned_num_cell;
     std::array<int, 2> global_cell_offset;
 
-    // The total global cells are avaragely assgined to all ranks
-    // The remainder is averagely spreaded in the first several ranks
+    // The total global cells are averagely assigned to all ranks
+    // The remainder is averagely spread in the first several ranks
     partitioner.ownedCellInfo( cart_comm, global_num_cell, owned_num_cell,
                                global_cell_offset );
 
@@ -146,6 +146,22 @@ void testBlockPartitioner3d()
 {
     DimBlockPartitioner<3> partitioner;
     owned_cell_info_test_3d( partitioner );
+
+    // Check automatic 2d-YZ decomposition.
+    DimBlockPartitioner<3> partitioner_2d( Cajita::Dim::I );
+    std::array<int, 3> global_cells = { 0, 0, 0 };
+    auto ranks_per_dim_2d =
+        partitioner_2d.ranksPerDimension( MPI_COMM_WORLD, global_cells );
+    EXPECT_EQ( ranks_per_dim_2d[0], 1 );
+    owned_cell_info_test_3d( partitioner_2d );
+
+    // Check automatic 1d-X decomposition.
+    DimBlockPartitioner<3> partitioner_1d( Cajita::Dim::J, Cajita::Dim::K );
+    auto ranks_per_dim_1d =
+        partitioner_1d.ranksPerDimension( MPI_COMM_WORLD, global_cells );
+    EXPECT_EQ( ranks_per_dim_1d[1], 1 );
+    EXPECT_EQ( ranks_per_dim_1d[2], 1 );
+    owned_cell_info_test_3d( partitioner_1d );
 }
 
 void testManualPartitioner3d()
@@ -185,6 +201,13 @@ void testBlockPartitioner2d()
 {
     DimBlockPartitioner<2> partitioner;
     owned_cell_info_test_2d( partitioner );
+
+    // Check automatic 1d-X decomposition.
+    DimBlockPartitioner<2> partitioner_1d( Cajita::Dim::J );
+    auto ranks_per_dim_1d =
+        partitioner_1d.ranksPerDimension( MPI_COMM_WORLD, { 0, 0 } );
+    EXPECT_EQ( ranks_per_dim_1d[1], 1 );
+    owned_cell_info_test_2d( partitioner_1d );
 }
 
 void testManualPartitioner2d()

--- a/example/cajita_tutorial/06_local_grid/local_grid_example.cpp
+++ b/example/cajita_tutorial/06_local_grid/local_grid_example.cpp
@@ -41,10 +41,8 @@ void localGridExample()
     }
 
     // Here we partition only in x to simplify the example below.
-    int comm_size;
-    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> input_ranks_per_dim = { comm_size, 1, 1 };
-    Cajita::ManualBlockPartitioner<3> partitioner( input_ranks_per_dim );
+    Cajita::DimBlockPartitioner<3> partitioner( Cajita::Dim::J,
+                                                Cajita::Dim::K );
 
     // Create the global mesh.
     std::array<int, 3> global_num_cell = { 20, 10, 10 };

--- a/example/cajita_tutorial/12_halo/halo_example.cpp
+++ b/example/cajita_tutorial/12_halo/halo_example.cpp
@@ -50,11 +50,8 @@ void gridHaloExample()
     using device_type = exec_space::device_type;
 
     // Use linear MPI partitioning to make this example simpler.
-    int comm_size;
-    MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { comm_size, 1, 1 };
-    MPI_Dims_create( comm_size, 3, ranks_per_dim.data() );
-    Cajita::ManualBlockPartitioner<3> partitioner( ranks_per_dim );
+    Cajita::DimBlockPartitioner<3> partitioner( Cajita::Dim::J,
+                                                Cajita::Dim::K );
 
     /*
       Boundaries are not periodic in this example, thus ranks at system


### PR DESCRIPTION
Extend `DimBlockPartitioner` to do 1d/2d partitioning for 3d systems and 1d for 2d systems. User passes indices for un-partitioned directions (where no arguments results in 3d partitions)