### PR TITLE
CI fixup: action versions and timeouts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
         liball: ['OFF']
         silo: ['OFF']
         hdf5: ['OFF']
+        sanitizer: ['ASAN']
         coverage: ['OFF']
         include:
           - distro: 'ubuntu:latest'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -249,7 +249,7 @@ jobs:
     continue-on-error: ${{ (matrix.distro == 'ubuntu:intel' && matrix.backend == 'SERIAL' && matrix.cmake_build_type == 'Release') || matrix.distro == 'opensuse:latest' }}
     steps:
       - name: Cache ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.distro }}-${{github.run_id}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,8 @@ jobs:
             heffte: 'MKL'
             hypre: 'OFF'
             coverage: 'OFF'
-          - distro: 'fedora:latest'
+          # FIXME: use fedora:latest when MPI timeouts are fixed
+          - distro: 'fedora:rawhide'
             cxx: 'g++'
             backend: 'OPENMP'
             cmake_build_type: 'Release'
@@ -103,7 +104,8 @@ jobs:
             hypre: 'OFF'
             coverage: 'OFF'
             doxygen: 'ON'
-          - distro: 'fedora:latest'
+          # FIXME: use fedora:latest when MPI timeouts are fixed
+          - distro: 'fedora:rawhide'
             cxx: 'clang++'
             backend: 'OPENMP'
             cmake_build_type: 'Release'

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ecp-copa/ci-containers/fedora:latest 
+FROM ghcr.io/ecp-copa/ci-containers/fedora:rawhide 
 
 WORKDIR /home/kokkos/src/
 COPY kokkos/ /home/kokkos/src/kokkos

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -16,6 +16,7 @@ jobs:
         backend: ["OPENMP", "SERIAL"]
         distro: ['ubuntu:latest', 'fedora:rawhide']
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     container:
       image: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Cabana
         run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/Cabana -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx" -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON -DCabana_REQUIRE_${{ matrix.backend }}=ON -DVALGRIND_EXECUTABLE=False -DCMAKE_DISABLE_FIND_PACKAGE_HDF5=ON ${{ github.event.inputs.cmake_args }}
+          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/Cabana -DCMAKE_PREFIX_PATH="$HOME/kokkos;$HOME/arborx" -DCabana_ENABLE_TESTING=ON -DCabana_ENABLE_EXAMPLES=ON -DCabana_REQUIRE_${{ matrix.backend }}=ON -DVALGRIND_EXECUTABLE=False ${{ github.event.inputs.cmake_args }}
           cmake --build build --parallel 2
           ctest --test-dir build --output-on-failure  ${{ github.event.inputs.ctest_args }}
           cmake --install build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout kokkos
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
           path: cabana
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build and Push Docker Image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ${{github.workspace}}
           file: cabana/.github/workflows/Dockerfile

--- a/core/src/Cabana_Parallel.hpp
+++ b/core/src/Cabana_Parallel.hpp
@@ -222,9 +222,9 @@ class TeamVectorOpTag
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
-  \param SerialOpTag Tag indicating a serial loop strategy over neighbors.
+  \note SerialOpTag Tag indicating a serial loop strategy over neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_for called by this code and can be used for
   identification and profiling purposes.
@@ -304,9 +304,9 @@ inline void neighbor_parallel_for(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param SerialOpTag Tag indicating a serial loop strategy over neighbors.
+  \note SerialOpTag Tag indicating a serial loop strategy over neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_for called by this code and can be used for
   identification and profiling purposes.
@@ -375,9 +375,9 @@ inline void neighbor_parallel_for(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
-  \param TeamOpTag Tag indicating a team parallel strategy over neighbors.
+  \note TeamOpTag Tag indicating a team parallel strategy over neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_for called by this code and can be used for
   identification and profiling purposes.
@@ -446,9 +446,9 @@ inline void neighbor_parallel_for(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param TeamOpTag Tag indicating a team parallel strategy over particle first
+  \note TeamOpTag Tag indicating a team parallel strategy over particle first
   neighbors and serial execution over second neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_for called by this code and can be used for
@@ -524,9 +524,9 @@ inline void neighbor_parallel_for(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param TeamVectorOpTag Tag indicating a team parallel strategy over particle
+  \note TeamVectorOpTag Tag indicating a team parallel strategy over particle
   first neighbors and vector parallel loop strategy over second neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_for called by this code and can be used for
@@ -607,9 +607,9 @@ inline void neighbor_parallel_for(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
-  \param SerialOpTag Tag indicating a serial loop strategy over
+  \note SerialOpTag Tag indicating a serial loop strategy over
   neighbors.
   \param reduce_val Scalar to be reduced across particles and neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
@@ -696,9 +696,9 @@ inline void neighbor_parallel_reduce(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param SerialOpTag Tag indicating a serial loop strategy over neighbors.
+  \note SerialOpTag Tag indicating a serial loop strategy over neighbors.
   \param reduce_val Scalar to be reduced across particles and neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
   the Kokkos::parallel_reduce called by this code and can be used for
@@ -772,9 +772,9 @@ inline void neighbor_parallel_reduce(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
-  \param TeamOpTag Tag indicating a team parallel strategy over particle
+  \note TeamOpTag Tag indicating a team parallel strategy over particle
   neighbors.
   \param reduce_val Scalar to be reduced across particles and neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
@@ -853,9 +853,9 @@ inline void neighbor_parallel_reduce(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param TeamOpTag Tag indicating a team parallel strategy over particle first
+  \note TeamOpTag Tag indicating a team parallel strategy over particle first
   neighbors and serial loops over second neighbors.
   \param reduce_val Scalar to be reduced across particles and neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
@@ -939,9 +939,9 @@ inline void neighbor_parallel_reduce(
   \param exec_policy The policy over which to execute the functor.
   \param functor The functor to execute in parallel
   \param list The neighbor list over which to execute the neighbor operations.
-  \param SecondNeighborsTag Tag indicating operations over particle first and
+  \note SecondNeighborsTag Tag indicating operations over particle first and
   second neighbors.
-  \param TeamVectorOpTag Tag indicating a team parallel strategy over particle
+  \note TeamVectorOpTag Tag indicating a team parallel strategy over particle
   first neighbors and vector loops over second neighbors.
   \param reduce_val Scalar to be reduced across particles and neighbors.
   \param str Optional name for the functor. Will be forwarded if non-empty to
@@ -1028,7 +1028,7 @@ inline void neighbor_parallel_reduce(
   \param i Particle index.
   \param neighbor_functor The neighbor functor to execute in parallel.
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
 
   A "functor" is a class containing the function to execute in parallel, data
@@ -1079,7 +1079,7 @@ for_each_neighbor( const IndexType i, const FunctorType& neighbor_functor,
   \param team Kokkos team.
   \param neighbor_functor The neighbor functor to execute in parallel.
   \param list The neighbor list over which to execute the neighbor operations.
-  \param FirstNeighborsTag Tag indicating operations over particle first
+  \note FirstNeighborsTag Tag indicating operations over particle first
   neighbors.
 */
 template <class IndexType, class FunctorType, class NeighborListType,

--- a/grid/src/Cabana_Grid_FastFourierTransform.hpp
+++ b/grid/src/Cabana_Grid_FastFourierTransform.hpp
@@ -575,7 +575,7 @@ class HeffteFastFourierTransform
     /*!
       \brief Do a forward FFT.
       \param x The array on which to perform the forward transform.
-      \param ScaleType Method of scaling data.
+      \note ScaleType Method of scaling data.
     */
     template <class Array_t, class ScaleType>
     void forwardImpl( const Array_t& x, const ScaleType )
@@ -586,7 +586,7 @@ class HeffteFastFourierTransform
     /*!
      \brief Do a reverse FFT.
      \param x The array on which to perform the reverse transform
-     \param ScaleType Method of scaling data.
+     \note ScaleType Method of scaling data.
     */
     template <class Array_t, class ScaleType>
     void reverseImpl( const Array_t& x, const ScaleType )


### PR DESCRIPTION
Updates action versions, switches `fedora:latest` to `fedora:rawhide` in order to avoid MPI timeouts, adds reasonable timeouts to all CI, and updates some doxygen (due to newer version in rawhide where it's built)

Related to #634 