### PR TITLE
Resolve issues #828 and #829

### DIFF
--- a/grid/src/Cabana_Grid_Array.hpp
+++ b/grid/src/Cabana_Grid_Array.hpp
@@ -774,14 +774,6 @@ struct DotFunctor
             dst[j] += src[j];
     }
 
-    //! Join operation.
-    KOKKOS_INLINE_FUNCTION
-    void join( volatile value_type dst, const volatile value_type src ) const
-    {
-        for ( size_type j = 0; j < value_count; ++j )
-            dst[j] += src[j];
-    }
-
     //! Zero initialization.
     KOKKOS_INLINE_FUNCTION void init( value_type sum ) const
     {
@@ -882,15 +874,6 @@ struct NormInfFunctor
                 dst[j] = src[j];
     }
 
-    //! Join operation.
-    KOKKOS_INLINE_FUNCTION
-    void join( volatile value_type dst, const volatile value_type src ) const
-    {
-        for ( size_type j = 0; j < value_count; ++j )
-            if ( src[j] > dst[j] )
-                dst[j] = src[j];
-    }
-
     //! Zero initialization.
     KOKKOS_INLINE_FUNCTION void init( value_type norm ) const
     {
@@ -984,14 +967,6 @@ struct Norm1Functor
             dst[j] += src[j];
     }
 
-    //! Join operation.
-    KOKKOS_INLINE_FUNCTION
-    void join( volatile value_type dst, const volatile value_type src ) const
-    {
-        for ( size_type j = 0; j < value_count; ++j )
-            dst[j] += src[j];
-    }
-
     //! Zero initialization.
     KOKKOS_INLINE_FUNCTION void init( value_type norm ) const
     {
@@ -1080,14 +1055,6 @@ struct Norm2Functor
     //! Join operation.
     KOKKOS_INLINE_FUNCTION
     void join( value_type dst, const value_type src ) const
-    {
-        for ( size_type j = 0; j < value_count; ++j )
-            dst[j] += src[j];
-    }
-
-    //! Join operation.
-    KOKKOS_INLINE_FUNCTION
-    void join( volatile value_type dst, const volatile value_type src ) const
     {
         for ( size_type j = 0; j < value_count; ++j )
             dst[j] += src[j];

--- a/grid/src/Cabana_Grid_IndexSpace.hpp
+++ b/grid/src/Cabana_Grid_IndexSpace.hpp
@@ -172,10 +172,11 @@ class IndexSpace
 */
 template <class ExecutionSpace>
 Kokkos::RangePolicy<ExecutionSpace>
-createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace& )
+createExecutionPolicy( const IndexSpace<1>& index_space,
+                       const ExecutionSpace& exec_space )
 {
-    return Kokkos::RangePolicy<ExecutionSpace>( index_space.min( 0 ),
-                                                index_space.max( 0 ) );
+    return Kokkos::RangePolicy<ExecutionSpace>(
+        exec_space, index_space.min( 0 ), index_space.max( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -187,11 +188,11 @@ createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace& )
 */
 template <class ExecutionSpace, class WorkTag>
 Kokkos::RangePolicy<ExecutionSpace, WorkTag>
-createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace&,
-                       const WorkTag& )
+createExecutionPolicy( const IndexSpace<1>& index_space,
+                       const ExecutionSpace& exec_space, const WorkTag& )
 {
-    return Kokkos::RangePolicy<ExecutionSpace, WorkTag>( index_space.min( 0 ),
-                                                         index_space.max( 0 ) );
+    return Kokkos::RangePolicy<ExecutionSpace, WorkTag>(
+        exec_space, index_space.min( 0 ), index_space.max( 0 ) );
 }
 
 //---------------------------------------------------------------------------//
@@ -201,11 +202,12 @@ createExecutionPolicy( const IndexSpace<1>& index_space, const ExecutionSpace&,
 */
 template <class IndexSpace_t, class ExecutionSpace>
 Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<IndexSpace_t::Rank>>
-createExecutionPolicy( const IndexSpace_t& index_space, const ExecutionSpace& )
+createExecutionPolicy( const IndexSpace_t& index_space,
+                       const ExecutionSpace& exec_space )
 {
     return Kokkos::MDRangePolicy<ExecutionSpace,
                                  Kokkos::Rank<IndexSpace_t::Rank>>(
-        index_space.min(), index_space.max() );
+        exec_space, index_space.min(), index_space.max() );
 }
 
 //---------------------------------------------------------------------------//
@@ -216,12 +218,12 @@ createExecutionPolicy( const IndexSpace_t& index_space, const ExecutionSpace& )
 */
 template <class IndexSpace_t, class ExecutionSpace, class WorkTag>
 Kokkos::MDRangePolicy<ExecutionSpace, WorkTag, Kokkos::Rank<IndexSpace_t::Rank>>
-createExecutionPolicy( const IndexSpace_t& index_space, const ExecutionSpace&,
-                       const WorkTag& )
+createExecutionPolicy( const IndexSpace_t& index_space,
+                       const ExecutionSpace& exec_space, const WorkTag& )
 {
     return Kokkos::MDRangePolicy<ExecutionSpace, WorkTag,
                                  Kokkos::Rank<IndexSpace_t::Rank>>(
-        index_space.min(), index_space.max() );
+        exec_space, index_space.min(), index_space.max() );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR resolves 2 issues:

The commit b40fb5d resolves #828 issue by deleting the `join()` functions using the volatile function parameters.

The commit e478b7f resolves #829 issue by utilizing the `exec_space` function parameter in `createExecutionPolicy()` to avoid synchronization bugs.