### PR TITLE
Fix and cleanup targets and deprecations

### DIFF
--- a/cmake/CabanaConfig.cmakein
+++ b/cmake/CabanaConfig.cmakein
@@ -24,10 +24,6 @@ endif()
 set(Cabana_ENABLE_GRID @Cabana_ENABLE_GRID@)
 set(Cabana_ENABLE_CAJITA @Cabana_ENABLE_CAJITA@) # FIXME: remove in next release
 include("${CMAKE_CURRENT_LIST_DIR}/Cabana_Targets.cmake")
-add_library(Cabana::Core ALIAS Cabana::cabanacore) # FIXME: remove in next release
-if(Cabana_ENABLE_GRID)
-  add_library(Cabana::Grid ALIAS Cabana::Cajita) # FIXME: remove in next release
-endif()
 set(Cabana_ENABLE_HYPRE @Cabana_ENABLE_HYPRE@)
 if(Cabana_ENABLE_HYPRE)
   find_dependency(HYPRE @HYPRE_VERSION@ REQUIRED)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -63,11 +63,12 @@ set(HEADERS_IMPL
   impl/Cabana_TypeTraits.hpp
   )
 
-add_library(cabanacore INTERFACE)
-add_library(Core ALIAS cabanacore)
-add_library(Cabana::Core ALIAS cabanacore)
+add_library(Core INTERFACE)
+add_library(Cabana::Core ALIAS Core)
+
 ### FIXME: remove cabanacore in next release.
-add_library(Cabana::cabanacore ALIAS cabanacore)
+add_library(cabanacore INTERFACE)
+target_link_libraries(cabanacore INTERFACE Core)
 if(CMAKE_VERSION VERSION_GREATER 3.17)
   if(NOT Cabana_DISABLE_CAJITA_DEPRECATION_WARNINGS)
     set_property(TARGET cabanacore PROPERTY DEPRECATION "NOTE: cabanacore subpackage is now Core. Link to Cabana::Core. Cabana::cabanacore will be removed in a future release.")
@@ -75,35 +76,35 @@ if(CMAKE_VERSION VERSION_GREATER 3.17)
 endif()
 
 # Require minimum of C++17
-set_target_properties(cabanacore PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+set_target_properties(Core PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
 
-target_link_libraries(cabanacore INTERFACE Kokkos::kokkos)
+target_link_libraries(Core INTERFACE Kokkos::kokkos)
 
 if(Cabana_ENABLE_ARBORX)
-  target_link_libraries(cabanacore INTERFACE ArborX::ArborX)
+  target_link_libraries(Core INTERFACE ArborX::ArborX)
 endif()
 
 if(Cabana_ENABLE_SILO)
-  target_link_libraries(cabanacore INTERFACE SILO::silo)
+  target_link_libraries(Core INTERFACE SILO::silo)
 endif()
 
 if(Cabana_ENABLE_HDF5)
   # FIXME: replace with HDF5::HDF5 when requiring newer CMake
-  target_link_libraries(cabanacore INTERFACE ${HDF5_LIBRARIES})
+  target_link_libraries(Core INTERFACE ${HDF5_LIBRARIES})
 endif()
 
 if(Cabana_ENABLE_MPI)
-  target_link_libraries(cabanacore INTERFACE MPI::MPI_CXX)
+  target_link_libraries(Core INTERFACE MPI::MPI_CXX)
 endif()
 
-target_include_directories(cabanacore INTERFACE
+target_include_directories(Core INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   ${HDF5_INCLUDE_DIRS} # FIXME: remove when requiring newer CMake
   )
 
-install(TARGETS cabanacore
+install(TARGETS Core cabanacore
   EXPORT Cabana_Targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/grid/src/CMakeLists.txt
+++ b/grid/src/CMakeLists.txt
@@ -69,43 +69,45 @@ if(Cabana_ENABLE_SILO)
   list(APPEND HEADERS_PUBLIC Cabana_Grid_SiloParticleOutput.hpp)
 endif()
 
-add_library(Cajita INTERFACE)
-set_target_properties(Cajita PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+add_library(Grid INTERFACE)
+add_library(Cabana::Grid ALIAS Grid)
+
 ### FIXME: remove Cajita in next release.
-add_library(Cabana::Cajita ALIAS Cajita)
+add_library(Cajita INTERFACE)
+target_link_libraries(Cajita INTERFACE Grid)
 if(CMAKE_VERSION VERSION_GREATER 3.17)
   if(NOT Cabana_DISABLE_CAJITA_DEPRECATION_WARNINGS)
     set_property(TARGET Cajita PROPERTY DEPRECATION "NOTE: Cajita subpackage is now Grid. Link to Cabana::Grid. Cabana::Cajita will be removed in a future release.")
   endif()
 endif()
-add_library(Grid ALIAS Cajita)
-add_library(Cabana::Grid ALIAS Cajita)
 
-target_link_libraries(Cajita INTERFACE
+set_target_properties(Grid PROPERTIES INTERFACE_COMPILE_FEATURES cxx_std_17)
+
+target_link_libraries(Grid INTERFACE
   Cabana::Core
   Kokkos::kokkos
   MPI::MPI_CXX
   )
 
 if(Cabana_ENABLE_HYPRE)
-  target_link_libraries(Cajita INTERFACE HYPRE::HYPRE)
+  target_link_libraries(Grid INTERFACE HYPRE::HYPRE)
 endif()
 
 if(Cabana_ENABLE_HEFFTE)
-  target_link_libraries(Cajita INTERFACE Heffte::Heffte)
+  target_link_libraries(Grid INTERFACE Heffte::Heffte)
 endif()
 
 if(Cabana_ENABLE_ALL)
-    target_link_libraries(Cajita INTERFACE ALL::ALL)
+  target_link_libraries(Grid INTERFACE ALL::ALL)
 endif()
 
-target_include_directories(Cajita
+target_include_directories(Grid
   INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-install(TARGETS Cajita
+install(TARGETS Grid Cajita
   EXPORT Cabana_Targets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Configuration logs are littered with deprecation warnings (following the merge of #680)
```
CMake Warning (dev) at cmake/test_harness/test_harness.cmake:27 (target_link_libraries):
  The library that is being linked to, cabanacore, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  NOTE: cabanacore subpackage is now Core.  Link to Cabana::Core.
  Cabana::cabanacore will be removed in a future release.

Call Stack (most recent call first):
  core/unit_test/CMakeLists.txt:49 (Cabana_add_tests_nobackend)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This gets rid of the issue, exports both the new targets `Cabana::{Core,Grid}` and the old (deprecated) ones `Cabana::{cabanacore,Cajita}`.
The targets `cabanacore` and `Cajita` are removed since they are not exported and we don't link against them.