### PR TITLE
Remove unecessary ArrayOp from grid halo example

### DIFF
--- a/example/cajita_tutorial/12_halo/halo_example.cpp
+++ b/example/cajita_tutorial/12_halo/halo_example.cpp
@@ -99,7 +99,6 @@ void gridHaloExample()
 
         // Assign the owned cells a value of 1 and ghosted 0.
         Cajita::ArrayOp::assign( *array, 0.0, Cajita::Ghost() );
-        Cajita::ArrayOp::assign( *array, 1.0, Cajita::Own() );
 
         // create host mirror view
         auto array_view = array->view();


### PR DESCRIPTION
Duplicates what was already done with the `Ghost` assign