### PR TITLE
Add total neighbor interface and fix max neighbors

### DIFF
--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -536,6 +536,32 @@ class NeighborList<Experimental::CrsGraph<MemorySpace, Tag>>
   public:
     //! Kokkos memory space.
     using memory_space = MemorySpace;
+
+    //! Get the total number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static size_type totalNeighbor( crs_graph_type const& crs_graph )
+    {
+        std::size_t total_n = 0;
+        std::size_t num_p = crs_graph.total;
+        // Sum neighbors across all particles.
+        for ( std::size_t p = 0; p < num_p; p++ )
+            total_n += numNeighbor( crs_graph, p );
+        return total_n;
+    }
+
+    //! Get the maximum number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static size_type maxNeighbor( crs_graph_type const& crs_graph )
+    {
+        size_type max_n = 0;
+        size_type num_p = crs_graph.total;
+        // Loop across all particles to find maximum number of neighbors.
+        for ( size_type p = 0; p < num_p; p++ )
+            if ( numNeighbor( crs_graph, p ) > max_n )
+                max_n = numNeighbor( crs_graph, p );
+        return max_n;
+    }
+
     //! Get the number of neighbors for a given particle index.
     static KOKKOS_FUNCTION size_type
     numNeighbor( crs_graph_type const& crs_graph, size_type p )
@@ -568,6 +594,32 @@ class NeighborList<Experimental::Dense<MemorySpace, Tag>>
   public:
     //! Kokkos memory space.
     using memory_space = MemorySpace;
+
+    //! Get the total number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static size_type totalNeighbor( specialization_type const& d )
+    {
+        std::size_t total_n = 0;
+        std::size_t num_p = d.total;
+        // Sum neighbors across all particles.
+        for ( std::size_t p = 0; p < num_p; p++ )
+            total_n += numNeighbor( d, p );
+        return total_n;
+    }
+
+    //! Get the maximum number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static size_type maxNeighbor( specialization_type const& d )
+    {
+        size_type max_n = 0;
+        size_type num_p = d.total;
+        // Loop across all particles to find maximum number of neighbors.
+        for ( size_type p = 0; p < num_p; p++ )
+            if ( numNeighbor( d, p ) > max_n )
+                max_n = numNeighbor( d, p );
+        return max_n;
+    }
+
     //! Get the number of neighbors for a given particle index.
     static KOKKOS_FUNCTION size_type numNeighbor( specialization_type const& d,
                                                   size_type p )

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -245,7 +245,7 @@ struct CrsGraph
     Kokkos::View<int*, MemorySpace> row_ptr;
     //! Neighbor offset shift.
     typename MemorySpace::size_type shift;
-    //! Total neighbors.
+    //! Total particles.
     typename MemorySpace::size_type total;
 };
 
@@ -368,7 +368,7 @@ struct Dense
     Kokkos::View<int**, MemorySpace> val;
     //! Neighbor offset shift.
     typename MemorySpace::size_type shift;
-    //! Total neighbors.
+    //! Total particles.
     typename MemorySpace::size_type total;
 };
 
@@ -541,25 +541,14 @@ class NeighborList<Experimental::CrsGraph<MemorySpace, Tag>>
     KOKKOS_INLINE_FUNCTION
     static size_type totalNeighbor( crs_graph_type const& crs_graph )
     {
-        std::size_t total_n = 0;
-        std::size_t num_p = crs_graph.total;
-        // Sum neighbors across all particles.
-        for ( std::size_t p = 0; p < num_p; p++ )
-            total_n += numNeighbor( crs_graph, p );
-        return total_n;
+        return Impl::totalNeighbor( crs_graph, crs_graph.total );
     }
 
     //! Get the maximum number of neighbors across all particles.
     KOKKOS_INLINE_FUNCTION
     static size_type maxNeighbor( crs_graph_type const& crs_graph )
     {
-        size_type max_n = 0;
-        size_type num_p = crs_graph.total;
-        // Loop across all particles to find maximum number of neighbors.
-        for ( size_type p = 0; p < num_p; p++ )
-            if ( numNeighbor( crs_graph, p ) > max_n )
-                max_n = numNeighbor( crs_graph, p );
-        return max_n;
+        return Impl::maxNeighbor( crs_graph, crs_graph.total );
     }
 
     //! Get the number of neighbors for a given particle index.
