### PR TITLE
Added prefix argument to Grid writeTimeStep

### DIFF
--- a/grid/src/Cabana_Grid_BovWriter.hpp
+++ b/grid/src/Cabana_Grid_BovWriter.hpp
@@ -172,6 +172,7 @@ reorderView( TargetView& target, const SourceView& source,
   This version writes a single output and does not use bricklets. We will do
   this in the future to improve parallel visualization.
 
+  \param prefix The filename prefix
   \param time_step_index The index of the time step we are writing.
   \param time The current time
   \param array The array to write
@@ -179,9 +180,9 @@ reorderView( TargetView& target, const SourceView& source,
   consistent.
 */
 template <class ExecutionSpace, class Array_t>
-void writeTimeStep( ExecutionSpace, const int time_step_index,
-                    const double time, const Array_t& array,
-                    const bool gather_array = true )
+void writeTimeStep( ExecutionSpace, const std::string& prefix,
+                    const int time_step_index, const double time,
+                    const Array_t& array, const bool gather_array = true )
 {
     static_assert( isUniformMesh<typename Array_t::mesh_type>::value,
                    "ViSIT BOV writer can only be used with uniform mesh" );
@@ -281,8 +282,8 @@ void writeTimeStep( ExecutionSpace, const int time_step_index,
 
     // Compose a data file name prefix.
     std::stringstream file_name;
-    file_name << "grid_" << array.label() << "_" << std::setfill( '0' )
-              << std::setw( 6 ) << time_step_index;
+    file_name << prefix << "_" << std::setfill( '0' ) << std::setw( 6 )
+              << time_step_index;
 
     // Open a binary data file.
     std::string data_file_name = file_name.str() + ".dat";
@@ -393,6 +394,52 @@ void writeTimeStep( ExecutionSpace, const int time_step_index,
   This version writes a single output and does not use bricklets. We will do
   this in the future to improve parallel visualization.
 
+  \param prefix The filename prefix
+  \param time_step_index The index of the time step we are writing.
+  \param time The current time
+  \param array The array to write
+  \param gather_array Gather the array before writing to make parallel
+  consistent.
+*/
+template <class Array_t>
+void writeTimeStep( const std::string& prefix, const int time_step_index,
+                    const double time, const Array_t& array,
+                    const bool gather_array = true )
+{
+    using exec_space = typename Array_t::execution_space;
+    writeTimeStep( exec_space{}, prefix, time_step_index, time, array,
+                   gather_array );
+}
+
+/*!
+  \brief Write a grid array to a VisIt BOV.
+
+  This version writes a single output and does not use bricklets. We will do
+  this in the future to improve parallel visualization.
+
+  \param time_step_index The index of the time step we are writing.
+  \param time The current time
+  \param array The array to write
+  \param gather_array Gather the array before writing to make parallel
+  consistent.
+*/
+template <class ExecutionSpace, class Array_t,
+          typename std::enable_if<
+              Kokkos::is_execution_space<ExecutionSpace>::value, int>::type = 0>
+void writeTimeStep( ExecutionSpace, const int time_step_index,
+                    const double time, const Array_t& array,
+                    const bool gather_array = true )
+{
+    writeTimeStep( ExecutionSpace{}, "grid_" + array.label(), time_step_index,
+                   time, array, gather_array );
+}
+
+/*!
+  \brief Write a grid array to a VisIt BOV.
+
+  This version writes a single output and does not use bricklets. We will do
+  this in the future to improve parallel visualization.
+
   \param time_step_index The index of the time step we are writing.
   \param time The current time
   \param array The array to write
@@ -404,7 +451,8 @@ void writeTimeStep( const int time_step_index, const double time,
                     const Array_t& array, const bool gather_array = true )
 {
     using exec_space = typename Array_t::execution_space;
-    writeTimeStep( exec_space{}, time_step_index, time, array, gather_array );
+    writeTimeStep( exec_space{}, "grid_" + array.label(), time_step_index, time,
+                   array, gather_array );
 }
 
 //---------------------------------------------------------------------------//

--- a/grid/unit_test/tstBovWriter.hpp
+++ b/grid/unit_test/tstBovWriter.hpp
@@ -115,7 +115,7 @@ void writeTest3d()
         // Write the fields to a file.
         Experimental::BovWriter::writeTimeStep( "grid_cell_field_3d", 302, 3.43,
                                                 *cell_field );
-        Experimental::BovWriter::writeTimeStep( "grid_cell_field_3d", 1972,
+        Experimental::BovWriter::writeTimeStep( "grid_node_field_3d", 1972,
                                                 12.457, *node_field );
     }
     // Read the data back in on rank 0 and make sure it is OK.
@@ -274,7 +274,7 @@ void writeTest2d()
         // Write the fields to a file.
         Experimental::BovWriter::writeTimeStep( "grid_cell_field_2d", 302, 3.43,
                                                 *cell_field );
-        Experimental::BovWriter::writeTimeStep( "grid_cell_field_2d", 1972,
+        Experimental::BovWriter::writeTimeStep( "grid_node_field_2d", 1972,
                                                 12.457, *node_field );
     }
     // Read the data back in on rank 0 and make sure it is OK.

--- a/grid/unit_test/tstBovWriter.hpp
+++ b/grid/unit_test/tstBovWriter.hpp
@@ -113,8 +113,10 @@ void writeTest3d()
         node_halo->gather( TEST_EXECSPACE(), *node_field );
 
         // Write the fields to a file.
-        Experimental::BovWriter::writeTimeStep( 302, 3.43, *cell_field );
-        Experimental::BovWriter::writeTimeStep( 1972, 12.457, *node_field );
+        Experimental::BovWriter::writeTimeStep( "grid_cell_field_3d", 302, 3.43,
+                                                *cell_field );
+        Experimental::BovWriter::writeTimeStep( "grid_cell_field_3d", 1972,
+                                                12.457, *node_field );
     }
     // Read the data back in on rank 0 and make sure it is OK.
     int rank;
@@ -270,8 +272,10 @@ void writeTest2d()
         node_halo->gather( TEST_EXECSPACE(), *node_field );
 
         // Write the fields to a file.
-        Experimental::BovWriter::writeTimeStep( 302, 3.43, *cell_field );
-        Experimental::BovWriter::writeTimeStep( 1972, 12.457, *node_field );
+        Experimental::BovWriter::writeTimeStep( "grid_cell_field_2d", 302, 3.43,
+                                                *cell_field );
+        Experimental::BovWriter::writeTimeStep( "grid_cell_field_2d", 1972,
+                                                12.457, *node_field );
     }
     // Read the data back in on rank 0 and make sure it is OK.
     int rank;


### PR DESCRIPTION
Grid's BovWriter currently does not allow the user any control over the filename. This change makes it work the same as the HDF5 particle output.