### PR TITLE
Update min required clang-format in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ Cabana_add_dependency( PACKAGE ArborX )
 Cabana_add_dependency( PACKAGE ALL )
 
 # find Clang Format
-find_package( CLANG_FORMAT 10 )
+find_package( CLANG_FORMAT 14 )
 
 # find hypre
 Cabana_add_dependency( PACKAGE HYPRE VERSION 2.22.1 )


### PR DESCRIPTION
Was updated in #531, but never in CMake