@@ -599,25 +588,14 @@ class NeighborList<Experimental::Dense<MemorySpace, Tag>>
     KOKKOS_INLINE_FUNCTION
     static size_type totalNeighbor( specialization_type const& d )
     {
-        std::size_t total_n = 0;
-        std::size_t num_p = d.total;
-        // Sum neighbors across all particles.
-        for ( std::size_t p = 0; p < num_p; p++ )
-            total_n += numNeighbor( d, p );
-        return total_n;
+        return Impl::totalNeighbor( d, d.total );
     }
 
     //! Get the maximum number of neighbors across all particles.
     KOKKOS_INLINE_FUNCTION
     static size_type maxNeighbor( specialization_type const& d )
     {
-        size_type max_n = 0;
-        size_type num_p = d.total;
-        // Loop across all particles to find maximum number of neighbors.
-        for ( size_type p = 0; p < num_p; p++ )
-            if ( numNeighbor( d, p ) > max_n )
-                max_n = numNeighbor( d, p );
-        return max_n;
+        return Impl::maxNeighbor( d, d.total );
     }
 
     //! Get the number of neighbors for a given particle index.

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -59,6 +59,10 @@ class NeighborList
     //! Kokkos memory space.
     using memory_space = typename NeighborListType::memory_space;
 
+    //! Get the total number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t totalNeighbor( const NeighborListType& list );
+
     //! Get the maximum number of neighbors across all particles.
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const NeighborListType& list );

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -59,6 +59,10 @@ class NeighborList
     //! Kokkos memory space.
     using memory_space = typename NeighborListType::memory_space;
 
+    //! Get the maximum number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t maxNeighbor( const NeighborListType& list );
+
     //! Get the number of neighbors for a given particle index.
     KOKKOS_INLINE_FUNCTION
     static std::size_t numNeighbor( const NeighborListType& list,

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -87,6 +87,33 @@ class NeighborList
 
 //---------------------------------------------------------------------------//
 
+namespace Impl
+{
+//! Iterate to get the total number of neighbors.
+template <class ListType>
+KOKKOS_INLINE_FUNCTION std::size_t
+totalNeighbor( const ListType& list, const std::size_t num_particles )
+{
+    std::size_t total_n = 0;
+    // Sum neighbors across all particles.
+    for ( std::size_t p = 0; p < num_particles; p++ )
+        total_n += NeighborList<ListType>::numNeighbor( list, p );
+    return total_n;
+}
+
+//! Iterate to find the maximum number of neighbors.
+template <class ListType>
+KOKKOS_INLINE_FUNCTION std::size_t
+maxNeighbor( const ListType& list, const std::size_t num_particles )
+{
+    std::size_t max_n = 0;
+    for ( std::size_t p = 0; p < num_particles; p++ )
+        if ( NeighborList<ListType>::numNeighbor( list, p ) > max_n )
+            max_n = NeighborList<ListType>::numNeighbor( list, p );
+    return max_n;
+}
+} // namespace Impl
+
 } // end namespace Cabana
 
 #endif // end CABANA_NEIGHBORLIST_HPP

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -91,6 +91,10 @@ struct VerletListData<MemorySpace, VerletLayout2D>
     //! Neighbor list.
     Kokkos::View<int**, memory_space> neighbors;
 
+    //! Actual maximum neighbors per particle (potentially less than allocated
+    //! space).
+    std::size_t max_n;
+
     //! Add a neighbor to the list.
     KOKKOS_INLINE_FUNCTION
     void addNeighbor( const int pid, const int nid ) const
@@ -244,8 +248,8 @@ struct VerletListBuilder
     bool refill;
     bool count;
 
