### PR TITLE
Implement `Impl::max_reduce` since `ArborX::max` has been deprecated

### DIFF
--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -18,6 +18,7 @@
 
 #include <Cabana_NeighborList.hpp>
 #include <Cabana_Slice.hpp>
+#include <Cabana_Types.hpp> // is_accessible_from
 
 #include <ArborX.hpp>
 
@@ -68,6 +69,29 @@ auto makePredicates(
 {
     return Impl::SubsliceAndRadius<stdcxx20::remove_cvref_t<Slice>>{
         std::forward<Slice>( slice ), first, last, radius };
+}
+
+template <typename ExecutionSpace, typename D, typename... P>
+typename Kokkos::View<D, P...>::non_const_value_type
+max_reduce( ExecutionSpace const& space, Kokkos::View<D, P...> const& v )
+{
+    using V = Kokkos::View<D, P...>;
+    static_assert( V::rank() == 1 );
+    static_assert( Kokkos::is_execution_space_v<ExecutionSpace> );
+    static_assert(
+        is_accessible_from<typename V::memory_space, ExecutionSpace>::value );
+    using Ret = typename Kokkos::View<D, P...>::non_const_value_type;
+    Ret max_val;
+    Kokkos::parallel_reduce(
+        Kokkos::RangePolicy<ExecutionSpace>( space, 0, v.extent( 0 ) ),
+        KOKKOS_LAMBDA( int i, Ret& partial_max ) {
+            if ( v( i ) > partial_max )
+            {
+                partial_max = v( i );
+            }
+        },
+        Kokkos::Max<Ret>( max_val ) );
+    return max_val;
 }
 //! \endcond
 } // namespace Impl
@@ -437,7 +461,7 @@ auto make2DNeighborList( ExecutionSpace space, Tag,
                                                             Tag>{ counts } );
     }
 
-    auto const max_neighbors = ArborX::max( space, counts );
+    auto const max_neighbors = Impl::max_reduce( space, counts );
     if ( max_neighbors <= buffer_size )
     {
         // NOTE We do not bother shrinking to eliminate the excess allocation.

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -76,7 +76,7 @@ typename Kokkos::View<D, P...>::non_const_value_type
 max_reduce( ExecutionSpace const& space, Kokkos::View<D, P...> const& v )
 {
     using V = Kokkos::View<D, P...>;
-    static_assert( V::rank() == 1 );
+    static_assert( V::rank == 1 );
     static_assert( Kokkos::is_execution_space_v<ExecutionSpace> );
     static_assert(
         is_accessible_from<typename V::memory_space, ExecutionSpace>::value );

--- a/core/src/Cabana_Experimental_NeighborList.hpp
+++ b/core/src/Cabana_Experimental_NeighborList.hpp
@@ -77,7 +77,7 @@ max_reduce( ExecutionSpace const& space, Kokkos::View<D, P...> const& v )
 {
     using V = Kokkos::View<D, P...>;
     static_assert( V::rank == 1 );
-    static_assert( Kokkos::is_execution_space_v<ExecutionSpace> );
+    static_assert( Kokkos::is_execution_space<ExecutionSpace>::value );
     static_assert(
         is_accessible_from<typename V::memory_space, ExecutionSpace>::value );
     using Ret = typename Kokkos::View<D, P...>::non_const_value_type;


### PR DESCRIPTION
The `ArborX::max` algorithm was never intended to be public and was deprecated in arborx/ArborX#998
This PR introduces `Impl::max_reduce`.  An alternative would be to use the Kokkos (experimental) parallel algorithms.

Loosely related to arborx/ArborX#1013