### PR TITLE
Remove MemoryManaged tag in AoSoA

### DIFF
--- a/core/src/Cabana_AoSoA.hpp
+++ b/core/src/Cabana_AoSoA.hpp
@@ -111,12 +111,14 @@ slice( const AoSoA_t& aosoa, const std::string& slice_label = "" )
   <tt>MemorySpace</tt>.
 
   \tparam MemoryTraits (optional) Memory traits for the AoSoA data. Can be
-  used to indicate managed memory, unmanaged memory, etc.
+  used to indicate unmanaged memory, atomic access, etc.
  */
 template <class DataTypes, class MemorySpace,
           int VectorLength = Impl::PerformanceTraits<
               typename MemorySpace::execution_space>::vector_length,
-          class MemoryTraits = Kokkos::MemoryManaged>
+          // FIXME: MemoryManaged removed post 4.6 when default was added.
+          // Remove 0 when 4.7 is required.
+          class MemoryTraits = Kokkos::MemoryTraits<0>>
 class AoSoA
 {
   public:


### PR DESCRIPTION
`MemoryManaged` removed post 4.6 (kokkos/kokkos#8066); `MemoryTraits<0>` provides the same behavior. Plan to use default (`MemoryTraits<>`) when 4.7 required.