-    // Maximum neighbors per particle
-    std::size_t max_n;
+    // Maximum allocated neighbors per particle
+    std::size_t alloc_n;
 
     // Constructor.
     VerletListBuilder( PositionSlice slice, const std::size_t begin,
@@ -259,7 +263,7 @@ struct VerletListBuilder
         , pid_end( end )
         , cell_stencil( neighborhood_radius, cell_size_ratio, grid_min,
                         grid_max )
-        , max_n( max_neigh )
+        , alloc_n( max_neigh )
     {
         count = true;
         refill = false;
@@ -438,13 +442,13 @@ struct VerletListBuilder
 
     void initCounts( VerletLayout2D )
     {
-        if ( max_n > 0 )
+        if ( alloc_n > 0 )
         {
             count = false;
 
             _data.neighbors = Kokkos::View<int**, memory_space>(
                 Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
-                _data.counts.size(), max_n );
+                _data.counts.size(), alloc_n );
         }
     }
 
@@ -481,8 +485,8 @@ struct VerletListBuilder
     {
         // Calculate the maximum number of neighbors.
         auto counts = _data.counts;
-        int max_num_neighbor = 0;
-        Kokkos::Max<int> max_reduce( max_num_neighbor );
+        int max;
+        Kokkos::Max<int> max_reduce( max );
         Kokkos::parallel_reduce(
             "Cabana::VerletListBuilder::reduce_max",
             Kokkos::RangePolicy<execution_space>( 0, _data.counts.size() ),
@@ -492,16 +496,16 @@ struct VerletListBuilder
             },
             max_reduce );
         Kokkos::fence();
+        _data.max_n = static_cast<std::size_t>( max );
 
         // Reallocate the neighbor list if previous size is exceeded.
-        if ( count or ( std::size_t )
-                              max_num_neighbor > _data.neighbors.extent( 1 ) )
+        if ( count or _data.max_n > _data.neighbors.extent( 1 ) )
         {
             refill = true;
             Kokkos::deep_copy( _data.counts, 0 );
             _data.neighbors = Kokkos::View<int**, memory_space>(
                 Kokkos::ViewAllocateWithoutInitializing( "neighbors" ),
-                _data.counts.size(), max_num_neighbor );
+                _data.counts.size(), _data.max_n );
         }
     }
 
@@ -903,18 +907,8 @@ class NeighborList<
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const list_type& list )
     {
-        // Size of the allocated memory (list._data.neighbors.extent( 1 )) would
-        // give maximum neighbors, but we keep an overallocation in most cases
-        // (making the size incorrect).
-        std::size_t max_n = 0;
-        std::size_t num_p = list._data.counts.size();
-        // Loop across all particles to find maximum number of neighbors.
-        for ( std::size_t p = 0; p < num_p; p++ )
-        {
-            if ( numNeighbor( list, p ) > max_n )
-                max_n = numNeighbor( list, p );
-        }
-        return max_n;
+        // Stored during neighbor search.
+        return list._data.max_n;
     }
 
     //! Get the number of neighbors for a given particle index.

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -833,11 +833,17 @@ class NeighborList<
     using list_type =
         VerletList<MemorySpace, AlgorithmTag, VerletLayoutCSR, BuildTag>;
 
-    //! Get the total number of neighbors (maximum size of CSR list).
+    //! Get the maximum number of neighbors across all particles.
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const list_type& list )
     {
-        return list._data.neighbors.extent( 0 );
+        std::size_t max_n = 0;
+        std::size_t num_p = list._data.counts.size();
+        // Loop across all particles to find maximum number of neighbors.
+        for ( std::size_t p = 0; p < num_p; p++ )
+            if ( numNeighbor( list, p ) > max_n )
+                max_n = numNeighbor( list, p );
+        return max_n;
     }
 
     //! Get the number of neighbors for a given particle index.
