### PR TITLE
fixup: HIP CI heffte not compiled due to version

### DIFF
--- a/.github/workflows/CI-e4s.yml
+++ b/.github/workflows/CI-e4s.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Checkout heffte
         # actions/checkout doesn't work for external repos yet (actions/checkout#447)
         run: |
-          git clone --depth 1 --branch v2.1.0 https://bitbucket.org/icl/heffte.git heffte
+          git clone --depth 1 --branch v2.3.0 https://bitbucket.org/icl/heffte.git heffte
       - name: Build heffte
         working-directory: heffte
         run: |
@@ -133,6 +133,8 @@ jobs:
             -DCabana_ENABLE_PERFORMANCE_TESTING=ON \
             -DCabana_PERFORMANCE_EXPECTED_FLOPS=0 \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
+            -DCabana_REQUIRE_ARBORX=ON \
+            -DCabana_REQUIRE_HEFFTE=ON \
             -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON \
             -DGPU_TARGETS="gfx908"
           cmake --build build --parallel 2 --verbose


### PR DESCRIPTION
Make tpl required in HIP CI 