### PR TITLE
Inherit Hypre matrices/vectors to avoid memory leak

### DIFF
--- a/grid/src/Cabana_Grid_HypreStructuredSolver.hpp
+++ b/grid/src/Cabana_Grid_HypreStructuredSolver.hpp
@@ -407,7 +407,7 @@ class HypreStructuredSolver
         checkHypreError( error );
 
         // Solve the problem
-        this->solveImpl( _A, _b, _x );
+        this->solveImpl();
 
         // Extract the solution from the LHS
         error = HYPRE_StructVectorGetBoxValues(
@@ -451,8 +451,7 @@ class HypreStructuredSolver
     virtual void setupImpl() = 0;
 
     //! Solver implementation.
-    virtual void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                            HYPRE_StructVector x ) = 0;
+    virtual void solveImpl() = 0;
 
     //! Get the number of iterations taken on the last solve.
     virtual int getNumIterImpl() = 0;
@@ -587,10 +586,9 @@ class HypreStructPCG
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructPCGSolve( _solver, A, b, x );
+        auto error = HYPRE_StructPCGSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -713,10 +711,9 @@ class HypreStructGMRES
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructGMRESSolve( _solver, A, b, x );
+        auto error = HYPRE_StructGMRESSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -832,10 +829,9 @@ class HypreStructBiCGSTAB
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructBiCGSTABSolve( _solver, A, b, x );
+        auto error = HYPRE_StructBiCGSTABSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1022,10 +1018,9 @@ class HypreStructPFMG
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructPFMGSolve( _solver, A, b, x );
+        auto error = HYPRE_StructPFMGSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1154,10 +1149,9 @@ class HypreStructSMG
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructSMGSolve( _solver, A, b, x );
+        auto error = HYPRE_StructSMGSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1254,10 +1248,9 @@ class HypreStructJacobi
         this->checkHypreError( error );
     }
 
-    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void solveImpl() override
     {
-        auto error = HYPRE_StructJacobiSolve( _solver, A, b, x );
+        auto error = HYPRE_StructJacobiSolve( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1347,8 +1340,7 @@ class HypreStructDiagonal
             "Diagonal preconditioner cannot be used as a solver" );
     }
 