@@ -877,7 +883,18 @@ class NeighborList<
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const list_type& list )
     {
-        return list._data.neighbors.extent( 1 );
+        // Size of the allocated memory (list._data.neighbors.extent( 1 )) would
+        // give maximum neighbors, but we keep an overallocation in most cases
+        // (making the size incorrect).
+        std::size_t max_n = 0;
+        std::size_t num_p = list._data.counts.size();
+        // Loop across all particles to find maximum number of neighbors.
+        for ( std::size_t p = 0; p < num_p; p++ )
+        {
+            if ( numNeighbor( list, p ) > max_n )
+                max_n = numNeighbor( list, p );
+        }
+        return max_n;
     }
 
     //! Get the number of neighbors for a given particle index.

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -833,6 +833,14 @@ class NeighborList<
     using list_type =
         VerletList<MemorySpace, AlgorithmTag, VerletLayoutCSR, BuildTag>;
 
+    //! Get the total number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t totalNeighbor( const list_type& list )
+    {
+        // Size of the allocated memory gives total neighbors.
+        return list._data.neighbors.extent( 0 );
+    }
+
     //! Get the maximum number of neighbors across all particles.
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const list_type& list )
@@ -878,6 +886,18 @@ class NeighborList<
     //! Neighbor list type.
     using list_type =
         VerletList<MemorySpace, AlgorithmTag, VerletLayout2D, BuildTag>;
+
+    //! Get the total number of neighbors across all particles.
+    KOKKOS_INLINE_FUNCTION
+    static std::size_t totalNeighbor( const list_type& list )
+    {
+        std::size_t total_n = 0;
+        std::size_t num_p = list._data.counts.size();
+        // Sum neighbors across all particles.
+        for ( std::size_t p = 0; p < num_p; p++ )
+            total_n += numNeighbor( list, p );
+        return total_n;
+    }
 
     //! Get the maximum number of neighbors per particle.
     KOKKOS_INLINE_FUNCTION

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -849,13 +849,8 @@ class NeighborList<
     KOKKOS_INLINE_FUNCTION
     static std::size_t maxNeighbor( const list_type& list )
     {
-        std::size_t max_n = 0;
         std::size_t num_p = list._data.counts.size();
-        // Loop across all particles to find maximum number of neighbors.
-        for ( std::size_t p = 0; p < num_p; p++ )
-            if ( numNeighbor( list, p ) > max_n )
-                max_n = numNeighbor( list, p );
-        return max_n;
+        return Impl::maxNeighbor( list, num_p );
     }
 
     //! Get the number of neighbors for a given particle index.
@@ -895,12 +890,8 @@ class NeighborList<
     KOKKOS_INLINE_FUNCTION
     static std::size_t totalNeighbor( const list_type& list )
     {
-        std::size_t total_n = 0;
         std::size_t num_p = list._data.counts.size();
-        // Sum neighbors across all particles.
-        for ( std::size_t p = 0; p < num_p; p++ )
-            total_n += numNeighbor( list, p );
-        return total_n;
+        return Impl::totalNeighbor( list, num_p );
     }
 
     //! Get the maximum number of neighbors per particle.

--- a/core/unit_test/tstNeighborListArborX.hpp
+++ b/core/unit_test/tstNeighborListArborX.hpp
@@ -290,13 +290,13 @@ void testNeighborArborXParallelReduce()
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, verlet_list_full_test ) { testArborXListFull(); }
+TEST( TEST_CATEGORY, neighbor_list_full_test ) { testArborXListFull(); }
 
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, verlet_list_half_test ) { testArborXListHalf(); }
+TEST( TEST_CATEGORY, neighbor_list_half_test ) { testArborXListHalf(); }
 
 //---------------------------------------------------------------------------//
-TEST( TEST_CATEGORY, verlet_list_full_range_test )
+TEST( TEST_CATEGORY, neighbor_list_full_range_test )
 {
     testArborXListFullPartialRange();
 }


### PR DESCRIPTION
Previous max interface was incorrect for any overallocated 2d layout and returned total for CSR layout. Was not implemented for ArborX lists and was not previously tested 