### PR TITLE
Link against namespaced targets in examples and benchmarks

### DIFF
--- a/benchmark/core/CMakeLists.txt
+++ b/benchmark/core/CMakeLists.txt
@@ -10,22 +10,22 @@
 ############################################################################
 
 add_executable(BinSortPerformance Cabana_BinSortPerformance.cpp)
-target_link_libraries(BinSortPerformance Core)
+target_link_libraries(BinSortPerformance Cabana::Core)
 
 add_executable(NeighborVerletPerformance Cabana_NeighborVerletPerformance.cpp)
-target_link_libraries(NeighborVerletPerformance Core)
+target_link_libraries(NeighborVerletPerformance Cabana::Core)
 
 if(Cabana_ENABLE_ARBORX)
 add_executable(NeighborArborXPerformance Cabana_NeighborArborXPerformance.cpp)
-target_link_libraries(NeighborArborXPerformance Core)
+target_link_libraries(NeighborArborXPerformance Cabana::Core)
 endif()
 
 add_executable(LinkedCellPerformance Cabana_LinkedCellPerformance.cpp)
-target_link_libraries(LinkedCellPerformance Core)
+target_link_libraries(LinkedCellPerformance Cabana::Core)
 
 if(Cabana_ENABLE_MPI)
 add_executable(CommPerformance Cabana_CommPerformance.cpp)
-target_link_libraries(CommPerformance Core)
+target_link_libraries(CommPerformance Cabana::Core)
 endif()
 
 if(Cabana_ENABLE_TESTING)

--- a/benchmark/grid/CMakeLists.txt
+++ b/benchmark/grid/CMakeLists.txt
@@ -11,21 +11,21 @@
 
 if(NOT Kokkos_ENABLE_SYCL) #FIXME_SYCL
   add_executable(SparseMapPerformance Cabana_Grid_SparseMapPerformance.cpp)
-  target_link_libraries(SparseMapPerformance Grid)
+  target_link_libraries(SparseMapPerformance Cabana::Grid)
 
   add_executable(SparsePartitionerPerformance Cabana_Grid_SparsePartitionerPerformance.cpp)
-  target_link_libraries(SparsePartitionerPerformance Grid)
+  target_link_libraries(SparsePartitionerPerformance Cabana::Grid)
 endif()
 
 add_executable(HaloPerformance Cabana_Grid_HaloPerformance.cpp)
-target_link_libraries(HaloPerformance Grid)
+target_link_libraries(HaloPerformance Cabana::Grid)
 
 add_executable(InterpolationPerformance Cabana_Grid_InterpolationPerformance.cpp)
-target_link_libraries(InterpolationPerformance Grid)
+target_link_libraries(InterpolationPerformance Cabana::Grid)
 
 if(Cabana_ENABLE_HEFFTE)
   add_executable(FastFourierTransformPerformance Cabana_Grid_FastFourierTransformPerformance.cpp)
-  target_link_libraries(FastFourierTransformPerformance Grid)
+  target_link_libraries(FastFourierTransformPerformance Cabana::Grid)
 endif()
 
 if(Cabana_ENABLE_TESTING)

--- a/example/core_tutorial/02_tuple/CMakeLists.txt
+++ b/example/core_tutorial/02_tuple/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(Tuple tuple_example.cpp)
-  target_link_libraries(Tuple Core)
+  target_link_libraries(Tuple Cabana::Core)
   add_test(NAME Core_tutorial_02 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:Tuple>)

--- a/example/core_tutorial/03_struct_of_arrays/CMakeLists.txt
+++ b/example/core_tutorial/03_struct_of_arrays/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(StructOfArrays soa_example.cpp)
-  target_link_libraries(StructOfArrays Core)
+  target_link_libraries(StructOfArrays Cabana::Core)
   add_test(NAME Core_tutorial_03 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:StructOfArrays>)

--- a/example/core_tutorial/04_aosoa/CMakeLists.txt
+++ b/example/core_tutorial/04_aosoa/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(ArrayOfStructsOfArrays aosoa_example.cpp)
-  target_link_libraries(ArrayOfStructsOfArrays Core)
+  target_link_libraries(ArrayOfStructsOfArrays Cabana::Core)
   add_test(NAME Core_tutorial_04 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:ArrayOfStructsOfArrays>)

