### PR TITLE
Fix heFFTe overflow

### DIFF
--- a/grid/src/Cabana_Grid_FastFourierTransform.hpp
+++ b/grid/src/Cabana_Grid_FastFourierTransform.hpp
@@ -555,7 +555,7 @@ class HeffteFastFourierTransform
         _fft = Impl::createHeffteFft3d(
             heffte_execution_space, heffte_backend_type{}, inbox, outbox,
             layout.localGrid()->globalGrid().comm(), heffte_params );
-        int fftsize = std::max( _fft->size_outbox(), _fft->size_inbox() );
+        long long fftsize = std::max( _fft->size_outbox(), _fft->size_inbox() );
 
         // Check the size.
         auto entity_space =
@@ -568,7 +568,8 @@ class HeffteFastFourierTransform
             Kokkos::ViewAllocateWithoutInitializing( "fft_work" ),
             2 * fftsize );
         _workspace = Kokkos::View<Scalar* [2], memory_space>(
-            "workspace", _fft->size_workspace() );
+            Kokkos::ViewAllocateWithoutInitializing( "workspace" ),
+	    _fft->size_workspace() );
     }
 
     /*!

--- a/grid/src/Cabana_Grid_FastFourierTransform.hpp
+++ b/grid/src/Cabana_Grid_FastFourierTransform.hpp
@@ -568,8 +568,7 @@ class HeffteFastFourierTransform
             Kokkos::ViewAllocateWithoutInitializing( "fft_work" ),
             2 * fftsize );
         _workspace = Kokkos::View<Scalar* [2], memory_space>(
-            Kokkos::ViewAllocateWithoutInitializing( "workspace" ),
-            4 * fftsize );
+            "workspace", _fft->size_workspace() );
     }
 
     /*!

--- a/grid/src/Cabana_Grid_FastFourierTransform.hpp
+++ b/grid/src/Cabana_Grid_FastFourierTransform.hpp
@@ -569,7 +569,7 @@ class HeffteFastFourierTransform
             2 * fftsize );
         _workspace = Kokkos::View<Scalar* [2], memory_space>(
             Kokkos::ViewAllocateWithoutInitializing( "workspace" ),
-	    _fft->size_workspace() );
+            _fft->size_workspace() );
     }
 
     /*!


### PR DESCRIPTION
Heffte FFTs would crash on MPI communication in some cases because ~the workspace passed in wasn't ever allocated.~ of integer overflow. Also use the proper heffte routine to query the size of the workspace to allocate.