### PR TITLE
Ubuntu Intel CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
             hypre: 'OFF'
             silo: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             cxx: 'icpx'
             backend: 'OPENMP'
             cmake_build_type: 'Release'
@@ -56,7 +56,7 @@ jobs:
             heffte: 'OFF'
             hypre: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             cxx: 'icpx'
             backend: 'OPENMP'
             cmake_build_type: 'Debug'
@@ -65,7 +65,7 @@ jobs:
             heffte: 'OFF'
             hypre: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             cxx: 'icpx'
             backend: 'SERIAL'
             cmake_build_type: 'Release'
@@ -74,7 +74,7 @@ jobs:
             heffte: 'OFF'
             hypre: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             cxx: 'icpx'
             backend: 'SERIAL'
             cmake_build_type: 'Debug'
@@ -83,7 +83,7 @@ jobs:
             heffte: 'OFF'
             hypre: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:intel'
+          - distro: 'ubuntu:intel'
             cxx: 'icpx'
             backend: 'SERIAL'
             cmake_build_type: 'Debug'
@@ -245,7 +245,7 @@ jobs:
       image: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
       options: --security-opt seccomp=unconfined
     # FIXME: remove failing distributions here when passing
-    continue-on-error: ${{ (matrix.distro == 'fedora:intel' && matrix.backend == 'SERIAL' && matrix.cmake_build_type == 'Release') || matrix.distro == 'opensuse:latest' }}
+    continue-on-error: ${{ (matrix.distro == 'ubuntu:intel' && matrix.backend == 'SERIAL' && matrix.cmake_build_type == 'Release') || matrix.distro == 'opensuse:latest' }}
     steps:
       - name: Cache ccache
         uses: actions/cache@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -311,7 +311,6 @@ jobs:
         run: |
           [[ ${{ matrix.heffte }} == "FFTW" ]] && heffte_cmake_opts+=( -DHeffte_ENABLE_FFTW=ON )
           [[ ${{ matrix.heffte }} == "MKL" ]] && heffte_cmake_opts+=( -DHeffte_ENABLE_MKL=ON )
-          # FIXME: Remove MKL path below when we update heFFTe
           cmake -B build \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=$HOME/heffte \
@@ -319,7 +318,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DMKL_ROOT=/opt/intel/oneapi/mkl/latest \
-            -DHeffte_MKL_IOMP5=/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin/libiomp5.so \
             ${heffte_cmake_opts[@]}
           cmake --build build --parallel 2
           cmake --install build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -380,7 +380,7 @@ jobs:
             fi
           fi
           #FIXME: Run valgrind for all builds once fixed/suppressed
-          [[ ${{ matrix.distro }} == 'ubuntu:latest' || ${{ matrix.distro }} == 'ubuntu:rolling' || ${{ matrix.backend }} == OPENMP || ${{ matrix.cmake_build_type }} == Release ]] && cabana_cmake_opts+=( -DVALGRIND_EXECUTABLE=False )
+          [[ ${{ matrix.distro }} == *"ubuntu"* || ${{ matrix.backend }} == OPENMP || ${{ matrix.cmake_build_type }} == Release ]] && cabana_cmake_opts+=( -DVALGRIND_EXECUTABLE=False )
           cmake -B build \
             -DCMAKE_INSTALL_PREFIX=$HOME/Cabana \
             -DMPIEXEC_MAX_NUMPROCS=2 -DMPIEXEC_PREFLAGS="--oversubscribe" \


### PR DESCRIPTION
Switch to `ubuntu:intel` containers

Also remove a now unnecessary explicit path for heffte in the CI