### PR TITLE
2d neighbors

### DIFF
--- a/benchmark/core/Cabana_LinkedCellPerformance.cpp
+++ b/benchmark/core/Cabana_LinkedCellPerformance.cpp
@@ -112,7 +112,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             double grid_min[3] = { x_min[p], x_min[p], x_min[p] };
             double grid_max[3] = { x_max[p], x_max[p], x_max[p] };
-            auto linked_cell_list = Cabana::createLinkedCellList<memory_space>(
+            auto linked_cell_list = Cabana::createLinkedCellList(
                 x, sort_delta, grid_min, grid_max );
 
             // Setup for neighbor iteration.

--- a/benchmark/core/Cabana_NeighborArborXPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborArborXPerformance.cpp
@@ -78,7 +78,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
             auto x = Cabana::slice<0>( aosoas[p], "position" );
-            auto linked_cell_list = Cabana::createLinkedCellList<memory_space>(
+            auto linked_cell_list = Cabana::createLinkedCellList(
                 x, sort_delta, grid_min, grid_max );
             Cabana::permute( linked_cell_list, aosoas[p] );
         }

--- a/benchmark/core/Cabana_NeighborVerletPerformance.cpp
+++ b/benchmark/core/Cabana_NeighborVerletPerformance.cpp
@@ -85,7 +85,7 @@ void performanceTest( std::ostream& stream, const std::string& test_prefix,
             // in cells the size of the smallest cutoff distance.
             double cutoff = cutoff_ratios.front();
             double sort_delta[3] = { cutoff, cutoff, cutoff };
-            auto linked_cell_list = Cabana::createLinkedCellList<memory_space>(
+            auto linked_cell_list = Cabana::createLinkedCellList(
                 x, sort_delta, grid_min, grid_max );
             Cabana::permute( linked_cell_list, aosoas[p] );
         }

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -95,6 +95,22 @@ class NeighborDiscriminator<FullNeighborTag>
       not neighbor itself (i.e. the particle index "p" is not the same as the
       neighbor index "n").
     */
+    template <std::size_t NumSpaceDim>
+    KOKKOS_INLINE_FUNCTION static bool
+    isValid( const std::size_t p, const Kokkos::Array<double, NumSpaceDim>,
+             const std::size_t n, const Kokkos::Array<double, NumSpaceDim> )
+    {
+        return ( p != n );
+    }
+
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Full neighbor lists count and store the neighbors of all particles. The
+      only criteria for a potentially valid neighbor is that the particle does
+      not neighbor itself (i.e. the particle index "p" is not the same as the
+      neighbor index "n").
+    */
     KOKKOS_INLINE_FUNCTION
     static bool isValid( const std::size_t p, const double, const double,
                          const double, const std::size_t n, const double,
@@ -109,6 +125,29 @@ template <>
 class NeighborDiscriminator<HalfNeighborTag>
 {
   public:
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Half neighbor lists only store half of the neighbors be eliminating
+      duplicate pairs such that the fact that particle "p" neighbors particle
+      "n" is stored in the list but "n" neighboring "p" is not stored but rather
+      implied. We discriminate by only storing neighbors whose coordinates are
+      greater in the x direction. If they are the same then the y direction is
+      checked next and finally the z direction if the y coordinates are the
+      same.
+    */
+    template <std::size_t NumSpaceDim>
+    KOKKOS_INLINE_FUNCTION static bool
+    isValid( const std::size_t p, const Kokkos::Array<double, NumSpaceDim> xp,
+             const std::size_t n, const Kokkos::Array<double, NumSpaceDim> xn )
+    {
+        return ( ( p != n ) &&
+                 ( ( xn[0] > xp[0] ) ||
+                   ( ( xn[0] == xp[0] ) &&
+                     ( ( xn[1] > xp[1] ) ||
+                       ( ( xn[1] == xp[1] ) && ( xn[2] > xp[2] ) ) ) ) ) );
+    }
+
     /*!
       \brief Check whether neighbor pair is valid.
 

--- a/core/src/Cabana_NeighborList.hpp
+++ b/core/src/Cabana_NeighborList.hpp
@@ -26,7 +26,7 @@ namespace Cabana
 // Neighbor List Interface
 //---------------------------------------------------------------------------//
 /*!
-  \brief Tag for full neighbor lists.
+  \brief Tag for building full neighbor lists.
 
   In this case every particle has its neighbors stored in the list. So, if
   particle "i" neighbors particle "j" then "j" will be in the neighbor list
@@ -38,7 +38,7 @@ class FullNeighborTag
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Tag for half neighbor lists.
+  \brief Tag for building half neighbor lists.
 
   In this case only half of the neighbors are stored and the inverse
   relationship is implied. So, if particle "i" neighbors particle "j" then "j"
@@ -50,9 +50,37 @@ class HalfNeighborTag
 };
 
 //---------------------------------------------------------------------------//
+/*!
+  \brief Tag for neighbor list iteration, ignoring only self neighbors.
+*/
+class SelfNeighborTag
+{
+};
+
+//---------------------------------------------------------------------------//
 //! Neighborhood discriminator.
 template <class Tag>
 class NeighborDiscriminator;
+
+//! Self neighbor discriminator specialization.
+//! \note This is not sufficient for building both full and half neighbor lists
+//! and is intended for neighbor iteration.
+template <>
+class NeighborDiscriminator<SelfNeighborTag>
+{
+  public:
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      This check only considers self neighbors (i.e. the particle index "p" is
+      not the same as the neighbor index "n").
+    */
+    KOKKOS_INLINE_FUNCTION
+    static bool isValid( const std::size_t p, const std::size_t n )
+    {
+        return ( p != n );
+    }
+};
 
 //! Full list discriminator specialization.
 template <>
@@ -81,6 +109,48 @@ template <>
 class NeighborDiscriminator<HalfNeighborTag>
 {
   public:
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Half neighbor lists only store half of the neighbors be eliminating
+      duplicate pairs such that the fact that particle "p" neighbors particle
+      "n" is stored in the list but "n" neighboring "p" is not stored but rather
+      implied. We discriminate by only storing neighbors whose coordinates are
+      greater in the x direction. If they are the same then the y direction is
+      checked next and finally the z direction if the y coordinates are the
+      same.
+    */
+    KOKKOS_INLINE_FUNCTION static bool
+    isValid( const std::size_t p, const Kokkos::Array<double, 3> xp,
+             const std::size_t n, const Kokkos::Array<double, 3> xn )
+    {
+        return ( ( p != n ) &&
+                 ( ( xn[0] > xp[0] ) ||
+                   ( ( xn[0] == xp[0] ) &&
+                     ( ( xn[1] > xp[1] ) ||
+                       ( ( xn[1] == xp[1] ) && ( xn[2] > xp[2] ) ) ) ) ) );
+    }
+
+    /*!
+      \brief Check whether neighbor pair is valid.
+
+      Half neighbor lists only store half of the neighbors be eliminating
+      duplicate pairs such that the fact that particle "p" neighbors particle
+      "n" is stored in the list but "n" neighboring "p" is not stored but rather
+      implied. We discriminate by only storing neighbors whose coordinates are
+      greater in the x direction. If they are the same then the y direction is
+      checked next and finally the z direction if the y coordinates are the
+      same.
+    */
+    KOKKOS_INLINE_FUNCTION static bool
+    isValid( const std::size_t p, const Kokkos::Array<double, 2> xp,
+             const std::size_t n, const Kokkos::Array<double, 2> xn )
+    {
+        return ( ( p != n ) &&
+                 ( ( xn[0] > xp[0] ) ||
+                   ( ( xn[0] == xp[0] ) && ( ( xn[1] > xp[1] ) ) ) ) );
+    }
+
     /*!
       \brief Check whether neighbor pair is valid.
 

--- a/core/src/impl/Cabana_CartesianGrid.hpp
+++ b/core/src/impl/Cabana_CartesianGrid.hpp
@@ -23,131 +23,232 @@ namespace Impl
 {
 //! \cond Impl
 
-template <class Real, typename std::enable_if<
-                          std::is_floating_point<Real>::value, int>::type = 0>
+template <class Real, std::size_t NumSpaceDim = 3>
 class CartesianGrid
 {
+    static_assert( std::is_floating_point<Real>::value,
+                   "Scalar type must be floating point type." );
+
   public:
     using real_type = Real;
+    static constexpr std::size_t num_space_dim = NumSpaceDim;
 
-    Real _min_x;
-    Real _min_y;
-    Real _min_z;
-    Real _max_x;
-    Real _max_y;
-    Real _max_z;
-    Real _dx;
-    Real _dy;
-    Real _dz;
-    Real _rdx;
-    Real _rdy;
-    Real _rdz;
-    int _nx;
-    int _ny;
-    int _nz;
+    Kokkos::Array<real_type, num_space_dim> _min;
+    Kokkos::Array<real_type, num_space_dim> _max;
+    Kokkos::Array<real_type, num_space_dim> _dx;
+    Kokkos::Array<real_type, num_space_dim> _rdx;
+    Kokkos::Array<int, num_space_dim> _nx;
 
     CartesianGrid() = default;
 
+    template <class ArrayType>
+    CartesianGrid( const ArrayType min, const ArrayType max,
+                   const real_type delta_x )
+    {
+        Kokkos::Array<real_type, num_space_dim> delta;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            delta[d] = delta_x;
+        init( min, max, delta );
+    }
+
+    template <class ArrayType>
+    CartesianGrid( const ArrayType min, const ArrayType max,
+                   const ArrayType delta )
+    {
+        init( min, max, delta );
+    }
+
+    template <class ArrayType, class DeltaArrayType>
+    void init( const ArrayType min, const ArrayType max,
+               const DeltaArrayType delta )
+    {
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            _min[d] = min[d];
+            _max[d] = max[d];
+            _nx[d] = cellsBetween( max[d], min[d], 1.0 / delta[d] );
+            _dx[d] = ( max[d] - min[d] ) / _nx[d];
+            _rdx[d] = 1.0 / _dx[d];
+        }
+    }
+
+    template <std::size_t NSD = num_space_dim>
     CartesianGrid( const Real min_x, const Real min_y, const Real min_z,
                    const Real max_x, const Real max_y, const Real max_z,
-                   const Real delta_x, const Real delta_y, const Real delta_z )
-        : _min_x( min_x )
-        , _min_y( min_y )
-        , _min_z( min_z )
-        , _max_x( max_x )
-        , _max_y( max_y )
-        , _max_z( max_z )
+                   const Real delta_x, const Real delta_y, const Real delta_z,
+                   typename std::enable_if<NSD == 3, int>::type* = 0 )
+        : _min( { min_x, min_y, min_z } )
+        , _max( { max_x, max_y, max_z } )
     {
-        _nx = cellsBetween( max_x, min_x, 1.0 / delta_x );
-        _ny = cellsBetween( max_y, min_y, 1.0 / delta_y );
-        _nz = cellsBetween( max_z, min_z, 1.0 / delta_z );
+        _nx[0] = cellsBetween( max_x, min_x, 1.0 / delta_x );
+        _nx[1] = cellsBetween( max_y, min_y, 1.0 / delta_y );
+        _nx[2] = cellsBetween( max_z, min_z, 1.0 / delta_z );
 
-        _dx = ( max_x - min_x ) / _nx;
-        _dy = ( max_y - min_y ) / _ny;
-        _dz = ( max_z - min_z ) / _nz;
+        _dx[0] = ( max_x - min_x ) / _nx[0];
+        _dx[1] = ( max_y - min_y ) / _nx[1];
+        _dx[2] = ( max_z - min_z ) / _nx[2];
 
-        _rdx = 1.0 / _dx;
-        _rdy = 1.0 / _dy;
-        _rdz = 1.0 / _dz;
+        _rdx[0] = 1.0 / _dx[0];
+        _rdx[1] = 1.0 / _dx[1];
+        _rdx[2] = 1.0 / _dx[2];
     }
 
     // Get the total number of cells.
     KOKKOS_INLINE_FUNCTION
-    std::size_t totalNumCells() const { return _nx * _ny * _nz; }
+    std::size_t totalNumCells() const
+    {
+        std::size_t total = 1;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+            total *= _nx[d];
+        return total;
+    }
 
     // Get the number of cells in each direction.
-    KOKKOS_INLINE_FUNCTION
-    void numCells( int& num_x, int& num_y, int& num_z )
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, void>
+    numCells( int& num_x, int& num_y, int& num_z )
     {
-        num_x = _nx;
-        num_y = _ny;
-        num_z = _nz;
+        num_x = _nx[0];
+        num_y = _nx[1];
+        num_z = _nx[2];
+    }
+
+    // Get the number of cells in each direction.
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, void>
+    numCells( int& num_x, int& num_y )
+    {
+        num_x = _nx[0];
+        num_y = _nx[1];
     }
 
     // Get the number of cells in a given direction.
     KOKKOS_INLINE_FUNCTION
     int numBin( const int dim ) const
     {
+        assert( static_cast<std::size_t>( dim ) < num_space_dim );
+
         if ( 0 == dim )
-            return _nx;
+            return _nx[0];
         else if ( 1 == dim )
-            return _ny;
+            return _nx[1];
         else if ( 2 == dim )
-            return _nz;
+            return _nx[2];
         else
             return -1;
     }
 
     // Given a position get the ijk indices of the cell in which
-    KOKKOS_INLINE_FUNCTION
-    void locatePoint( const Real xp, const Real yp, const Real zp, int& ic,
-                      int& jc, int& kc ) const
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, void>
+    locatePoint( const Real xp, const Real yp, const Real zp, int& ic, int& jc,
+                 int& kc ) const
     {
         // Since we use a floor function a point on the outer boundary
         // will be found in the next cell, causing an out of bounds error
-        ic = cellsBetween( xp, _min_x, _rdx );
-        ic = ( ic == _nx ) ? ic - 1 : ic;
-        jc = cellsBetween( yp, _min_y, _rdy );
-        jc = ( jc == _ny ) ? jc - 1 : jc;
-        kc = cellsBetween( zp, _min_z, _rdz );
-        kc = ( kc == _nz ) ? kc - 1 : kc;
+        ic = cellsBetween( xp, _min[0], _rdx[0] );
+        ic = ( ic == _nx[0] ) ? ic - 1 : ic;
+        jc = cellsBetween( yp, _min[1], _rdx[1] );
+        jc = ( jc == _nx[1] ) ? jc - 1 : jc;
+        kc = cellsBetween( zp, _min[2], _rdx[2] );
+        kc = ( kc == _nx[2] ) ? kc - 1 : kc;
+    }
+
+    // Given a position get the ijk indices of the cell in which
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, void>
+    locatePoint( const Real xp, const Real yp, int& ic, int& jc ) const
+    {
+        // Since we use a floor function a point on the outer boundary
+        // will be found in the next cell, causing an out of bounds error
+        ic = cellsBetween( xp, _min[0], _rdx[0] );
+        ic = ( ic == _nx[0] ) ? ic - 1 : ic;
+        jc = cellsBetween( yp, _min[1], _rdx[1] );
+        jc = ( jc == _nx[1] ) ? jc - 1 : jc;
     }
 
     // Given a position and a cell index get square of the minimum distance to
     // that point to any point in the cell. If the point is in the cell the
     // returned distance is zero.
-    KOKKOS_INLINE_FUNCTION
-    Real minDistanceToPoint( const Real xp, const Real yp, const Real zp,
-                             const int ic, const int jc, const int kc ) const
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, Real>
+    minDistanceToPoint( const Real xp, const Real yp, const Real zp,
+                        const int ic, const int jc, const int kc ) const
     {
-        Real xc = _min_x + ( ic + 0.5 ) * _dx;
-        Real yc = _min_y + ( jc + 0.5 ) * _dy;
-        Real zc = _min_z + ( kc + 0.5 ) * _dz;
+        Kokkos::Array<Real, num_space_dim> x;
+        x[0] = xp;
+        x[1] = yp;
+        x[2] = zp;
+        Kokkos::Array<int, num_space_dim> c;
+        c[0] = ic;
+        c[1] = jc;
+        c[2] = kc;
 
-        Real rx = fabs( xp - xc ) - 0.5 * _dx;
-        Real ry = fabs( yp - yc ) - 0.5 * _dy;
-        Real rz = fabs( zp - zc ) - 0.5 * _dz;
+        return minDistanceToPoint( x, c );
+    }
 
-        rx = ( rx > 0.0 ) ? rx : 0.0;
-        ry = ( ry > 0.0 ) ? ry : 0.0;
-        rz = ( rz > 0.0 ) ? rz : 0.0;
+    // Given a position and a cell index get square of the minimum distance to
+    // that point to any point in the cell. If the point is in the cell the
+    // returned distance is zero.
+    KOKKOS_INLINE_FUNCTION Real
+    minDistanceToPoint( const Kokkos::Array<Real, num_space_dim> x,
+                        const Kokkos::Array<int, num_space_dim> c ) const
+    {
+        Real rsqr = 0.0;
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            Real xc = _min[d] + ( c[d] + 0.5 ) * _dx[d];
+            Real rx = fabs( x[d] - xc ) - 0.5 * _dx[d];
 
-        return rx * rx + ry * ry + rz * rz;
+            rx = ( rx > 0.0 ) ? rx : 0.0;
+
+            rsqr += rx * rx;
+        }
+
+        return rsqr;
     }
 
     // Given the ijk index of a cell get its cardinal index.
-    KOKKOS_INLINE_FUNCTION
-    int cardinalCellIndex( const int i, const int j, const int k ) const
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, int>
+    cardinalCellIndex( const int i, const int j, const int k ) const
     {
-        return ( i * _ny + j ) * _nz + k;
+        return ( i * _nx[1] + j ) * _nx[2] + k;
     }
 
-    KOKKOS_INLINE_FUNCTION
-    void ijkBinIndex( const int cardinal, int& i, int& j, int& k ) const
+    // Given the ij index of a cell get its cardinal index.
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, int>
+    cardinalCellIndex( const int i, const int j ) const
     {
-        i = cardinal / ( _ny * _nz );
-        j = ( cardinal / _nz ) % _ny;
-        k = cardinal % _nz;
+        return i * _nx[1] + j;
+    }
+
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<3 == NSD, void>
+    ijkBinIndex( const int cardinal, int& i, int& j, int& k ) const
+    {
+        i = cardinal / ( _nx[1] * _nx[2] );
+        j = ( cardinal / _nx[2] ) % _nx[1];
+        k = cardinal % _nx[2];
+    }
+
+    template <std::size_t NSD = num_space_dim>
+    KOKKOS_INLINE_FUNCTION std::enable_if_t<2 == NSD, void>
+    ijkBinIndex( const int cardinal, int& i, int& j ) const
+    {
+        i = cardinal / ( _nx[1] );
+        j = cardinal % _nx[1];
+    }
+
+    KOKKOS_INLINE_FUNCTION void
+    ijkBinIndex( const int cardinal,
+                 Kokkos::Array<int, num_space_dim>& ijk ) const
+    {
+        if constexpr ( num_space_dim == 3 )
+            return ijkBinIndex( cardinal, ijk[0], ijk[1], ijk[2] );
+        else
+            return ijkBinIndex( cardinal, ijk[0], ijk[1] );
     }
 
     // Calculate the number of full cells between 2 points.

--- a/core/src/impl/Cabana_CartesianGrid.hpp
+++ b/core/src/impl/Cabana_CartesianGrid.hpp
@@ -167,6 +167,20 @@ class CartesianGrid
         jc = ( jc == _nx[1] ) ? jc - 1 : jc;
     }
 
+    // Given a position get the ijk indices of the cell in which
+    KOKKOS_INLINE_FUNCTION void
+    locatePoint( const Kokkos::Array<Real, num_space_dim> p,
+                 Kokkos::Array<int, num_space_dim>& c ) const
+    {
+        // Since we use a floor function a point on the outer boundary
+        // will be found in the next cell, causing an out of bounds error
+        for ( std::size_t d = 0; d < num_space_dim; ++d )
+        {
+            c[d] = cellsBetween( p[d], _min[d], _rdx[d] );
+            c[d] = ( c[d] == _nx[d] ) ? c[d] - 1 : c[d];
+        }
+    }
+
     // Given a position and a cell index get square of the minimum distance to
     // that point to any point in the cell. If the point is in the cell the
     // returned distance is zero.
@@ -222,6 +236,16 @@ class CartesianGrid
     cardinalCellIndex( const int i, const int j ) const
     {
         return i * _nx[1] + j;
+    }
+
+    // Given the ij index of a cell get its cardinal index.
+    KOKKOS_INLINE_FUNCTION int
+    cardinalCellIndex( const Kokkos::Array<int, num_space_dim> ijk ) const
+    {
+        if constexpr ( num_space_dim == 3 )
+            return cardinalCellIndex( ijk[0], ijk[1], ijk[2] );
+        else
+            return cardinalCellIndex( ijk[0], ijk[1] );
     }
 
     template <std::size_t NSD = num_space_dim>

--- a/core/unit_test/tstCartesianGrid.cpp
+++ b/core/unit_test/tstCartesianGrid.cpp
@@ -19,7 +19,7 @@
 namespace Test
 {
 
-TEST( CartesianGrid, Test )
+TEST( CartesianGrid, 3d )
 {
     double min[3] = { -1.0, -0.5, -0.6 };
     double max[3] = { 2.5, 1.5, 1.9 };
@@ -56,6 +56,37 @@ TEST( CartesianGrid, Test )
     EXPECT_EQ( ic, 6 );
     EXPECT_EQ( jc, 15 );
     EXPECT_EQ( kc, 9 );
+}
+
+TEST( CartesianGrid, 2d )
+{
+    double min[2] = { -1.0, -0.5 };
+    double max[2] = { 2.5, 1.5 };
+    double delta[2] = { 0.5, 0.125 };
+
+    Cabana::Impl::CartesianGrid<double, 2> grid( min, max, delta );
+
+    int nx, ny;
+    grid.numCells( nx, ny );
+    EXPECT_EQ( nx, 7 );
+    EXPECT_EQ( ny, 16 );
+    auto total = grid.totalNumCells();
+    EXPECT_EQ( total, nx * ny );
+
+    Kokkos::Array<double, 2> xp = { -0.9, 1.4 };
+    Kokkos::Array<int, 2> ic;
+    grid.locatePoint( xp, ic );
+    EXPECT_EQ( ic[0], 0 );
+    EXPECT_EQ( ic[1], 15 );
+
+    double min_dist = grid.minDistanceToPoint( xp, ic );
+    EXPECT_DOUBLE_EQ( min_dist, 0.0 );
+
+    xp[0] = 2.5;
+    xp[1] = 1.5;
+    grid.locatePoint( xp, ic );
+    EXPECT_EQ( ic[0], 6 );
+    EXPECT_EQ( ic[1], 15 );
 }
 
 } // end namespace Test

--- a/core/unit_test/tstCartesianGrid.cpp
+++ b/core/unit_test/tstCartesianGrid.cpp
@@ -34,6 +34,8 @@ TEST( CartesianGrid, Test )
     EXPECT_EQ( nx, 7 );
     EXPECT_EQ( ny, 16 );
     EXPECT_EQ( nz, 10 );
+    auto total = grid.totalNumCells();
+    EXPECT_EQ( total, nx * ny * nz );
 
     double xp = -0.9;
     double yp = 1.4;

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -338,7 +338,7 @@ void testLinkedList()
     {
         auto begin = test_data.begin;
         auto end = test_data.end;
-        auto cell_list = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+        auto cell_list = Cabana::createLinkedCellList(
             pos, begin, end, grid_delta, grid_min, grid_max,
             test_data.grid_delta[0], 1.0 );
         Cabana::permute( cell_list, test_data.aosoa );
@@ -351,7 +351,7 @@ void testLinkedList()
 
     // Now bin and permute all of the particles.
     {
-        auto cell_list = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+        auto cell_list = Cabana::createLinkedCellList(
             pos, grid_delta, grid_min, grid_max, test_data.grid_delta[0] );
         Cabana::permute( cell_list, test_data.aosoa );
 
@@ -376,7 +376,7 @@ void testLinkedListSlice()
     {
         auto begin = test_data.begin;
         auto end = test_data.end;
-        auto cell_list = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+        auto cell_list = Cabana::createLinkedCellList(
             pos, begin, end, grid_delta, grid_min, grid_max, grid_delta[0] );
         Cabana::permute( cell_list, pos );
 
@@ -387,7 +387,7 @@ void testLinkedListSlice()
     }
     // Now bin and permute all of the particles.
     {
-        auto cell_list = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+        auto cell_list = Cabana::createLinkedCellList(
             pos, grid_delta, grid_min, grid_max, grid_delta[0] );
         Cabana::permute( cell_list, pos );
 
@@ -640,7 +640,7 @@ void testLinkedCellNeighborInterface()
     // Create the linked cell list.
     double grid_size = test_data.cell_size_ratio * test_data.test_radius;
     double grid_delta[3] = { grid_size, grid_size, grid_size };
-    auto nlist = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+    auto nlist = Cabana::createLinkedCellList(
         positions, test_data.begin, test_data.end, grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );
@@ -665,7 +665,7 @@ void testLinkedCellParallel()
     // Create the linked cell list.
     double grid_size = test_data.cell_size_ratio * test_data.test_radius;
     double grid_delta[3] = { grid_size, grid_size, grid_size };
-    auto nlist = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+    auto nlist = Cabana::createLinkedCellList(
         positions, test_data.begin, test_data.end, grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );
@@ -690,7 +690,7 @@ void testLinkedCellReduce()
     // Create the linked cell list.
     double grid_size = test_data.cell_size_ratio * test_data.test_radius;
     double grid_delta[3] = { grid_size, grid_size, grid_size };
-    auto nlist = Cabana::createLinkedCellList<TEST_MEMSPACE>(
+    auto nlist = Cabana::createLinkedCellList(
         positions, test_data.begin, test_data.end, grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );

--- a/core/unit_test/tstLinkedCellList.hpp
+++ b/core/unit_test/tstLinkedCellList.hpp
@@ -22,7 +22,12 @@ namespace Test
 //---------------------------------------------------------------------------//
 // Test data
 //---------------------------------------------------------------------------//
-struct LCLTestData
+
+template <std::size_t Dim>
+struct LCLTestData;
+
+template <>
+struct LCLTestData<3>
 {
     enum MyFields
     {
@@ -46,10 +51,10 @@ struct LCLTestData
     double x_min = 0.0;
     double x_max = x_min + nx * dx;
 
-    // Create a grid.
-    double grid_delta[3] = { dx, dx, dx };
-    double grid_min[3] = { x_min, x_min, x_min };
-    double grid_max[3] = { x_max, x_max, x_max };
+    // Create a grid. Either are options for construction.
+    Kokkos::Array<double, 3> grid_delta = { dx, dx, dx };
+    Kokkos::Array<double, 3> grid_min = { x_min, x_min, x_min };
+    Kokkos::Array<double, 3> grid_max = { x_max, x_max, x_max };
 
     using IDViewType = Kokkos::View<int* [3], TEST_MEMSPACE>;
     using PosViewType = Kokkos::View<double* [3], TEST_MEMSPACE>;
@@ -100,20 +105,90 @@ struct LCLTestData
     }
 };
 
+template <>
+struct LCLTestData<2> : public LCLTestData<3>
+{
+    using base_type = LCLTestData<3>;
+    using base_type::MyFields;
+    std::size_t begin = 25;
+    std::size_t end = 75;
+    std::size_t num_p = 100;
+
+    using data_types = Cabana::MemberTypes<double[2], int[2]>;
+    using aosoa_type = Cabana::AoSoA<data_types, TEST_MEMSPACE>;
+    using size_type = typename aosoa_type::memory_space::size_type;
+    aosoa_type aosoa;
+
+    using base_type::dx;
+    using base_type::nx;
+    using base_type::x_max;
+    using base_type::x_min;
+
+    // Create a grid.
+    Kokkos::Array<double, 2> grid_delta = { dx, dx };
+    Kokkos::Array<double, 2> grid_min = { x_min, x_min };
+    Kokkos::Array<double, 2> grid_max = { x_max, x_max };
+
+    using IDViewType = Kokkos::View<int* [2], TEST_MEMSPACE>;
+    using PosViewType = Kokkos::View<double* [2], TEST_MEMSPACE>;
+    using BinViewType = Kokkos::View<size_type**, TEST_MEMSPACE>;
+
+    using layout = typename TEST_EXECSPACE::array_layout;
+    Kokkos::View<int* [2], layout, Kokkos::HostSpace> ids_mirror;
+    Kokkos::View<double* [2], layout, Kokkos::HostSpace> pos_mirror;
+    Kokkos::View<size_type**, layout, Kokkos::HostSpace> bin_size_mirror;
+    Kokkos::View<size_type**, layout, Kokkos::HostSpace> bin_offset_mirror;
+
+    LCLTestData()
+    {
+        aosoa = aosoa_type( "aosoa", num_p );
+
+        createParticles();
+    }
+
+    void createParticles()
+    {
+        // Create local variables for lambda capture
+        auto nx_ = nx;
+        auto x_min_ = x_min;
+        auto dx_ = dx;
+
+        // Fill the AoSoA with positions and ijk cell ids.
+        auto pos = Cabana::slice<Position>( aosoa, "position" );
+        auto cell_id = Cabana::slice<CellId>( aosoa, "cell_id" );
+        Kokkos::parallel_for(
+            "initialize", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx_ ),
+            KOKKOS_LAMBDA( const int j ) {
+                for ( int i = 0; i < nx_; ++i )
+                {
+                    std::size_t particle_id = i + j * nx_;
+
+                    cell_id( particle_id, 0 ) = i;
+                    cell_id( particle_id, 1 ) = j;
+
+                    pos( particle_id, 0 ) = x_min_ + ( i + 0.5 ) * dx_;
+                    pos( particle_id, 1 ) = x_min_ + ( j + 0.5 ) * dx_;
+                }
+            } );
+    }
+};
+
 void copyListToHost(
-    LCLTestData& test_data,
-    const Cabana::LinkedCellList<TEST_MEMSPACE, double> cell_list )
+    LCLTestData<3>& test_data,
+    const Cabana::LinkedCellList<TEST_MEMSPACE, double, 3> cell_list )
 {
     // Copy data to the host for testing.
     auto np = test_data.num_p;
     auto nx = test_data.nx;
-    auto pos_slice = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
-    auto id_slice = Cabana::slice<LCLTestData::CellId>( test_data.aosoa );
+    auto pos_slice = Cabana::slice<LCLTestData<3>::Position>( test_data.aosoa );
+    auto id_slice = Cabana::slice<LCLTestData<3>::CellId>( test_data.aosoa );
 
-    LCLTestData::IDViewType ids( "cell_ids", np );
-    LCLTestData::PosViewType pos( "cell_ids", np );
-    LCLTestData::BinViewType bin_size( "bin_size", nx, nx, nx );
-    LCLTestData::BinViewType bin_offset( "bin_offset", nx, nx, nx );
+    LCLTestData<3>::IDViewType ids( "cell_ids", np );
+    LCLTestData<3>::PosViewType pos( "cell_ids", np );
+    using BinViewType =
+        Kokkos::View<typename LCLTestData<3>::size_type***, TEST_MEMSPACE>;
+    BinViewType bin_size( "bin_size", nx, nx, nx );
+    BinViewType bin_offset( "bin_offset", nx, nx, nx );
     Kokkos::parallel_for(
         "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
         KOKKOS_LAMBDA( const int i ) {
@@ -142,25 +217,68 @@ void copyListToHost(
         Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), bin_offset );
 }
 
+void copyListToHost(
+    LCLTestData<2>& test_data,
+    const Cabana::LinkedCellList<TEST_MEMSPACE, double, 2> cell_list )
+{
+    // Copy data to the host for testing.
+    auto np = test_data.num_p;
+    auto nx = test_data.nx;
+    auto pos_slice = Cabana::slice<LCLTestData<2>::Position>( test_data.aosoa );
+    auto id_slice = Cabana::slice<LCLTestData<2>::CellId>( test_data.aosoa );
+
+    LCLTestData<2>::IDViewType ids( "cell_ids", np );
+    LCLTestData<2>::PosViewType pos( "cell_ids", np );
+    using BinViewType =
+        Kokkos::View<typename LCLTestData<2>::size_type**, TEST_MEMSPACE>;
+    BinViewType bin_size( "bin_size", nx, nx );
+    BinViewType bin_offset( "bin_offset", nx, nx );
+    Kokkos::parallel_for(
+        "copy bin data", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, nx ),
+        KOKKOS_LAMBDA( const int i ) {
+            for ( int j = 0; j < nx; ++j )
+            {
+                std::size_t original_id = i + j * nx;
+                ids( original_id, 0 ) = id_slice( original_id, 0 );
+                ids( original_id, 1 ) = id_slice( original_id, 1 );
+                pos( original_id, 0 ) = pos_slice( original_id, 0 );
+                pos( original_id, 1 ) = pos_slice( original_id, 1 );
+                Kokkos::Array<int, 2> ij = { i, j };
+                bin_size( i, j ) = cell_list.binSize( ij );
+                bin_offset( i, j ) = cell_list.binOffset( ij );
+            }
+        } );
+    Kokkos::fence();
+    test_data.ids_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), ids );
+    test_data.pos_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), pos );
+    test_data.bin_size_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), bin_size );
+    test_data.bin_offset_mirror =
+        Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), bin_offset );
+}
+
 //---------------------------------------------------------------------------//
 // Main Linked Cell List tests
 //---------------------------------------------------------------------------//
-void checkBins( const LCLTestData test_data,
-                const Cabana::LinkedCellList<TEST_MEMSPACE, double> cell_list )
+template <std::size_t Dim>
+void checkBins(
+    const LCLTestData<Dim> test_data,
+    const Cabana::LinkedCellList<TEST_MEMSPACE, double, Dim> cell_list )
 {
     auto nx = test_data.nx;
 
     // Checking the binning.
-    EXPECT_EQ( cell_list.totalBins(), nx * nx * nx );
-    EXPECT_EQ( cell_list.numBin( 0 ), nx );
-    EXPECT_EQ( cell_list.numBin( 1 ), nx );
-    EXPECT_EQ( cell_list.numBin( 2 ), nx );
+    EXPECT_EQ( cell_list.totalBins(), std::pow( nx, Dim ) );
+    for ( std::size_t d = 0; d < Dim; ++d )
+        EXPECT_EQ( cell_list.numBin( d ), nx );
 }
 
 // Check LinkedCell data, where either a subset (begin->end) or all data is
 // sorted and where the IDs are sorted or not based on whether the entire AoSoA
 // or only the position slice was permuted.
-void checkLinkedCell( const LCLTestData test_data,
+void checkLinkedCell( const LCLTestData<3> test_data,
                       const std::size_t check_begin,
                       const std::size_t check_end, const bool sorted_ids )
 {
@@ -208,7 +326,7 @@ void checkLinkedCell( const LCLTestData test_data,
                     // right offset.
                     EXPECT_EQ( bin_size_mirror( i, j, k ), 1 );
                     EXPECT_EQ( bin_offset_mirror( i, j, k ),
-                               LCLTestData::size_type( particle_id ) );
+                               LCLTestData<3>::size_type( particle_id ) );
 
                     // Increment the particle id.
                     ++particle_id;
@@ -246,10 +364,85 @@ void checkLinkedCell( const LCLTestData test_data,
     }
 }
 
+void checkLinkedCell( const LCLTestData<2> test_data,
+                      const std::size_t check_begin,
+                      const std::size_t check_end, const bool sorted_ids )
+{
+    auto nx = test_data.nx;
+    auto ids_mirror = test_data.ids_mirror;
+    auto bin_size_mirror = test_data.bin_size_mirror;
+    auto bin_offset_mirror = test_data.bin_offset_mirror;
+
+    // The order should be reversed with the i index moving the slowest
+    // for those that are actually in the binning range. Do this pass
+    // first. We do this by looping through in the sorted order and
+    // check those that had original indices in the sorting range.
+    std::size_t particle_id = 0;
+    for ( int i = 0; i < nx; ++i )
+    {
+        for ( int j = 0; j < nx; ++j )
+        {
+            std::size_t original_id = i + j * nx;
+            if ( check_begin <= original_id && original_id < check_end )
+            {
+                // Get what should be the local id of the particle
+                // in the newly sorted decomposition. We are looping
+                // through this in k-fastest order (the indexing of
+                // the grid cells) and therefore should get the
+                // particles in their sorted order.
+                int sort_id = check_begin + particle_id;
+
+                // Back calculate what we think the ijk indices of
+                // the particle are based on k-fastest ordering.
+                int grid_id = i * nx * nx + j * nx;
+                int grid_i = grid_id / ( nx * nx );
+                int grid_j = ( grid_id / nx ) % nx;
+
+                // Check the indices of the particle, if sorted.
+                if ( sorted_ids )
+                {
+                    EXPECT_EQ( ids_mirror( sort_id, 0 ), grid_i );
+                    EXPECT_EQ( ids_mirror( sort_id, 1 ), grid_j );
+                }
+                // Check that we binned the particle and got the
+                // right offset.
+                EXPECT_EQ( bin_size_mirror( i, j ), 1 );
+                EXPECT_EQ( bin_offset_mirror( i, j ),
+                           LCLTestData<2>::size_type( particle_id ) );
+
+                // Increment the particle id.
+                ++particle_id;
+            }
+        }
+    }
+
+    // For those that are outside the binned range IDs should be
+    // unchanged and the bins should empty.
+    particle_id = 0;
+    for ( int j = 0; j < nx; ++j )
+    {
+        for ( int i = 0; i < nx; ++i, ++particle_id )
+        {
+            if ( check_begin > particle_id || particle_id >= check_end )
+            {
+                EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
+                EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
+                EXPECT_EQ( bin_size_mirror( i, j ), 0 );
+            }
+            else if ( not sorted_ids )
+            {
+                // If sorted by position slice, IDs in range should
+                // still not be sorted.
+                EXPECT_EQ( ids_mirror( particle_id, 0 ), i );
+                EXPECT_EQ( ids_mirror( particle_id, 1 ), j );
+            }
+        }
+    }
+}
+
 //---------------------------------------------------------------------------//
 // Linked cell list cell stencil test.
-
-void testLinkedCellStencil()
+void testLinkedCellStencil3d()
 {
     // Point in the middle
     {
@@ -324,14 +517,114 @@ void testLinkedCellStencil()
     }
 }
 
+void testLinkedCellStencil2d()
+{
+    // Point in the middle
+    {
+        double min[2] = { 0.0, 0.0 };
+        double max[2] = { 10.0, 10.0 };
+        double radius = 1.0;
+        double ratio = 1.0;
+        Cabana::LinkedCellStencil<double, 2> stencil( radius, ratio, min, max );
+
+        Kokkos::Array<double, 2> xp = { 4.5, 5.5 };
+        Kokkos::Array<int, 2> ic;
+        stencil.grid.locatePoint( xp, ic );
+        int cell = stencil.grid.cardinalCellIndex( ic );
+        Kokkos::Array<int, 2> cmin, cmax;
+        stencil.getCells( cell, cmin, cmax );
+        EXPECT_EQ( cmin[0], 3 );
+        EXPECT_EQ( cmax[0], 6 );
+        EXPECT_EQ( cmin[1], 4 );
+        EXPECT_EQ( cmax[1], 7 );
+    }
+
+    // Point in the lower right corner
+    {
+        double min[2] = { 0.0, 0.0 };
+        double max[2] = { 10.0, 10.0 };
+        double radius = 1.0;
+        double ratio = 1.0;
+        Cabana::LinkedCellStencil<double, 2> stencil( radius, ratio, min, max );
+
+        Kokkos::Array<double, 2> xp = { 0.5, 0.5 };
+        Kokkos::Array<int, 2> ic;
+        stencil.grid.locatePoint( xp, ic );
+        int cell = stencil.grid.cardinalCellIndex( ic );
+        Kokkos::Array<int, 2> cmin, cmax;
+        stencil.getCells( cell, cmin, cmax );
+        EXPECT_EQ( cmin[0], 0 );
+        EXPECT_EQ( cmax[0], 2 );
+        EXPECT_EQ( cmin[1], 0 );
+        EXPECT_EQ( cmax[1], 2 );
+    }
+
+    // Point in the upper left corner
+    {
+        double min[2] = { 0.0, 0.0 };
+        double max[2] = { 10.0, 10.0 };
+        double radius = 1.0;
+        double ratio = 1.0;
+        Cabana::LinkedCellStencil<double, 2> stencil( radius, ratio, min, max );
+
+        Kokkos::Array<double, 2> xp = { 9.5, 9.5 };
+        Kokkos::Array<int, 2> ic;
+        stencil.grid.locatePoint( xp, ic );
+        int cell = stencil.grid.cardinalCellIndex( ic );
+        Kokkos::Array<int, 2> cmin, cmax;
+        stencil.getCells( cell, cmin, cmax );
+        EXPECT_EQ( cmin[0], 8 );
+        EXPECT_EQ( cmax[0], 10 );
+        EXPECT_EQ( cmin[1], 8 );
+        EXPECT_EQ( cmax[1], 10 );
+    }
+}
+
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedList()
 {
-    LCLTestData test_data;
+    LCLTestData<Dim> test_data;
     auto grid_delta = test_data.grid_delta;
     auto grid_min = test_data.grid_min;
     auto grid_max = test_data.grid_max;
-    auto pos = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
+    auto pos = Cabana::slice<LCLTestData<Dim>::Position>( test_data.aosoa );
+
+    // Bin and permute the particles in the grid. First do this by only
+    // operating on a subset of the particles.
+    {
+        auto begin = test_data.begin;
+        auto end = test_data.end;
+        auto cell_list = Cabana::createLinkedCellList(
+            pos, begin, end, grid_delta, grid_min, grid_max,
+            test_data.grid_delta[0], 1.0 );
+        Cabana::permute( cell_list, test_data.aosoa );
+
+        copyListToHost( test_data, cell_list );
+
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, begin, end, true );
+    }
+
+    // Now bin and permute all of the particles.
+    {
+        auto cell_list = Cabana::createLinkedCellList(
+            pos, grid_delta, grid_min, grid_max, test_data.grid_delta[0] );
+        Cabana::permute( cell_list, test_data.aosoa );
+
+        copyListToHost( test_data, cell_list );
+
+        checkBins( test_data, cell_list );
+        checkLinkedCell( test_data, 0, test_data.num_p, true );
+    }
+}
+
+template <class ArrayType>
+void testLinkedListArray( ArrayType grid_delta, ArrayType grid_min,
+                          ArrayType grid_max )
+{
+    LCLTestData<3> test_data;
+    auto pos = Cabana::slice<LCLTestData<3>::Position>( test_data.aosoa );
 
     // Bin and permute the particles in the grid. First do this by only
     // operating on a subset of the particles.
@@ -363,13 +656,14 @@ void testLinkedList()
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedListSlice()
 {
-    LCLTestData test_data;
+    LCLTestData<Dim> test_data;
     auto grid_delta = test_data.grid_delta;
     auto grid_min = test_data.grid_min;
     auto grid_max = test_data.grid_max;
-    auto pos = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
+    auto pos = Cabana::slice<LCLTestData<Dim>::Position>( test_data.aosoa );
 
     // Bin the particles in the grid and permute only the position slice.
     // First do this by only operating on a subset of the particles.
@@ -407,7 +701,8 @@ void testLinkedListSlice()
     }
 }
 
-template <class ListType, class TestListType, class PositionType>
+template <std::size_t Dim, class ListType, class TestListType,
+          class PositionType>
 void checkLinkedCellNeighborInterface( const ListType& nlist,
                                        const TestListType& N2_list_copy,
                                        const std::size_t begin,
@@ -415,15 +710,13 @@ void checkLinkedCellNeighborInterface( const ListType& nlist,
                                        const PositionType positions,
                                        const double cutoff )
 {
-    using memory_space = typename TEST_MEMSPACE::memory_space;
-
     // Purposely using zero-init.
-    Kokkos::View<std::size_t*, memory_space> num_n2_neighbors(
+    Kokkos::View<std::size_t*, TEST_MEMSPACE> num_n2_neighbors(
         "num_n2_neighbors", positions.size() );
     Kokkos::View<std::size_t*, Kokkos::HostSpace> N2_copy_neighbors(
         "num_n2_neighbors", positions.size() );
 
-    Cabana::NeighborDiscriminator<Cabana::FullNeighborTag> _discriminator;
+    Cabana::NeighborDiscriminator<Cabana::SelfNeighborTag> _discriminator;
 
     std::size_t max_n2_neighbors = 0;
     std::size_t sum_n2_neighbors = 0;
@@ -460,13 +753,13 @@ void checkLinkedCellNeighborInterface( const ListType& nlist,
                 std::size_t np = Cabana::NeighborList<ListType>::getNeighbor(
                     nlist, pid, i );
 
-                const double dx = positions( pid, 0 ) - positions( np, 0 );
-                const double dy = positions( pid, 1 ) - positions( np, 1 );
-                const double dz = positions( pid, 2 ) - positions( np, 2 );
-                const double r2 = dx * dx + dy * dy + dz * dz;
-
-                if ( r2 <= c2 &&
-                     _discriminator.isValid( pid, 0, 0, 0, np, 0, 0, 0 ) )
+                double r2 = 0.0;
+                for ( std::size_t d = 0; d < Dim; ++d )
+                {
+                    const double dx = positions( pid, d ) - positions( np, d );
+                    r2 += dx * dx;
+                }
+                if ( r2 <= c2 && _discriminator.isValid( pid, np ) )
                 {
                     if ( nlist.sorted() )
                         Kokkos::atomic_add(
@@ -505,7 +798,8 @@ void checkLinkedCellNeighborInterface( const ListType& nlist,
 //---------------------------------------------------------------------------//
 // linked_list_parallel
 //---------------------------------------------------------------------------//
-template <class ListType, class TestListType, class PositionType>
+template <std::size_t Dim, class ListType, class TestListType,
+          class PositionType>
 void checkLinkedCellNeighborParallel( const ListType& nlist,
                                       const TestListType& N2_list_copy,
                                       const std::size_t begin,
@@ -514,25 +808,26 @@ void checkLinkedCellNeighborParallel( const ListType& nlist,
                                       const double cutoff )
 {
     // Create Kokkos views for the write operation.
-    using memory_space = typename TEST_MEMSPACE::memory_space;
-    Kokkos::View<int*, memory_space> serial_result( "serial_result",
-                                                    positions.size() );
-    Kokkos::View<int*, memory_space> team_result( "team_result",
-                                                  positions.size() );
+    Kokkos::View<int*, TEST_MEMSPACE> serial_result( "serial_result",
+                                                     positions.size() );
+    Kokkos::View<int*, TEST_MEMSPACE> team_result( "team_result",
+                                                   positions.size() );
 
     // Test the list parallel operation by adding a value from each neighbor
     // to the particle (within cutoff) and compare to counts.
     auto c2 = cutoff * cutoff;
 
-    Cabana::NeighborDiscriminator<Cabana::FullNeighborTag> _discriminator;
+    Cabana::NeighborDiscriminator<Cabana::SelfNeighborTag> _discriminator;
 
     auto serial_count_op = KOKKOS_LAMBDA( const int i, const int j )
     {
-        const double dx = positions( i, 0 ) - positions( j, 0 );
-        const double dy = positions( i, 1 ) - positions( j, 1 );
-        const double dz = positions( i, 2 ) - positions( j, 2 );
-        const double r2 = dx * dx + dy * dy + dz * dz;
-        if ( r2 <= c2 && _discriminator.isValid( i, 0, 0, 0, j, 0, 0, 0 ) )
+        double r2 = 0.0;
+        for ( std::size_t d = 0; d < Dim; ++d )
+        {
+            const double dx = positions( i, d ) - positions( j, d );
+            r2 += dx * dx;
+        }
+        if ( r2 <= c2 && _discriminator.isValid( i, j ) )
         {
             if ( nlist.sorted() )
             {
@@ -548,11 +843,13 @@ void checkLinkedCellNeighborParallel( const ListType& nlist,
     };
     auto team_count_op = KOKKOS_LAMBDA( const int i, const int j )
     {
-        const double dx = positions( i, 0 ) - positions( j, 0 );
-        const double dy = positions( i, 1 ) - positions( j, 1 );
-        const double dz = positions( i, 2 ) - positions( j, 2 );
-        const double r2 = dx * dx + dy * dy + dz * dz;
-        if ( r2 <= c2 && _discriminator.isValid( i, 0, 0, 0, j, 0, 0, 0 ) )
+        double r2 = 0.0;
+        for ( std::size_t d = 0; d < Dim; ++d )
+        {
+            const double dx = positions( i, d ) - positions( j, d );
+            r2 += dx * dx;
+        }
+        if ( r2 <= c2 && _discriminator.isValid( i, j ) )
         {
             if ( nlist.sorted() )
             {
@@ -582,7 +879,7 @@ void checkLinkedCellNeighborParallel( const ListType& nlist,
 //---------------------------------------------------------------------------//
 // linked_list_parallel
 //---------------------------------------------------------------------------//
-template <class ListType, class TestListType, class AoSoAType>
+template <std::size_t Dim, class ListType, class TestListType, class AoSoAType>
 void checkLinkedCellNeighborReduce( const ListType& nlist,
                                     const TestListType& N2_list_copy,
                                     const AoSoAType aosoa,
@@ -595,15 +892,17 @@ void checkLinkedCellNeighborReduce( const ListType& nlist,
     // to the particle (within cutoff) and compare to counts.
     auto c2 = cutoff * cutoff;
 
-    Cabana::NeighborDiscriminator<Cabana::FullNeighborTag> _discriminator;
+    Cabana::NeighborDiscriminator<Cabana::SelfNeighborTag> _discriminator;
 
     auto sum_op = KOKKOS_LAMBDA( const int i, const int j, double& sum )
     {
-        const double dx = position( i, 0 ) - position( j, 0 );
-        const double dy = position( i, 1 ) - position( j, 1 );
-        const double dz = position( i, 2 ) - position( j, 2 );
-        const double r2 = dx * dx + dy * dy + dz * dz;
-        if ( r2 <= c2 && _discriminator.isValid( i, 0, 0, 0, j, 0, 0, 0 ) )
+        double r2 = 0.0;
+        for ( std::size_t d = 0; d < Dim; ++d )
+        {
+            const double dx = position( i, d ) - position( j, d );
+            r2 += dx * dx;
+        }
+        if ( r2 <= c2 && _discriminator.isValid( i, j ) )
         {
             if ( nlist.sorted() )
             {
@@ -632,91 +931,90 @@ void checkLinkedCellNeighborReduce( const ListType& nlist,
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedCellNeighborInterface()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto positions = Cabana::slice<0>( test_data.aosoa );
     // Create the linked cell list.
-    double grid_size = test_data.cell_size_ratio * test_data.test_radius;
-    double grid_delta[3] = { grid_size, grid_size, grid_size };
     auto nlist = Cabana::createLinkedCellList(
-        positions, test_data.begin, test_data.end, grid_delta,
+        positions, test_data.begin, test_data.end, test_data.grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );
 
-    checkLinkedCellNeighborInterface( nlist, test_data.N2_list_copy,
-                                      test_data.begin, test_data.end, positions,
-                                      test_data.test_radius );
+    checkLinkedCellNeighborInterface<Dim>( nlist, test_data.N2_list_copy,
+                                           test_data.begin, test_data.end,
+                                           positions, test_data.test_radius );
 
     Cabana::permute( nlist, positions );
 
-    checkLinkedCellNeighborInterface( nlist, test_data.N2_list_copy,
-                                      test_data.begin, test_data.end, positions,
-                                      test_data.test_radius );
+    checkLinkedCellNeighborInterface<Dim>( nlist, test_data.N2_list_copy,
+                                           test_data.begin, test_data.end,
+                                           positions, test_data.test_radius );
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedCellParallel()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto positions = Cabana::slice<0>( test_data.aosoa );
     // Create the linked cell list.
-    double grid_size = test_data.cell_size_ratio * test_data.test_radius;
-    double grid_delta[3] = { grid_size, grid_size, grid_size };
     auto nlist = Cabana::createLinkedCellList(
-        positions, test_data.begin, test_data.end, grid_delta,
+        positions, test_data.begin, test_data.end, test_data.grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );
 
-    checkLinkedCellNeighborParallel( nlist, test_data.N2_list_copy,
-                                     test_data.begin, test_data.end, positions,
-                                     test_data.test_radius );
+    checkLinkedCellNeighborParallel<Dim>( nlist, test_data.N2_list_copy,
+                                          test_data.begin, test_data.end,
+                                          positions, test_data.test_radius );
 
     Cabana::permute( nlist, positions );
 
-    checkLinkedCellNeighborParallel( nlist, test_data.N2_list_copy,
-                                     test_data.begin, test_data.end, positions,
-                                     test_data.test_radius );
+    checkLinkedCellNeighborParallel<Dim>( nlist, test_data.N2_list_copy,
+                                          test_data.begin, test_data.end,
+                                          positions, test_data.test_radius );
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedCellReduce()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto positions = Cabana::slice<0>( test_data.aosoa );
     // Create the linked cell list.
-    double grid_size = test_data.cell_size_ratio * test_data.test_radius;
-    double grid_delta[3] = { grid_size, grid_size, grid_size };
     auto nlist = Cabana::createLinkedCellList(
-        positions, test_data.begin, test_data.end, grid_delta,
+        positions, test_data.begin, test_data.end, test_data.grid_delta,
         test_data.grid_min, test_data.grid_max, test_data.test_radius,
         test_data.cell_size_ratio );
 
-    checkLinkedCellNeighborReduce( nlist, test_data.N2_list_copy,
-                                   test_data.aosoa, test_data.begin,
-                                   test_data.end, test_data.test_radius );
+    checkLinkedCellNeighborReduce<Dim>( nlist, test_data.N2_list_copy,
+                                        test_data.aosoa, test_data.begin,
+                                        test_data.end, test_data.test_radius );
 
     Cabana::permute( nlist, positions );
 
-    checkLinkedCellNeighborReduce( nlist, test_data.N2_list_copy,
-                                   test_data.aosoa, test_data.begin,
-                                   test_data.end, test_data.test_radius );
+    checkLinkedCellNeighborReduce<Dim>( nlist, test_data.N2_list_copy,
+                                        test_data.aosoa, test_data.begin,
+                                        test_data.end, test_data.test_radius );
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testLinkedListView()
 {
-    LCLTestData test_data;
+    LCLTestData<Dim> test_data;
     auto grid_delta = test_data.grid_delta;
     auto grid_min = test_data.grid_min;
     auto grid_max = test_data.grid_max;
-    auto slice = Cabana::slice<LCLTestData::Position>( test_data.aosoa );
+    auto slice = Cabana::slice<LCLTestData<Dim>::Position>( test_data.aosoa );
 
     // Copy manually into a View.
-    Kokkos::View<double**, TEST_MEMSPACE> view( "positions", slice.size(), 3 );
+    Kokkos::View<double* [Dim], TEST_MEMSPACE> view( "positions",
+                                                     slice.size() );
     copySliceToView( view, slice, 0, slice.size() );
 
     // Bin the particles in the grid and permute only the position slice.
@@ -724,7 +1022,7 @@ void testLinkedListView()
     {
         auto begin = test_data.begin;
         auto end = test_data.end;
-        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list(
+        auto cell_list = Cabana::createLinkedCellList(
             view, begin, end, grid_delta, grid_min, grid_max );
         Cabana::permute( cell_list, view );
 
@@ -738,12 +1036,12 @@ void testLinkedListView()
     }
     // Now bin and permute all of the particles.
     {
-        Cabana::LinkedCellList<TEST_MEMSPACE> cell_list( view, grid_delta,
-                                                         grid_min, grid_max );
+        auto cell_list = Cabana::createLinkedCellList( view, grid_delta,
+                                                       grid_min, grid_max );
 
         // Copy manually into a View.
         Kokkos::View<double**, TEST_MEMSPACE> view( "positions", slice.size(),
-                                                    3 );
+                                                    Dim );
         copySliceToView( view, slice, 0, slice.size() );
 
         Cabana::permute( cell_list, view );
@@ -770,21 +1068,59 @@ void testLinkedListView()
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
-//---------------------------------------------------------------------------//
-TEST( LinkedCellList, Stencil ) { testLinkedCellStencil(); }
+TEST( LinkedCellList, Stencil3d ) { testLinkedCellStencil3d(); }
 
-TEST( LinkedCellList, AoSoA ) { testLinkedList(); }
+TEST( LinkedCellList, AoSoA3d ) { testLinkedList<3>(); }
 
-TEST( LinkedCellList, Slice ) { testLinkedListSlice(); }
+TEST( LinkedCellList, Arrays )
+{
+    LCLTestData<3> test_data;
+    double dx = test_data.dx;
+    double min = test_data.x_min;
+    double max = test_data.x_max;
+    {
+        double grid_delta[3] = { dx, dx, dx };
+        double grid_min[3] = { min, min, min };
+        double grid_max[3] = { max, max, max };
+        testLinkedListArray( grid_delta, grid_min, grid_max );
+    }
+    {
+        // With the current variadic template for the Kokkos::Array (deprecated
+        // in 4.4, but breaks compile without deprecated code enabled), nvcc
+        // cannot compile with std::array
+#if !defined( KOKKOS_ENABLE_CUDA ) &&                                          \
+    !defined( KOKKOS_ENABLE_DEPRECATED_CODE_4 )
+        std::array<double, 3> grid_delta = { dx, dx, dx };
+        std::array<double, 3> grid_min = { min, min, min };
+        std::array<double, 3> grid_max = { max, max, max };
+        testLinkedListArray( grid_delta, grid_min, grid_max );
+#endif
+    }
+}
 
-TEST( LinkedCellList, Neighbor ) { testLinkedCellNeighborInterface(); }
+TEST( LinkedCellList, Slice3d ) { testLinkedListSlice<3>(); }
 
-TEST( LinkedCellList, ParallelFor ) { testLinkedCellParallel(); }
+TEST( LinkedCellList, Neighbor3d ) { testLinkedCellNeighborInterface<3>(); }
 
-TEST( LinkedCellList, ParallelReduce ) { testLinkedCellReduce(); }
+TEST( LinkedCellList, ParallelFor3d ) { testLinkedCellParallel<3>(); }
 
-//---------------------------------------------------------------------------//
-TEST( LinkedCellList, linked_list_view_test ) { testLinkedListView(); }
+TEST( LinkedCellList, ParallelReduce3d ) { testLinkedCellReduce<3>(); }
+
+TEST( LinkedCellList, View3d ) { testLinkedListView<3>(); }
+
+TEST( LinkedCellList, Stencil2d ) { testLinkedCellStencil2d(); }
+
+TEST( LinkedCellList, AoSoA2d ) { testLinkedList<2>(); }
+
+TEST( LinkedCellList, Slice2d ) { testLinkedListSlice<2>(); }
+
+TEST( LinkedCellList, Neighbor2d ) { testLinkedCellNeighborInterface<2>(); }
+
+TEST( LinkedCellList, ParallelFor2d ) { testLinkedCellParallel<2>(); }
+
+TEST( LinkedCellList, ParallelReduce2d ) { testLinkedCellReduce<2>(); }
+
+TEST( LinkedCellList, View2d ) { testLinkedListView<2>(); }
 
 //---------------------------------------------------------------------------//
 

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -24,23 +24,23 @@ namespace Test
 {
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag, class BuildTag>
+template <std::size_t Dim, class LayoutTag, class BuildTag>
 void testVerletListFull()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist_full( position, 0, position.size(), test_data.test_radius,
                         test_data.cell_size_ratio, test_data.grid_min,
                         test_data.grid_max );
         // Test default construction.
         Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist;
 
         nlist = nlist_full;
@@ -58,7 +58,7 @@ void testVerletListFull()
     // Check again, building with a large array allocation size
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist_max( position, 0, position.size(), test_data.test_radius,
                        test_data.cell_size_ratio, test_data.grid_min,
                        test_data.grid_max, 100 );
@@ -68,7 +68,7 @@ void testVerletListFull()
     // Check again, building with a small array allocation size (refill)
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist_max2( position, 0, position.size(), test_data.test_radius,
                         test_data.cell_size_ratio, test_data.grid_min,
                         test_data.grid_max, 2 );
@@ -78,17 +78,17 @@ void testVerletListFull()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag, class BuildTag>
+template <std::size_t Dim, class LayoutTag, class BuildTag>
 void testVerletListHalf()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist( position, 0, position.size(), test_data.test_radius,
                    test_data.cell_size_ratio, test_data.grid_min,
                    test_data.grid_max );
@@ -100,7 +100,7 @@ void testVerletListHalf()
     // Check again, building with a large array allocation size
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist_max( position, 0, position.size(), test_data.test_radius,
                        test_data.cell_size_ratio, test_data.grid_min,
                        test_data.grid_max, 100 );
@@ -110,7 +110,7 @@ void testVerletListHalf()
     // Check again, building with a small array allocation size (refill)
     {
         Cabana::VerletList<TEST_MEMSPACE, Cabana::HalfNeighborTag, LayoutTag,
-                           BuildTag>
+                           BuildTag, Dim>
             nlist_max2( position, 0, position.size(), test_data.test_radius,
                         test_data.cell_size_ratio, test_data.grid_min,
                         test_data.grid_max, 2 );
@@ -120,16 +120,16 @@ void testVerletListHalf()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag, class BuildTag>
+template <std::size_t Dim, class LayoutTag, class BuildTag>
 void testVerletListFullPartialRange()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
     Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag, LayoutTag,
-                       BuildTag>
+                       BuildTag, Dim>
         nlist( position, test_data.begin, test_data.end, test_data.test_radius,
                test_data.cell_size_ratio, test_data.grid_min,
                test_data.grid_max );
@@ -141,19 +141,18 @@ void testVerletListFullPartialRange()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag>
+template <std::size_t Dim, class LayoutTag>
 void testNeighborParallelFor()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
-    using ListType = Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag,
-                                        LayoutTag, Cabana::TeamOpTag>;
-    ListType nlist( position, 0, position.size(), test_data.test_radius,
-                    test_data.cell_size_ratio, test_data.grid_min,
-                    test_data.grid_max );
+    auto nlist = Cabana::createVerletList<Cabana::FullNeighborTag, LayoutTag,
+                                          Cabana::TeamOpTag>(
+        position, 0, position.size(), test_data.test_radius,
+        test_data.cell_size_ratio, test_data.grid_min, test_data.grid_max );
 
     checkFirstNeighborParallelForLambda( nlist, test_data.N2_list_copy,
                                          test_data.num_particle );
@@ -176,16 +175,16 @@ void testNeighborParallelFor()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag>
+template <std::size_t Dim, class LayoutTag>
 void testNeighborParallelReduce()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
     using ListType = Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag,
-                                        LayoutTag, Cabana::TeamOpTag>;
+                                        LayoutTag, Cabana::TeamOpTag, Dim>;
     ListType nlist( position, 0, position.size(), test_data.test_radius,
                     test_data.cell_size_ratio, test_data.grid_min,
                     test_data.grid_max );
@@ -254,16 +253,16 @@ void testNonUniformRadius()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag>
+template <std::size_t Dim, class LayoutTag>
 void testModifyNeighbors()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Create the neighbor list.
     using ListType = Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag,
-                                        LayoutTag, Cabana::TeamOpTag>;
+                                        LayoutTag, Cabana::TeamOpTag, Dim>;
     ListType nlist( position, 0, position.size(), test_data.test_radius,
                     test_data.cell_size_ratio, test_data.grid_min,
                     test_data.grid_max );
@@ -293,18 +292,19 @@ void testModifyNeighbors()
 }
 
 //---------------------------------------------------------------------------//
-template <class LayoutTag>
+template <std::size_t Dim, class LayoutTag>
 void testNeighborView()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto slice = Cabana::slice<0>( test_data.aosoa );
 
     // Copy manually into a View.
-    Kokkos::View<double**, TEST_MEMSPACE> view( "positions", slice.size(), 3 );
+    Kokkos::View<double**, TEST_MEMSPACE> view( "positions", slice.size(),
+                                                Dim );
     auto view_copy = KOKKOS_LAMBDA( const int i )
     {
-        for ( std::size_t d = 0; d < 3; ++d )
+        for ( std::size_t d = 0; d < Dim; ++d )
             view( i, d ) = slice( i, d );
     };
     Kokkos::RangePolicy<TEST_EXECSPACE> policy( 0, slice.size() );
@@ -313,10 +313,12 @@ void testNeighborView()
 
     // Create the neighbor list with the View data.
     using ListType = Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag,
-                                        LayoutTag, Cabana::TeamOpTag>;
-    ListType nlist( view, 0, view.extent( 0 ), test_data.test_radius,
-                    test_data.cell_size_ratio, test_data.grid_min,
-                    test_data.grid_max );
+                                        LayoutTag, Cabana::TeamOpTag, Dim>;
+    ListType nlist( view, test_data.test_radius, test_data.cell_size_ratio,
+                    test_data.grid_min, test_data.grid_max );
+    nlist.build( TEST_EXECSPACE{}, view, 0, slice.size(), test_data.test_radius,
+                 test_data.cell_size_ratio, test_data.grid_min,
+                 test_data.grid_max );
 
     checkFullNeighborList( nlist, test_data.N2_list_copy,
                            test_data.num_particle );
@@ -378,82 +380,121 @@ void testNeighborHistogram()
     }
 }
 
-//---------------------------------------------------------------------------//
-// TESTS
-//---------------------------------------------------------------------------//
-TEST( VerletList, Full )
+template <std::size_t Dim, class ArrayType>
+void testVerletListArrays( ArrayType grid_min, ArrayType grid_max )
 {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListFull<Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
-#endif
-    testVerletListFull<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+    // Create the AoSoA and fill with random particle positions.
+    NeighborListTestData<Dim> test_data;
+    auto position = Cabana::slice<0>( test_data.aosoa );
+    Cabana::VerletList<TEST_MEMSPACE, Cabana::FullNeighborTag,
+                       Cabana::VerletLayout2D, Cabana::TeamOpTag, Dim>
+        nlist( position, 0, position.size(), test_data.test_radius,
+               test_data.cell_size_ratio, grid_min, grid_max );
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListFull<Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
-#endif
-    testVerletListFull<Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+    checkFullNeighborList( nlist, test_data.N2_list_copy,
+                           test_data.num_particle );
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, Half )
+// 3D TESTS
+//---------------------------------------------------------------------------//
+TEST( VerletList, Full3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListHalf<Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+    testVerletListFull<3, Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
 #endif
-    testVerletListHalf<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+    testVerletListFull<3, Cabana::VerletLayout2D, Cabana::TeamOpTag>();
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListHalf<Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+    testVerletListFull<3, Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
 #endif
-    testVerletListHalf<Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+    testVerletListFull<3, Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+}
+
+TEST( VerletList, Arrays3d )
+{
+    NeighborListTestData<3> test_data;
+    double min = test_data.box_min;
+    double max = test_data.box_max;
+    {
+        double grid_min[3] = { min, min, min };
+        double grid_max[3] = { max, max, max };
+        testVerletListArrays<3>( grid_min, grid_max );
+    }
+    {
+        // With the current variadic template for the Kokkos::Array (deprecated
+        // in 4.4, but breaks compile without deprecated code enabled), nvcc
+        // cannot compile with std::array
+#if !defined( KOKKOS_ENABLE_CUDA ) &&                                          \
+    !defined( KOKKOS_ENABLE_DEPRECATED_CODE_4 )
+        std::array<double, 3> grid_min = { min, min, min };
+        std::array<double, 3> grid_max = { max, max, max };
+        testVerletListArrays<3>( grid_min, grid_max );
+#endif
+    }
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, FullRange )
+TEST( VerletList, Half3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListFullPartialRange<Cabana::VerletLayoutCSR,
+    testVerletListHalf<3, Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+#endif
+    testVerletListHalf<3, Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListHalf<3, Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+#endif
+    testVerletListHalf<3, Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, FullRange3d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListFullPartialRange<3, Cabana::VerletLayoutCSR,
                                    Cabana::TeamOpTag>();
 #endif
-    testVerletListFullPartialRange<Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+    testVerletListFullPartialRange<3, Cabana::VerletLayout2D,
+                                   Cabana::TeamOpTag>();
 
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testVerletListFullPartialRange<Cabana::VerletLayoutCSR,
+    testVerletListFullPartialRange<3, Cabana::VerletLayoutCSR,
                                    Cabana::TeamVectorOpTag>();
 #endif
-    testVerletListFullPartialRange<Cabana::VerletLayout2D,
+    testVerletListFullPartialRange<3, Cabana::VerletLayout2D,
                                    Cabana::TeamVectorOpTag>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, ParallelFor )
+TEST( VerletList, ParallelFor3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testNeighborParallelFor<Cabana::VerletLayoutCSR>();
+    testNeighborParallelFor<3, Cabana::VerletLayoutCSR>();
 #endif
-    testNeighborParallelFor<Cabana::VerletLayout2D>();
+    testNeighborParallelFor<3, Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, ParallelReduce )
+TEST( VerletList, ParallelReduce3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testNeighborParallelReduce<Cabana::VerletLayoutCSR>();
+    testNeighborParallelReduce<3, Cabana::VerletLayoutCSR>();
 #endif
-    testNeighborParallelReduce<Cabana::VerletLayout2D>();
+    testNeighborParallelReduce<3, Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, ModifyList )
+TEST( VerletList, ModifyList3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testModifyNeighbors<Cabana::VerletLayoutCSR>();
+    testModifyNeighbors<3, Cabana::VerletLayoutCSR>();
 #endif
-    testModifyNeighbors<Cabana::VerletLayout2D>();
+    testModifyNeighbors<3, Cabana::VerletLayout2D>();
 }
 
 //---------------------------------------------------------------------------//
-TEST( VerletList, NeighborHistogram )
+TEST( VerletList, NeighborHistogram3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET
     testNeighborHistogram<Cabana::VerletLayoutCSR>();
@@ -469,14 +510,122 @@ TEST( VerletList, non_uniform_radius_test )
     testNonUniformRadius<Cabana::VerletLayout2D>();
 }
 
-TEST( VerletList, view_test )
+TEST( VerletList, View3d )
 {
 #ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
-    testNeighborView<Cabana::VerletLayoutCSR>();
+    testNeighborView<3, Cabana::VerletLayoutCSR>();
 #endif
-    testNeighborView<Cabana::VerletLayout2D>();
+    testNeighborView<3, Cabana::VerletLayout2D>();
 }
 
+//---------------------------------------------------------------------------//
+// 2D TESTS
+//---------------------------------------------------------------------------//
+
+TEST( VerletList, Full2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListFull<2, Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+#endif
+    testVerletListFull<2, Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListFull<2, Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+#endif
+    testVerletListFull<2, Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+}
+
+TEST( VerletList, Arrays2d )
+{
+    NeighborListTestData<2> test_data;
+    double min = test_data.box_min;
+    double max = test_data.box_max;
+    {
+        double grid_min[2] = { min, min };
+        double grid_max[2] = { max, max };
+        testVerletListArrays<2>( grid_min, grid_max );
+    }
+    {
+        // With the current variadic template for the Kokkos::Array (deprecated
+        // in 4.4, but breaks compile without deprecated code enabled), nvcc
+        // cannot compile with std::array
+#if !defined( KOKKOS_ENABLE_CUDA ) &&                                          \
+    !defined( KOKKOS_ENABLE_DEPRECATED_CODE_4 )
+        std::array<double, 2> grid_min = { min, min };
+        std::array<double, 2> grid_max = { max, max };
+        testVerletListArrays<2>( grid_min, grid_max );
+#endif
+    }
+}
+
+//---------------------------------------------------------------------------//
+
+TEST( VerletList, Half2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListHalf<2, Cabana::VerletLayoutCSR, Cabana::TeamOpTag>();
+#endif
+    testVerletListHalf<2, Cabana::VerletLayout2D, Cabana::TeamOpTag>();
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListHalf<2, Cabana::VerletLayoutCSR, Cabana::TeamVectorOpTag>();
+#endif
+    testVerletListHalf<2, Cabana::VerletLayout2D, Cabana::TeamVectorOpTag>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, FullRange2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListFullPartialRange<2, Cabana::VerletLayoutCSR,
+                                   Cabana::TeamOpTag>();
+#endif
+    testVerletListFullPartialRange<2, Cabana::VerletLayout2D,
+                                   Cabana::TeamOpTag>();
+
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testVerletListFullPartialRange<2, Cabana::VerletLayoutCSR,
+                                   Cabana::TeamVectorOpTag>();
+#endif
+    testVerletListFullPartialRange<2, Cabana::VerletLayout2D,
+                                   Cabana::TeamVectorOpTag>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, Parallel2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testNeighborParallelFor<2, Cabana::VerletLayoutCSR>();
+#endif
+    testNeighborParallelFor<2, Cabana::VerletLayout2D>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, Reduce2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testNeighborParallelReduce<2, Cabana::VerletLayoutCSR>();
+#endif
+    testNeighborParallelReduce<2, Cabana::VerletLayout2D>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, Modify2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testModifyNeighbors<2, Cabana::VerletLayoutCSR>();
+#endif
+    testModifyNeighbors<2, Cabana::VerletLayout2D>();
+}
+
+//---------------------------------------------------------------------------//
+TEST( VerletList, View2d )
+{
+#ifndef KOKKOS_ENABLE_OPENMPTARGET // FIXME_OPENMPTARGET
+    testNeighborView<2, Cabana::VerletLayoutCSR>();
+#endif
+    testNeighborView<2, Cabana::VerletLayout2D>();
+}
 //---------------------------------------------------------------------------//
 
 } // end namespace Test

--- a/core/unit_test/tstNeighborListArborX.hpp
+++ b/core/unit_test/tstNeighborListArborX.hpp
@@ -23,10 +23,11 @@
 namespace Test
 {
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testArborXListFull()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Check CSR neighbor lists.
@@ -84,10 +85,11 @@ void testArborXListFull()
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testArborXListHalf()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     // Check CSR neighbor lists.
@@ -145,10 +147,11 @@ void testArborXListHalf()
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testArborXListFullPartialRange()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     {
@@ -176,10 +179,11 @@ void testArborXListFullPartialRange()
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testNeighborArborXParallelFor()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     {
@@ -235,10 +239,11 @@ void testNeighborArborXParallelFor()
 }
 
 //---------------------------------------------------------------------------//
+template <std::size_t Dim>
 void testNeighborArborXParallelReduce()
 {
     // Create the AoSoA and fill with random particle positions.
-    NeighborListTestData test_data;
+    NeighborListTestData<Dim> test_data;
     auto position = Cabana::slice<0>( test_data.aosoa );
 
     {
@@ -290,19 +295,19 @@ void testNeighborArborXParallelReduce()
 //---------------------------------------------------------------------------//
 // TESTS
 //---------------------------------------------------------------------------//
-TEST( ArborXList, Full ) { testArborXListFull(); }
+TEST( ArborXList, Full3d ) { testArborXListFull<3>(); }
 
 //---------------------------------------------------------------------------//
-TEST( ArborXList, Half ) { testArborXListHalf(); }
+TEST( ArborXList, Half3d ) { testArborXListHalf<3>(); }
 
 //---------------------------------------------------------------------------//
-TEST( ArborXList, FullRange ) { testArborXListFullPartialRange(); }
+TEST( ArborXList, FullRange3d ) { testArborXListFullPartialRange<3>(); }
 
 //---------------------------------------------------------------------------//
-TEST( ArborXList, ParallelFor ) { testNeighborArborXParallelFor(); }
+TEST( ArborXList, ParallelFor3d ) { testNeighborArborXParallelFor<3>(); }
 
 //---------------------------------------------------------------------------//
-TEST( ArborXList, ParallelReduce ) { testNeighborArborXParallelReduce(); }
+TEST( ArborXList, ParallelReduce3d ) { testNeighborArborXParallelReduce<3>(); }
 //---------------------------------------------------------------------------//
 
 } // end namespace Test

--- a/example/core_tutorial/08_linked_cell_list/linked_cell_list_example.cpp
+++ b/example/core_tutorial/08_linked_cell_list/linked_cell_list_example.cpp
@@ -105,11 +105,11 @@ void linkedCellListExample()
       exercise, try adding both start and end (int) inputs to define a subset
       range of particles to permute:
 
-      auto cell_list = Cabana::createLinkedCellList<MemorySpace>(
+      auto cell_list = Cabana::createLinkedCellList(
           positions, start, end, grid_delta, grid_min, grid_max );
      */
-    auto cell_list = Cabana::createLinkedCellList<MemorySpace>(
-        positions, grid_delta, grid_min, grid_max );
+    auto cell_list = Cabana::createLinkedCellList( positions, grid_delta,
+                                                   grid_min, grid_max );
 
     /*
       Now permute the AoSoA (i.e. reorder the data) using the linked cell list.


### PR DESCRIPTION
Enable 2d neighbor construction and iteration. Dimension extracted from particle data in creation functions with default 3d template dimension in classes for backwards compatibility

Other notes:
- ArborX does not support 2d as far as I can tell
- New VerletList creation functions
- Adds new discriminator for LinkedCellList 

Closes #490 