### PR TITLE
Fix `VerletList` constructor

### DIFF
--- a/core/src/Cabana_VerletList.hpp
+++ b/core/src/Cabana_VerletList.hpp
@@ -864,7 +864,8 @@ class VerletList
                 const typename PositionSlice::value_type grid_min[3],
                 const typename PositionSlice::value_type grid_max[3],
                 const std::size_t max_neigh = 0,
-                typename std::enable_if<( is_slice<PositionSlice>::value ),
+                typename std::enable_if<( is_slice<PositionSlice>::value ||
+                                          Kokkos::is_view<PositionSlice>::value ),
                                         int>::type* = 0 )
     {
         build( x, begin, end, background_radius, neighborhood_radius,


### PR DESCRIPTION
Enable using `Kokkos::View` in `Cabana::VerletList` constructor overload with per-particle cutoff radius. It seems it was omitted by mistake (or by design?) from the constructor. 

It could be beneficial to add the constraint on `RadiusSlice` template parameter too ?