### PR TITLE
Guard adding HDF5 include directories

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -100,8 +100,12 @@ target_include_directories(cabanacore INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  ${HDF5_INCLUDE_DIRS} # FIXME: remove when requiring newer CMake
   )
+if(Cabana_ENABLE_HDF5)
+  target_include_directories(cabanacore INTERFACE
+    ${HDF5_INCLUDE_DIRS} # FIXME: remove when requiring newer CMake
+  )
+endif()
 
 install(TARGETS cabanacore
   EXPORT Cabana_Targets


### PR DESCRIPTION
Fix
```
CMake Error in core/src/CMakeLists.txt:
  Target "cabanacore" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "<Cabana>/core/src/HDF5_C_INCLUDE_DIR-NOTFOUND"

  which is prefixed in the source directory.
```
Bug was introduced in #590