### PR TITLE
Fix CMake target name clash

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -437,6 +437,7 @@ jobs:
             -DCabana_ENABLE_TESTING=ON \
             -DCabana_ENABLE_EXAMPLES=ON \
             -DCabana_ENABLE_PERFORMANCE_TESTING=ON \
+            -DCabana_ENABLE_DOXYGEN="$([[ -n "${{ matrix.doxygen }}" ]] && echo "${{ matrix.doxygen }}" || echo "OFF")" \
             -DCabana_PERFORMANCE_EXPECTED_FLOPS=0 \
             -DCabana_ENABLE_COVERAGE_BUILD=${{ matrix.coverage }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,8 +241,10 @@ if(Cabana_ENABLE_TESTING)
 endif()
 
 # enable doxygen
-find_package(Doxygen)
-if(Doxygen_FOUND)
+option(Cabana_ENABLE_DOXYGEN "Build documentation" OFF)
+add_feature_info(Documentation Cabana_ENABLE_DOXYGEN "Build documentation (requires Doxygen)")
+if(Cabana_ENABLE_DOXYGEN)
+  find_package(Doxygen REQUIRED)
   doxygen_add_docs(doxygen core/src grid/src)
 endif()
 


### PR DESCRIPTION
Make the `doxygen` target opt-in, such that parent projects using `FetchContent` can selectively disable it if they have a target with the same name.