### PR TITLE
Add Splines of order 4 - 6

### DIFF
--- a/grid/src/Cabana_Grid_Splines.hpp
+++ b/grid/src/Cabana_Grid_Splines.hpp
@@ -528,33 +528,29 @@ struct Spline<4>
         Scalar denom_0 = denom_2 * 2.0;
 
         // Knot at i - 2
-        Scalar xn = x0 - static_cast<int>( x0 );
-        xn -= 0.5;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        Scalar xn4 = xn2 * xn2;
         values[0] =
-            ( 1.0 +
-              xn * ( -8.0 + xn * ( 24.0 + xn * ( -32.0 + xn * ( 16.0 ) ) ) ) ) *
+            ( 16.0 * xn4 - 32.0 * xn * xn2 + 24.0 * xn2 - 8.0 * xn + 1.0 ) *
             denom_2;
 
         // Knot at i - 1
         values[1] =
-            ( 19.0 + xn * ( -44.0 +
-                            xn * ( 24.0 + xn * ( 16.0 + xn * ( -16.0 ) ) ) ) ) *
+            ( -16.0 * xn4 + 16.0 * xn * xn2 + 24.0 * xn2 - 44.0 * xn + 19.0 ) *
             denom_1;
 
         // Knot at i
-        values[2] =
-            ( 115.0 + xn * xn * ( -120.0 + xn * xn * ( 48.0 ) ) ) * denom_0;
+        values[2] = ( 48.0 * xn4 - 120.0 * xn2 + 115.0 ) * denom_0;
 
         // Knot at i + 1
         values[3] =
-            ( 19.0 + xn * ( 44.0 + xn * ( 24.0 + xn * ( -16.0 +
-                                                        xn * ( -16.0 ) ) ) ) ) *
+            ( -16.0 * xn4 - 16.0 * xn * xn2 + 24.0 * xn2 + 44.0 * xn + 19.0 ) *
             denom_1;
 
         // Knot at i + 2
         values[4] =
-            ( 1.0 +
-              xn * ( 8.0 + xn * ( 24.0 + xn * ( 32.0 + xn * ( 16.0 ) ) ) ) ) *
+            ( 16.0 * xn4 + 32.0 * xn * xn2 + 24.0 * xn2 + 8.0 * xn + 1 ) *
             denom_2;
     }
 
@@ -577,27 +573,25 @@ struct Spline<4>
         Scalar denom_0 = denom_2 * 12.0;
 
         // Knot at i - 2
-        Scalar xn = x0 - static_cast<int>( x0 ); // - 1.5;
-        xn -= 0.5;
-        gradients[0] = ( -1.0 + xn * ( 6.0 + xn * ( -12.0 + xn * ( 8.0 ) ) ) ) *
-                       denom_2 * rdx;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        gradients[0] =
+            ( 8.0 * xn * xn2 - 12.0 * xn2 + 6.0 * xn - 1.0 ) * denom_2 * rdx;
 
         // Knot at i - 1
-        gradients[1] =
-            ( -11.0 + xn * ( 12.0 + xn * ( 12.0 + xn * ( -16.0 ) ) ) ) *
-            denom_1 * rdx;
+        gradients[1] = ( -16.0 * xn * xn2 + 12.0 * xn2 + 12.0 * xn - 11.0 ) *
+                       denom_1 * rdx;
 
         // Knot at i
-        gradients[2] = ( xn * ( -5.0 + xn * xn * ( 4.0 ) ) ) * denom_0 * rdx;
+        gradients[2] = ( 4.0 * xn * xn2 - 5.0 * xn ) * denom_0 * rdx;
 
         // Knot at i + 1
-        gradients[3] =
-            ( 11.0 + xn * ( 12.0 + xn * ( -12.0 + xn * ( -16.0 ) ) ) ) *
-            denom_1 * rdx;
+        gradients[3] = ( -16.0 * xn * xn2 - 12.0 * xn2 + 12.0 * xn + 11.0 ) *
+                       denom_1 * rdx;
 
         // Knot at i + 2