-    void solveImpl( HYPRE_StructMatrix, HYPRE_StructVector,
-                    HYPRE_StructVector ) override
+    void solveImpl() override
     {
         throw std::logic_error(
             "Diagonal preconditioner cannot be used as a solver" );

--- a/grid/src/Cabana_Grid_HypreStructuredSolver.hpp
+++ b/grid/src/Cabana_Grid_HypreStructuredSolver.hpp
@@ -346,7 +346,7 @@ class HypreStructuredSolver
             throw std::logic_error( "Cannot call setup() on preconditioners" );
 
         // FIXME: appears to be a memory issue in the call to this function
-        this->setupImpl( _A, _b, _x );
+        this->setupImpl();
     }
 
     /*!
@@ -448,8 +448,7 @@ class HypreStructuredSolver
     virtual void setPrintLevelImpl( const int print_level ) = 0;
 
     //! Setup implementation.
-    virtual void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                            HYPRE_StructVector x ) = 0;
+    virtual void setupImpl() = 0;
 
     //! Solver implementation.
     virtual void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
@@ -481,6 +480,14 @@ class HypreStructuredSolver
         }
     }
 
+  protected:
+    //! Matrix for the problem Ax = b.
+    HYPRE_StructMatrix _A;
+    //! Forcing term for the problem Ax = b.
+    HYPRE_StructVector _b;
+    //! Solution to the problem Ax = b.
+    HYPRE_StructVector _x;
+
   private:
     MPI_Comm _comm;
     bool _is_preconditioner;
@@ -489,9 +496,6 @@ class HypreStructuredSolver
     std::vector<HYPRE_Int> _upper;
     HYPRE_StructStencil _stencil;
     unsigned _stencil_size;
-    HYPRE_StructMatrix _A;
-    HYPRE_StructVector _b;
-    HYPRE_StructVector _x;
     std::shared_ptr<HypreStructuredSolver<Scalar, EntityType, MemorySpace>>
         _preconditioner;
 };
@@ -504,12 +508,12 @@ class HypreStructPCG
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructPCG( const ArrayLayout_t& layout,
                     const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         if ( is_preconditioner )
             throw std::logic_error(
@@ -577,10 +581,9 @@ class HypreStructPCG
         this->checkHypreError( error );
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructPCGSetup( _solver, A, b, x );
+        auto error = HYPRE_StructPCGSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -621,6 +624,9 @@ class HypreStructPCG
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -631,12 +637,12 @@ class HypreStructGMRES
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructGMRES( const ArrayLayout_t& layout,
                       const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         if ( is_preconditioner )
             throw std::logic_error(
@@ -701,10 +707,9 @@ class HypreStructGMRES
         this->checkHypreError( error );
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructGMRESSetup( _solver, A, b, x );
+        auto error = HYPRE_StructGMRESSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -745,6 +750,9 @@ class HypreStructGMRES
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -755,12 +763,12 @@ class HypreStructBiCGSTAB
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructBiCGSTAB( const ArrayLayout_t& layout,
                          const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         if ( is_preconditioner )
             throw std::logic_error(
@@ -818,10 +826,9 @@ class HypreStructBiCGSTAB
         this->checkHypreError( error );
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructBiCGSTABSetup( _solver, A, b, x );
+        auto error = HYPRE_StructBiCGSTABSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -862,6 +869,9 @@ class HypreStructBiCGSTAB
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -872,12 +882,12 @@ class HypreStructPFMG
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructPFMG( const ArrayLayout_t& layout,
                      const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         auto error = HYPRE_StructPFMGCreate(
             layout.localGrid()->globalGrid().comm(), &_solver );
@@ -1006,10 +1016,9 @@ class HypreStructPFMG
         this->checkHypreError( error );
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructPFMGSetup( _solver, A, b, x );
+        auto error = HYPRE_StructPFMGSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1046,6 +1055,9 @@ class HypreStructPFMG
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -1056,12 +1068,12 @@ class HypreStructSMG
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructSMG( const ArrayLayout_t& layout,
                     const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         auto error = HYPRE_StructSMGCreate(
             layout.localGrid()->globalGrid().comm(), &_solver );
@@ -1136,10 +1148,9 @@ class HypreStructSMG
         this->checkHypreError( error );
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructSMGSetup( _solver, A, b, x );
+        auto error = HYPRE_StructSMGSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1176,6 +1187,9 @@ class HypreStructSMG
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -1186,12 +1200,12 @@ class HypreStructJacobi
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructJacobi( const ArrayLayout_t& layout,
                        const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         auto error = HYPRE_StructJacobiCreate(
             layout.localGrid()->globalGrid().comm(), &_solver );
@@ -1234,10 +1248,9 @@ class HypreStructJacobi
         // The Jacobi solver does not support a print level.
     }
 
-    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
-                    HYPRE_StructVector x ) override
+    void setupImpl() override
     {
-        auto error = HYPRE_StructJacobiSetup( _solver, A, b, x );
+        auto error = HYPRE_StructJacobiSetup( _solver, _A, _b, _x );
         this->checkHypreError( error );
     }
 
@@ -1274,6 +1287,9 @@ class HypreStructJacobi
 
   private:
     HYPRE_StructSolver _solver;
+    using base_type::_A;
+    using base_type::_b;
+    using base_type::_x;
 };
 
 //---------------------------------------------------------------------------//
@@ -1284,12 +1300,12 @@ class HypreStructDiagonal
 {
   public:
     //! Base HYPRE structured solver type.
-    using Base = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
+    using base_type = HypreStructuredSolver<Scalar, EntityType, MemorySpace>;
     //! Constructor
     template <class ArrayLayout_t>
     HypreStructDiagonal( const ArrayLayout_t& layout,
                          const bool is_preconditioner = false )
-        : Base( layout, is_preconditioner )
+        : base_type( layout, is_preconditioner )
     {
         if ( !is_preconditioner )
             throw std::logic_error(
@@ -1325,8 +1341,7 @@ class HypreStructDiagonal
             "Diagonal preconditioner cannot be used as a solver" );
     }
 
-    void setupImpl( HYPRE_StructMatrix, HYPRE_StructVector,
-                    HYPRE_StructVector ) override
+    void setupImpl() override
     {
         throw std::logic_error(
             "Diagonal preconditioner cannot be used as a solver" );


### PR DESCRIPTION
Clean up private/protected variables across structured and semi-structured interfaces - passing local copies of base member variables led to memory leaks in setup/solve. Related to #733 