### PR TITLE
Guarantee reciprocal neighbors

### DIFF
--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -348,9 +348,11 @@ struct VerletListBuilder
                             {
                                 // See if we should actually check this box for
                                 // neighbors.
-                                if ( linked_cell_list.cellStencil()
-                                         .grid.minDistanceToPoint(
-                                             x_p, y_p, z_p, i, j, k ) <= rsqr )
+                                if ( withinCutoff(
+                                         pid,
+                                         linked_cell_list.cellStencil()
+                                             .grid.minDistanceToPoint(
+                                                 x_p, y_p, z_p, i, j, k ) ) )
                                 {
                                     std::size_t n_offset =
                                         linked_cell_list.binOffset( i, j, k );
@@ -564,9 +566,11 @@ struct VerletListBuilder
                             {
                                 // See if we should actually check this box for
                                 // neighbors.
-                                if ( linked_cell_list.cellStencil()
-                                         .grid.minDistanceToPoint(
-                                             x_p, y_p, z_p, i, j, k ) <= rsqr )
+                                if ( withinCutoff(
+                                         pid,
+                                         linked_cell_list.cellStencil()
+                                             .grid.minDistanceToPoint(
+                                                 x_p, y_p, z_p, i, j, k ) ) )
                                 {
                                     // Check the particles in this bin to see if
                                     // they are neighbors.

--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -254,7 +254,7 @@ struct VerletListBuilder
     // should add instead for symmetry.
     KOKKOS_INLINE_FUNCTION auto
     neighborNotWithinCutoff( [[maybe_unused]] const int j,
-                             const double dist_sqr ) const
+                             [[maybe_unused]] const double dist_sqr ) const
     {
         // This neighbor needs to be added if they will not find this particle.
         if constexpr ( is_slice<RadiusType>::value ||

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -214,7 +214,7 @@ void testNonUniformRadius()
     // Create the AoSoA and fill custom particle details.
     std::size_t particle_x = 2;
     // Purposely choose radius to reach all particles.
-    double large_radius = 4.35;
+    double large_radius = 4.05;
     // Purposely choose radius to reach nearest neighbors only.
     double small_radius = 3.32;
     // Create the AoSoA and fill with particles

--- a/core/unit_test/tstNeighborList.hpp
+++ b/core/unit_test/tstNeighborList.hpp
@@ -249,7 +249,7 @@ void testNonUniformRadius()
         if ( p == 0 || p == test_data.num_particle - 1 )
             EXPECT_EQ( list_copy.counts( p ), 6 );
         else
-            EXPECT_EQ( list_copy.counts( p ), 3 );
+            EXPECT_EQ( list_copy.counts( p ), 4 );
     }
 }
 


### PR DESCRIPTION
In cases where non-uniform cutoff radii are used. This now ensures that if `i` neighbors `j`, `j` also neighbors `i`. Follow up to #757 

Test updated to reflect this reciprocity