-        gradients[4] = ( 1.0 + xn * ( 6.0 + xn * ( 12.0 + xn * ( 8.0 ) ) ) ) *
-                       denom_2 * rdx;
+        gradients[4] =
+            ( 8.0 * xn * xn2 + 12.0 * xn2 + 6.0 * xn + 1.0 ) * denom_2 * rdx;
     }
 };
 
@@ -679,59 +673,37 @@ struct Spline<5>
         Scalar denom_1 = denom_2 * 2.0;
 
         // Knot at i - 2
-        Scalar xn = x0 - static_cast<int>( x0 );
-        xn -= 0.5;
-        values[0] =
-            ( 1.0 +
-              xn * ( -10.0 +
-                     xn * ( 40.0 +
-                            xn * ( -80.0 +
-                                   xn * ( 80.0 + xn * ( -32.0 ) ) ) ) ) ) *
-            denom_2;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        Scalar xn4 = xn2 * xn2;
+        values[0] = ( -32.0 * xn * xn4 + 80.0 * xn4 - 80.0 * xn * xn2 +
+                      40.0 * xn2 - 10.0 * xn + 1.0 ) *
+                    denom_2;
 
         // Knot at i - 1
-        values[1] =
-            ( 237.0 +
-              xn * ( -750.0 +
-                     xn * ( 840.0 +
-                            xn * ( -240.0 +
-                                   xn * ( -240.0 + xn * ( 160.0 ) ) ) ) ) ) *
-            denom_2;
+        values[1] = ( 160.0 * xn * xn4 - 240.0 * xn4 - 240.0 * xn * xn2 +
+                      840.0 * xn2 - 750.0 * xn + 237.0 ) *
+                    denom_2;
 
         // Knot at i
-        values[2] =
-            ( 841.0 +
-              xn * ( -770.0 +
-                     xn * ( -440.0 +
-                            xn * ( 560.0 +
-                                   xn * ( 80.0 + xn * ( -160.0 ) ) ) ) ) ) *
-            denom_1;
+        values[2] = ( -160.0 * xn * xn4 + 80.0 * xn4 + 560.0 * xn * xn2 -
+                      440.0 * xn2 - 770.0 * xn + 841.0 ) *
+                    denom_1;
 
         // Knot at i + 1
-        values[3] =
-            ( 841.0 +
-              xn * ( 770.0 +
-                     xn * ( -440.0 +
-                            xn * ( -560.0 +
-                                   xn * ( 80.0 + xn * ( 160.0 ) ) ) ) ) ) *
-            denom_1;
+        values[3] = ( 160.0 * xn * xn4 + 80.0 * xn4 - 560.0 * xn * xn2 -
+                      440.0 * xn2 + 770.0 * xn + 841.0 ) *
+                    denom_1;
 
         // Knot at i + 2
-        values[4] =
-            ( 237.0 +
-              xn * ( 750.0 +
-                     xn * ( 840.0 +
-                            xn * ( 240.0 +
-                                   xn * ( -240.0 + xn * ( -160.0 ) ) ) ) ) ) *
-            denom_2;
+        values[4] = ( -160.0 * xn * xn4 - 240.0 * xn4 + 240.0 * xn * xn2 +
+                      840.0 * xn2 + 750.0 * xn + 237.0 ) *
+                    denom_2;
 
         // Knot at i + 3