--- a/example/core_tutorial/04_aosoa_advanced_unmanaged/CMakeLists.txt
+++ b/example/core_tutorial/04_aosoa_advanced_unmanaged/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
 add_executable(AdvancedUnmanagedAoSoA advanced_aosoa_unmanaged.cpp)
-target_link_libraries(AdvancedUnmanagedAoSoA Core)
+target_link_libraries(AdvancedUnmanagedAoSoA Cabana::Core)
 add_test(NAME Core_tutorial_04_unmanaged COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:AdvancedUnmanagedAoSoA>)

--- a/example/core_tutorial/05_slice/CMakeLists.txt
+++ b/example/core_tutorial/05_slice/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(Slice slice_example.cpp)
-  target_link_libraries(Slice Core)
+  target_link_libraries(Slice Cabana::Core)
   add_test(NAME Core_tutorial_05 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:Slice>)

--- a/example/core_tutorial/05_slice_advanced_cuda/CMakeLists.txt
+++ b/example/core_tutorial/05_slice_advanced_cuda/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(AdvancedCudaSlice advanced_slice_cuda.cpp)
-  target_link_libraries(AdvancedCudaSlice Core)
+  target_link_libraries(AdvancedCudaSlice Cabana::Core)
   add_test(NAME Core_tutorial_05_cuda COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:AdvancedCudaSlice>)

--- a/example/core_tutorial/05_slice_advanced_openmp/CMakeLists.txt
+++ b/example/core_tutorial/05_slice_advanced_openmp/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(AdvancedOpenMPSlice advanced_slice_openmp.cpp)
-  target_link_libraries(AdvancedOpenMPSlice Core)
+  target_link_libraries(AdvancedOpenMPSlice Cabana::Core)
   add_test(NAME Core_tutorial_05_openmp COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:AdvancedOpenMPSlice>)

--- a/example/core_tutorial/06_deep_copy/CMakeLists.txt
+++ b/example/core_tutorial/06_deep_copy/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(DeepCopy deep_copy_example.cpp)
-  target_link_libraries(DeepCopy Core)
+  target_link_libraries(DeepCopy Cabana::Core)
   add_test(NAME Core_tutorial_06 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:DeepCopy>)

--- a/example/core_tutorial/07_sorting/CMakeLists.txt
+++ b/example/core_tutorial/07_sorting/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(Sorting sorting_example.cpp)
-  target_link_libraries(Sorting Core)
+  target_link_libraries(Sorting Cabana::Core)
   add_test(NAME Core_tutorial_07 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:Sorting>)

--- a/example/core_tutorial/08_linked_cell_list/CMakeLists.txt
+++ b/example/core_tutorial/08_linked_cell_list/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(LinkedCellList linked_cell_list_example.cpp)
-  target_link_libraries(LinkedCellList Core)
+  target_link_libraries(LinkedCellList Cabana::Core)
   add_test(NAME Core_tutorial_08 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:LinkedCellList>)

--- a/example/core_tutorial/09_neighbor_list/CMakeLists.txt
+++ b/example/core_tutorial/09_neighbor_list/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(VerletList verlet_list_example.cpp)
-  target_link_libraries(VerletList Core)
+  target_link_libraries(VerletList Cabana::Core)
   add_test(NAME Core_tutorial_09 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:VerletList>)

--- a/example/core_tutorial/09_neighbor_list_arborx/CMakeLists.txt
+++ b/example/core_tutorial/09_neighbor_list_arborx/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(ArborXList arborx_neighborlist_example.cpp)
-  target_link_libraries(ArborXList Core)
+  target_link_libraries(ArborXList Cabana::Core)
   add_test(NAME Core_tutorial_09_arborx COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:ArborXList>)

--- a/example/core_tutorial/10_neighbor_parallel_for/CMakeLists.txt
+++ b/example/core_tutorial/10_neighbor_parallel_for/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(NeighParallelFor neighbor_parallel_for_example.cpp)
-  target_link_libraries(NeighParallelFor Core)
+  target_link_libraries(NeighParallelFor Cabana::Core)
   add_test(NAME Core_tutorial_10_neighbor COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:NeighParallelFor>)

--- a/example/core_tutorial/10_simd_parallel_for/CMakeLists.txt
+++ b/example/core_tutorial/10_simd_parallel_for/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
   add_executable(SimdParallelFor simd_parallel_for_example.cpp)
