### PR TITLE
Fixup ArborX predicates access traits specialization

### DIFF
--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -96,24 +96,26 @@ struct AccessTraits<Slice, PrimitivesTag,
     }
 };
 //! Neighbor access trait.
-template <typename SliceLike>
-struct AccessTraits<SliceLike, PredicatesTag>
+template <typename Slice>
+struct AccessTraits<Cabana::Experimental::Impl::SubsliceAndRadius<Slice>,
+                    PredicatesTag>
 {
+    using Self = Cabana::Experimental::Impl::SubsliceAndRadius<Slice>;
     //! Kokkos memory space.
-    using memory_space = typename SliceLike::memory_space;
+    using memory_space = typename Self::memory_space;
     //! Size type.
-    using size_type = typename SliceLike::size_type;
+    using size_type = typename Self::size_type;
     //! Get number of particles.
-    static KOKKOS_FUNCTION size_type size( SliceLike const& x )
+    static KOKKOS_FUNCTION size_type size( Self const& x )
     {
         return x.last - x.first;
     }
     //! Get the particle at the index.
-    static KOKKOS_FUNCTION auto get( SliceLike const& x, size_type i )
+    static KOKKOS_FUNCTION auto get( Self const& x, size_type i )
     {
         assert( i < size( x ) );
         auto const point =
-            AccessTraits<typename SliceLike::slice_type, PrimitivesTag>::get(
+            AccessTraits<typename Self::slice_type, PrimitivesTag>::get(
                 x.slice, x.first + i );
         return attach( intersects( Sphere{ point, x.radius } ), (int)i );
     }

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -415,7 +415,7 @@ auto make2DNeighborList( ExecutionSpace space, Tag,
         Impl::makePredicates( coordinate_slice, first, last, radius );
 
     auto const n_queries =
-        ArborX::AccessTraits<decltype( predicates ),
+        ArborX::AccessTraits<std::remove_const_t<decltype( predicates )>,
                              ArborX::PredicatesTag>::size( predicates );
 
     Kokkos::View<int**, memory_space> neighbors;

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -100,22 +100,23 @@ template <typename Slice>
 struct AccessTraits<Cabana::Experimental::Impl::SubsliceAndRadius<Slice>,
                     PredicatesTag>
 {
-    using Self = Cabana::Experimental::Impl::SubsliceAndRadius<Slice>;
+    //! Slice wrapper with partial range and radius information.
+    using SliceLike = Cabana::Experimental::Impl::SubsliceAndRadius<Slice>;
     //! Kokkos memory space.
-    using memory_space = typename Self::memory_space;
+    using memory_space = typename SliceLike::memory_space;
     //! Size type.
-    using size_type = typename Self::size_type;
+    using size_type = typename SliceLike::size_type;
     //! Get number of particles.
-    static KOKKOS_FUNCTION size_type size( Self const& x )
+    static KOKKOS_FUNCTION size_type size( SliceLike const& x )
     {
         return x.last - x.first;
     }
     //! Get the particle at the index.
-    static KOKKOS_FUNCTION auto get( Self const& x, size_type i )
+    static KOKKOS_FUNCTION auto get( SliceLike const& x, size_type i )
     {
         assert( i < size( x ) );
         auto const point =
-            AccessTraits<typename Self::slice_type, PrimitivesTag>::get(
+            AccessTraits<typename SliceLike::slice_type, PrimitivesTag>::get(
                 x.slice, x.first + i );
         return attach( intersects( Sphere{ point, x.radius } ), (int)i );
     }


### PR DESCRIPTION
Fix #726 

The `ArborX::AccessTraits` specialization is too generic and yields ambiguity errors with more recent versions of ArborX.

cc @aprokop 