-        values[5] =
-            ( 1.0 + xn * ( 10.0 +
-                           xn * ( 40.0 +
-                                  xn * ( 80.0 +
-                                         xn * ( 80.0 + xn * ( 32.0 ) ) ) ) ) ) *
-            denom_2;
+        values[5] = ( 32.0 * xn * xn4 + 80.0 * xn4 + 80.0 * xn * xn2 +
+                      40.0 * xn2 + 10.0 * xn + 1.0 ) *
+                    denom_2;
     }
 
     /*!
@@ -752,44 +724,36 @@ struct Spline<5>
         Scalar denom_1 = denom_2 * 2.0;
 
         // Knot at i - 2
-        Scalar xn = x0 - static_cast<int>( x0 );
-        xn -= 0.5;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        Scalar xn4 = xn2 * xn2;
         gradients[0] =
-            ( -1.0 +
-              xn * ( 8.0 + xn * ( -24.0 + xn * ( 32.0 + xn * ( -16.0 ) ) ) ) ) *
+            ( -16.0 * xn4 + 32.0 * xn * xn2 - 24.0 * xn2 + 8.0 * xn - 1.0 ) *
             denom_2 * rdx;
 
         // Knot at i - 1
         gradients[1] =
-            ( -75.0 +
-              xn * ( 168.0 +
-                     xn * ( -72.0 + xn * ( -96.0 + xn * ( 80.0 ) ) ) ) ) *
+            ( 80.0 * xn4 - 96.0 * xn * xn2 - 72.0 * xn2 + 168.0 * xn - 75.0 ) *
             denom_2 * rdx;
 
         // Knot at i
         gradients[2] =
-            ( -77.0 +
-              xn * ( -88.0 +
-                     xn * ( 168.0 + xn * ( 32.0 + xn * ( -80.0 ) ) ) ) ) *
+            ( -80.0 * xn4 + 32.0 * xn * xn2 + 168.0 * xn2 - 88.0 * xn - 77.0 ) *
             denom_1 * rdx;
 
         // Knot at i + 1
         gradients[3] =
-            ( 77.0 + xn * ( -88.0 + xn * ( -168.0 +
-                                           xn * ( 32.0 + xn * ( 80.0 ) ) ) ) ) *
+            ( 80.0 * xn4 + 32.0 * xn * xn2 - 168.0 * xn2 - 88.0 * xn + 77.0 ) *
             denom_1 * rdx;
 
         // Knot at i + 2
         gradients[4] =
-            ( 75.0 +
-              xn * ( 168.0 +
-                     xn * ( 72.0 + xn * ( -96.0 + xn * ( -80.0 ) ) ) ) ) *
+            ( -80.0 * xn4 - 96.0 * xn * xn2 + 72.0 * xn2 + 168.0 * xn + 75.0 ) *
             denom_2 * rdx;
 
         // Knot at i + 3
         gradients[5] =
-            ( 1.0 +
-              xn * ( 8.0 + xn * ( 24.0 + xn * ( 32.0 + xn * ( 16.0 ) ) ) ) ) *
+            ( 16.0 * xn4 + 32.0 * xn * xn2 + 24.0 * xn2 + 8.0 * xn + 1.0 ) *
             denom_2 * rdx;
     }
 };
@@ -875,79 +839,44 @@ struct Spline<6>
         Scalar denom_0 = denom_2 * 2.0;
 
         // Knot at i - 3
-        Scalar xn = x0 - static_cast<int>( x0 );
-        xn -= 0.5;
-        values[0] =
-            ( 1.0 +
-              xn * ( -12.0 +
-                     xn * ( 60.0 +
-                            xn * ( -160.0 +
-                                   xn * ( 240.0 +
-                                          xn * ( -192.0 +
-                                                 xn * ( 64.0 ) ) ) ) ) ) ) *
-            denom_31;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        Scalar xn4 = xn2 * xn2;
+        Scalar xn6 = xn2 * xn4;
+        values[0] = ( 64.0 * xn6 - 192.0 * xn * xn4 + 240.0 * xn4 -
+                      160.0 * xn * xn2 + 60.0 * xn2 - 12.0 * xn + 1.0 ) *
+                    denom_31;
 
         // Knot at i - 2
-        values[1] =
-            ( 361.0 +
-              xn * ( -1416.0 +
-                     xn * ( 2220.0 +
-                            xn * ( -1600.0 +
-                                   xn * ( 240.0 +
-                                          xn * ( 384.0 +
-                                                 xn * ( -192.0 ) ) ) ) ) ) ) *
-            denom_2;
+        values[1] = ( -192.0 * xn6 + 384.0 * xn * xn4 + 240.0 * xn4 -
+                      1600.0 * xn * xn2 + 2220.0 * xn2 - 1416.0 * xn + 361.0 ) *
+                    denom_2;
 
         // Knot at i - 1
         values[2] =
-            ( 10543.0 +
-              xn * ( -17340.0 +
-                     xn * ( 4740.0 +
-                            xn * ( 6880.0 +
-                                   xn * ( -4080.0 +
-                                          xn * ( -960.0 +
-                                                 xn * ( 960.0 ) ) ) ) ) ) ) *
+            ( 960.0 * xn6 - 960.0 * xn * xn4 - 4080.0 * xn4 +
+              6880.0 * xn * xn2 + 4740.0 * xn2 - 17340.0 * xn + 10543.0 ) *
             denom_31;
 
         // Knot at i
         values[3] =
-            ( 5887.0 +
-              xn * xn *
-                  ( -4620.0 + xn * xn * ( 1680.0 + xn * xn * ( -320.0 ) ) ) ) *
-            denom_0;
+            ( -320.0 * xn6 + 1680.0 * xn4 - 4620.0 * xn2 + 5887.0 ) * denom_0;
 
         // Knot at i + 1
         values[4] =
-            ( 10543.0 +
-              xn * ( 17340.0 +
-                     xn * ( 4740.0 +
-                            xn * ( -6880.0 +
-                                   xn * ( -4080.0 +
-                                          xn * ( 960.0 +
-                                                 xn * ( 960.0 ) ) ) ) ) ) ) *
+            ( 960.0 * xn6 + 960.0 * xn * xn4 - 4080.0 * xn4 -
+              6880.0 * xn * xn2 + 4740.0 * xn2 + 17340.0 * xn + 10543.0 ) *
             denom_31;
 
         // Knot at i + 2
-        values[5] =
-            ( 361.0 +
-              xn * ( 1416.0 +
-                     xn * ( 2220.0 +
-                            xn * ( 1600.0 +
-                                   xn * ( 240.0 +
-                                          xn * ( -384.0 +
-                                                 xn * ( -192.0 ) ) ) ) ) ) ) *
-            denom_2;
+        values[5] = ( -192.0 * xn6 - 384.0 * xn * xn4 + 240.0 * xn4 +
+                      1600.0 * xn * xn2 + 2220.0 * xn2 + 1416.0 * xn + 361.0 ) *
+                    denom_2;
 
         // Knot at i + 3
-        values[6] =
-            ( 1.0 +
-              xn * ( 12.0 +
-                     xn * ( 60.0 +
-                            xn * ( 160.0 +
-                                   xn * ( 240.0 +
-                                          xn * ( 192.0 +
-                                                 xn * ( 64.0 ) ) ) ) ) ) ) *
-            denom_31;
+        values[6] = ( 64.0 * xn6 + 192.0 * xn * xn4 + 240.0 * xn4 +
+                      160.0 * xn * xn2 + 60.0 * xn2 + 12.0 * xn + 1.0 ) *
+                    denom_31;
     }
 
     /*!
@@ -970,64 +899,41 @@ struct Spline<6>
         Scalar denom_0 = denom_3 * 40.0;
 
         // Knot at i - 2
-        Scalar xn = x0 - static_cast<int>( x0 );
-        xn -= 0.5;
-        gradients[0] =
-            ( -1.0 +
-              xn * ( 10.0 +
-                     xn * ( -40.0 +
-                            xn * ( 80.0 +
-                                   xn * ( -80.0 + xn * ( 32.0 ) ) ) ) ) ) *
-            denom_3 * rdx;
+        Scalar xn = x0 - static_cast<int>( x0 ) - 0.5;
+        Scalar xn2 = xn * xn;
+        Scalar xn4 = xn2 * xn2;
+        gradients[0] = ( 32.0 * xn * xn4 - 80.0 * xn4 + 80.0 * xn * xn2 -
+                         40.0 * xn2 + 10.0 * xn - 1.0 ) *
+                       denom_3 * rdx;
 
         // Knot at i - 2
-        gradients[1] =
-            ( -59.0 +
-              xn * ( 185.0 +
-                     xn * ( -200.0 +
-                            xn * ( 40.0 +
-                                   xn * ( 80.0 + xn * ( -48.0 ) ) ) ) ) ) *
-            denom_2 * rdx;
+        gradients[1] = ( -48.0 * xn * xn4 + 80.0 * xn4 + 40.0 * xn * xn2 -
+                         200.0 * xn2 + 185.0 * xn - 59.0 ) *
+                       denom_2 * rdx;
 
         // Knot at i - 1
-        gradients[2] =
-            ( -289.0 +
-              xn * ( 158.0 +
-                     xn * ( 344.0 +
-                            xn * ( -272.0 +
-                                   xn * ( -80.0 + xn * ( 96.0 ) ) ) ) ) ) *
-            denom_1 * rdx;
+        gradients[2] = ( 96.0 * xn * xn4 - 80.0 * xn4 - 272.0 * xn * xn2 +
+                         344.0 * xn2 + 158.0 * xn - 289.0 ) *
+                       denom_1 * rdx;
 
         // Knot at i
         gradients[3] =
-            ( xn * ( -77.0 + xn * xn * ( 56.0 + xn * xn * ( -16.0 ) ) ) ) *
-            denom_0 * rdx;
+            ( -16.0 * xn * xn4 + 56.0 * xn * xn2 - 77.0 * xn ) * denom_0 * rdx;
 
         // Knot at i + 1
-        gradients[4] =
-            ( 289.0 +
-              xn * ( 158.0 +
-                     xn * ( -344.0 +
-                            xn * ( -272.0 +
-                                   xn * ( 80.0 + xn * ( 96.0 ) ) ) ) ) ) *
-            denom_1 * rdx;
+        gradients[4] = ( 96.0 * xn * xn4 + 80.0 * xn4 - 272.0 * xn * xn2 -
+                         344.0 * xn2 + 158.0 * xn + 289.0 ) *
+                       denom_1 * rdx;
 
         // Knot at i + 2
-        gradients[5] =
-            ( 59.0 +
-              xn * ( 185.0 +
-                     xn * ( 200.0 +
-                            xn * ( 40.0 +
-                                   xn * ( -80.0 + xn * ( -48.0 ) ) ) ) ) ) *
-            denom_2 * rdx;
+        gradients[5] = ( -48.0 * xn * xn4 - 80.0 * xn4 + 40.0 * xn * xn2 +
+                         200.0 * xn2 + 185.0 * xn + 59.0 ) *
+                       denom_2 * rdx;
 
         // Knot at i + 3
-        gradients[6] =
-            ( 1.0 + xn * ( 10.0 +
-                           xn * ( 40.0 +
-                                  xn * ( 80.0 +
-                                         xn * ( 80.0 + xn * ( 32.0 ) ) ) ) ) ) *
-            denom_3 * rdx;
+        gradients[6] = ( 32.0 * xn * xn4 + 80.0 * xn4 + 80.0 * xn * xn2 +
+                         40.0 * xn2 + 10.0 * xn + 1.0 ) *
+                       denom_3 * rdx;
     }
 };
 

--- a/grid/unit_test/tstSplines.hpp
+++ b/grid/unit_test/tstSplines.hpp
@@ -281,4 +281,240 @@ TEST( Splines, Cubic )
     EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
 }
 
+TEST( Splines, Quartic )
+{
+    // Check partition of unity for the quartic spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[5];
+
+    double x0 = Spline<4>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<4>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<4>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<4>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<4>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<4>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a primal cell.
+    int node_id = 4;
+    xp = low_x + ( node_id + 0.25 ) * dx;
+    x0 = Spline<4>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[5];
+    Spline<4>::offsets( offsets );
+    EXPECT_EQ( int( x0 ) + offsets[0], node_id - 2 );
+    EXPECT_EQ( int( x0 ) + offsets[1], node_id - 1 );
+    EXPECT_EQ( int( x0 ) + offsets[2], node_id );
+    EXPECT_EQ( int( x0 ) + offsets[3], node_id + 1 );
+    EXPECT_EQ( int( x0 ) + offsets[4], node_id + 2 );
+
+    int stencil[5];
+    Spline<4>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], node_id - 2 );
+    EXPECT_EQ( stencil[1], node_id - 1 );
+    EXPECT_EQ( stencil[2], node_id );
+    EXPECT_EQ( stencil[3], node_id + 1 );
+    EXPECT_EQ( stencil[4], node_id + 2 );
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ) { return 4.32 * x - 0.31; };
+    double field[Spline<4>::num_knot];
+    field[0] = grid_func( low_x + ( node_id - 2 ) * dx );
+    field[1] = grid_func( low_x + ( node_id - 1 ) * dx );
+    field[2] = grid_func( low_x + node_id * dx );
+    field[3] = grid_func( low_x + ( node_id + 1 ) * dx );
+    field[4] = grid_func( low_x + ( node_id + 2 ) * dx );
+    Spline<4>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2] + field[3] * values[3] +
+                      field[4] * values[4];
+    EXPECT_FLOAT_EQ( field_xp, grid_func( xp ) );
+
+    // Check the derivative of a function.
+    Spline<4>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1] +
+                        field[2] * values[2] + field[3] * values[3] +
+                        field[4] * values[4];
+    auto grid_deriv = [=]( const double ) { return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
+}
+
+TEST( Splines, Quintic )
+{
+    // Check partition of unity for the quintic spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[6];
+
+    double x0 = Spline<5>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<5>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<5>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<5>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<5>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<5>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a primal cell.
+    int cell_id = 4;
+    xp = low_x + ( cell_id + 0.75 ) * dx;
+    x0 = Spline<5>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[6];
+    Spline<5>::offsets( offsets );
+    EXPECT_EQ( int( x0 ) + offsets[0], cell_id - 2 );
+    EXPECT_EQ( int( x0 ) + offsets[1], cell_id - 1 );
+    EXPECT_EQ( int( x0 ) + offsets[2], cell_id );
+    EXPECT_EQ( int( x0 ) + offsets[3], cell_id + 1 );
+    EXPECT_EQ( int( x0 ) + offsets[4], cell_id + 2 );
+    EXPECT_EQ( int( x0 ) + offsets[5], cell_id + 3 );
+
+    int stencil[6];
+    Spline<5>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], cell_id - 2 );
+    EXPECT_EQ( stencil[1], cell_id - 1 );
+    EXPECT_EQ( stencil[2], cell_id );
+    EXPECT_EQ( stencil[3], cell_id + 1 );
+    EXPECT_EQ( stencil[4], cell_id + 2 );
+    EXPECT_EQ( stencil[5], cell_id + 3 );
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ) { return 4.32 * x - 0.31; };
+    double field[Spline<5>::num_knot];
+    field[0] = grid_func( low_x + ( cell_id - 2 ) * dx );
+    field[1] = grid_func( low_x + ( cell_id - 1 ) * dx );
+    field[2] = grid_func( low_x + cell_id * dx );
+    field[3] = grid_func( low_x + ( cell_id + 1 ) * dx );
+    field[4] = grid_func( low_x + ( cell_id + 2 ) * dx );
+    field[5] = grid_func( low_x + ( cell_id + 3 ) * dx );
+    Spline<5>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2] + field[3] * values[3] +
+                      field[4] * values[4] + field[5] * values[5];
+    EXPECT_FLOAT_EQ( field_xp, grid_func( xp ) );
+
+    // Check the derivative of a function.
+    Spline<5>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1] +
+                        field[2] * values[2] + field[3] * values[3] +
+                        field[4] * values[4] + field[5] * values[5];
+    auto grid_deriv = [=]( const double ) { return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
+}
+
+TEST( Splines, Sextic )
+{
+    // Check partition of unity for the sextic spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[7];
+
+    double x0 = Spline<6>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<6>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<6>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<6>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<6>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<6>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values )
+        sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a primal cell.
+    int node_id = 4;
+    xp = low_x + ( node_id + 0.25 ) * dx;
+    x0 = Spline<6>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[7];
+    Spline<6>::offsets( offsets );
+    EXPECT_EQ( int( x0 ) + offsets[0], node_id - 3 );
+    EXPECT_EQ( int( x0 ) + offsets[1], node_id - 2 );
+    EXPECT_EQ( int( x0 ) + offsets[2], node_id - 1 );
+    EXPECT_EQ( int( x0 ) + offsets[3], node_id );
+    EXPECT_EQ( int( x0 ) + offsets[4], node_id + 1 );
+    EXPECT_EQ( int( x0 ) + offsets[5], node_id + 2 );
+    EXPECT_EQ( int( x0 ) + offsets[6], node_id + 3 );
+
+    int stencil[7];
+    Spline<6>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], node_id - 3 );
+    EXPECT_EQ( stencil[1], node_id - 2 );
+    EXPECT_EQ( stencil[2], node_id - 1 );
+    EXPECT_EQ( stencil[3], node_id );
+    EXPECT_EQ( stencil[4], node_id + 1 );
+    EXPECT_EQ( stencil[5], node_id + 2 );
+    EXPECT_EQ( stencil[6], node_id + 3 );
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ) { return 4.32 * x - 0.31; };
+    double field[Spline<6>::num_knot];
+    field[0] = grid_func( low_x + ( node_id - 3 ) * dx );
+    field[1] = grid_func( low_x + ( node_id - 2 ) * dx );
+    field[2] = grid_func( low_x + ( node_id - 1 ) * dx );
+    field[3] = grid_func( low_x + node_id * dx );
+    field[4] = grid_func( low_x + ( node_id + 1 ) * dx );
+    field[5] = grid_func( low_x + ( node_id + 2 ) * dx );
+    field[6] = grid_func( low_x + ( node_id + 3 ) * dx );
+    Spline<6>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2] + field[3] * values[3] +
+                      field[4] * values[4] + field[5] * values[5] +
+                      field[6] * values[6];
+    EXPECT_FLOAT_EQ( field_xp, grid_func( xp ) );
+
+    // Check the derivative of a function.
+    Spline<6>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1] +
+                        field[2] * values[2] + field[3] * values[3] +
+                        field[4] * values[4] + field[5] * values[5] +
+                        field[6] * values[6];
+    auto grid_deriv = [=]( const double ) { return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv( xp ) );
+}
+
 } // end namespace Test


### PR DESCRIPTION
This commits add BSplines of order 4 to 7 following the polynomial definitions on deserno1998 [1]

Following @streeve request,  PR #799  is now split into two PRs and once merged, this one will only show diff changes related to Splines.

This changes were done in cooperation with @rhalver 

[1] Markus Deserno, Christian Holm; How to mesh up Ewald sums. I. A theoretical and numerical comparison of various particle mesh routines. J. Chem. Phys. 8 November 1998; 109 (18): 7678–7693. https://doi.org/10.1063/1.477414