-  target_link_libraries(SimdParallelFor Core)
+  target_link_libraries(SimdParallelFor Cabana::Core)
   add_test(NAME Core_tutorial_10_simd COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:SimdParallelFor>)

--- a/example/core_tutorial/11_migration/CMakeLists.txt
+++ b/example/core_tutorial/11_migration/CMakeLists.txt
@@ -10,7 +10,7 @@
 ############################################################################
 
   add_executable(Migration migration_example.cpp)
-  target_link_libraries(Migration Core)
+  target_link_libraries(Migration Cabana::Core)
   add_test(NAME Core_tutorial_11 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
     ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Migration> ${MPIEXEC_POSTFLAGS})
   set_tests_properties(Core_tutorial_11 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/core_tutorial/12_halo_exchange/CMakeLists.txt
+++ b/example/core_tutorial/12_halo_exchange/CMakeLists.txt
@@ -10,7 +10,7 @@
 ############################################################################
 
   add_executable(HaloExchange halo_exchange_example.cpp)
-  target_link_libraries(HaloExchange Core)
+  target_link_libraries(HaloExchange Cabana::Core)
   add_test(NAME Core_tutorial_12 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
     ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:HaloExchange> ${MPIEXEC_POSTFLAGS})
   set_tests_properties(Core_tutorial_12 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/core_tutorial/13_hdf5_output/CMakeLists.txt
+++ b/example/core_tutorial/13_hdf5_output/CMakeLists.txt
@@ -10,7 +10,7 @@
 ############################################################################
 
 add_executable(HDF5Output hdf5_output_example.cpp)
-target_link_libraries(HDF5Output Core)
+target_link_libraries(HDF5Output Cabana::Core)
 add_test(NAME Core_tutorial_13 COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG}
   ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:HDF5Output> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Core_tutorial_13 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/01_types/CMakeLists.txt
+++ b/example/grid_tutorial/01_types/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
 add_executable(MeshTypes types_example.cpp)
-target_link_libraries(MeshTypes Grid)
+target_link_libraries(MeshTypes Cabana::Grid)
 add_test(NAME Grid_tutorial_01 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:MeshTypes>)

--- a/example/grid_tutorial/02_global_mesh/CMakeLists.txt
+++ b/example/grid_tutorial/02_global_mesh/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
 add_executable(GlobalMesh global_mesh_example.cpp)
-target_link_libraries(GlobalMesh Grid)
+target_link_libraries(GlobalMesh Cabana::Grid)
 add_test(NAME Grid_tutorial_02 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:GlobalMesh>)

--- a/example/grid_tutorial/03_partitioner/CMakeLists.txt
+++ b/example/grid_tutorial/03_partitioner/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Partitioner partitioner_example.cpp)
-target_link_libraries(Partitioner Grid)
+target_link_libraries(Partitioner Cabana::Grid)
 add_test(NAME Grid_tutorial_03 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Partitioner> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_03 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/04_global_grid/CMakeLists.txt
+++ b/example/grid_tutorial/04_global_grid/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(GlobalGrid global_grid_example.cpp)
-target_link_libraries(GlobalGrid Grid)
+target_link_libraries(GlobalGrid Cabana::Grid)
 add_test(NAME Grid_tutorial_04 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:GlobalGrid> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_04 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/05_index_space/CMakeLists.txt
+++ b/example/grid_tutorial/05_index_space/CMakeLists.txt
@@ -10,5 +10,5 @@
 ############################################################################
 
 add_executable(IndexSpace index_space_example.cpp)
-target_link_libraries(IndexSpace Grid)
+target_link_libraries(IndexSpace Cabana::Grid)
 add_test(NAME Grid_tutorial_05 COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:IndexSpace>)

--- a/example/grid_tutorial/06_local_grid/CMakeLists.txt
+++ b/example/grid_tutorial/06_local_grid/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(LocalGrid local_grid_example.cpp)
-target_link_libraries(LocalGrid Grid)
+target_link_libraries(LocalGrid Cabana::Grid)
 add_test(NAME Grid_tutorial_06 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:LocalGrid> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_06 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/07_local_mesh/CMakeLists.txt
+++ b/example/grid_tutorial/07_local_mesh/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(LocalMesh local_mesh_example.cpp)
-target_link_libraries(LocalMesh Grid)
+target_link_libraries(LocalMesh Cabana::Grid)
 add_test(NAME Grid_tutorial_07 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:LocalMesh> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_07 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/08_array/CMakeLists.txt
+++ b/example/grid_tutorial/08_array/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Array array_example.cpp)
-target_link_libraries(Array Grid)
+target_link_libraries(Array Cabana::Grid)
 add_test(NAME Grid_tutorial_08 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Array> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_08 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/09_grid_parallel/CMakeLists.txt
+++ b/example/grid_tutorial/09_grid_parallel/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(GridParallel grid_parallel_example.cpp)
-target_link_libraries(GridParallel Grid)
+target_link_libraries(GridParallel Cabana::Grid)
 add_test(NAME Grid_tutorial_09 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:GridParallel> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_09 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/10_fft_heffte/CMakeLists.txt
+++ b/example/grid_tutorial/10_fft_heffte/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(HeffteFFT heffte_fast_fourier_transform_example.cpp)
-target_link_libraries(HeffteFFT Grid)
+target_link_libraries(HeffteFFT Cabana::Grid)
 add_test(NAME Grid_tutorial_10 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:HeffteFFT> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_10 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/11_semi_structured_solver_multi_variate/CMakeLists.txt
+++ b/example/grid_tutorial/11_semi_structured_solver_multi_variate/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(HypreSemiStructuredSolverMulti hypre_semi_structured_solver_multi_example.cpp)
-target_link_libraries(HypreSemiStructuredSolverMulti Grid)
+target_link_libraries(HypreSemiStructuredSolverMulti Cabana::Grid)
 add_test(NAME Grid_tutorial_11_hypre_SS COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:HypreSemiStructuredSolverMulti> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_11_hypre_SS PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/11_structured_solver/CMakeLists.txt
+++ b/example/grid_tutorial/11_structured_solver/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(StructuredSolver structured_solver_example.cpp)
-target_link_libraries(StructuredSolver Grid)
+target_link_libraries(StructuredSolver Cabana::Grid)
 add_test(NAME Grid_tutorial_11 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:StructuredSolver> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_11 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/11_structured_solver_hypre/CMakeLists.txt
+++ b/example/grid_tutorial/11_structured_solver_hypre/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(HypreStructuredSolver hypre_structured_solver_example.cpp)
-target_link_libraries(HypreStructuredSolver Grid)
+target_link_libraries(HypreStructuredSolver Cabana::Grid)
 add_test(NAME Grid_tutorial_11_hypre COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:HypreStructuredSolver> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_11_hypre PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/12_halo/CMakeLists.txt
+++ b/example/grid_tutorial/12_halo/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Halo halo_example.cpp)
-target_link_libraries(Halo Grid)
+target_link_libraries(Halo Cabana::Grid)
 add_test(NAME Grid_tutorial_12 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Halo> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_12 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/13_all_loadbalancer/CMakeLists.txt
+++ b/example/grid_tutorial/13_all_loadbalancer/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Loadbalancer loadbalancer_example.cpp)
-target_link_libraries(Loadbalancer Grid)
+target_link_libraries(Loadbalancer Cabana::Grid)
 add_test(NAME Grid_tutorial_13 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Loadbalancer> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_13 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/14_spline/CMakeLists.txt
+++ b/example/grid_tutorial/14_spline/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Spline spline_example.cpp)
-target_link_libraries(Spline Grid)
+target_link_libraries(Spline Cabana::Grid)
 add_test(NAME Grid_tutorial_14 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Spline> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_14 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})

--- a/example/grid_tutorial/15_interpolation/CMakeLists.txt
+++ b/example/grid_tutorial/15_interpolation/CMakeLists.txt
@@ -10,6 +10,6 @@
 ############################################################################
 
 add_executable(Interpolation interpolation_example.cpp)
-target_link_libraries(Interpolation Grid)
+target_link_libraries(Interpolation Cabana::Grid)
 add_test(NAME Grid_tutorial_15 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:Interpolation> ${MPIEXEC_POSTFLAGS})
 set_tests_properties(Grid_tutorial_15 PROPERTIES PROCESSORS ${MPIEXEC_MAX_NUMPROCS})


### PR DESCRIPTION
Rational: Showcasing what users are expected to do downstream.  Unscoped targets are not exported.