### PR TITLE
Use ArborX v1.7 in CI until we move to v2.0

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: arborx/ArborX
-          ref: master
+          ref: v1.7
           path: arborx
       - name: Build arborx
         working-directory: arborx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: arborx/ArborX
-          ref: master
+          ref: v1.7
           path: arborx
       - name: Checkout heffte
         # actions/checkout doesn't work for external repos yet


### PR DESCRIPTION
2.0 breaks backwards compatibility 