### PR TITLE
Run CI with fedora latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,8 +93,7 @@ jobs:
             heffte: 'MKL'
             hypre: 'OFF'
             coverage: 'OFF'
-          # FIXME: use fedora:latest when MPI timeouts are fixed
-          - distro: 'fedora:rawhide'
+          - distro: 'fedora:latest'
             cxx: 'g++'
             backend: 'OPENMP'
             cmake_build_type: 'Release'
@@ -104,8 +103,7 @@ jobs:
             hypre: 'OFF'
             coverage: 'OFF'
             doxygen: 'ON'
-          # FIXME: use fedora:latest when MPI timeouts are fixed
-          - distro: 'fedora:rawhide'
+          - distro: 'fedora:latest'
             cxx: 'clang++'
             backend: 'OPENMP'
             cmake_build_type: 'Release'

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ecp-copa/ci-containers/fedora:rawhide 
+FROM ghcr.io/ecp-copa/ci-containers/fedora:latest
 
 WORKDIR /home/kokkos/src/
 COPY kokkos/ /home/kokkos/src/kokkos


### PR DESCRIPTION
Previous issues with MPI prompted move to rawhide; issues noted in #803 with gtest caused unrelated failures