### PR TITLE
Notice to use Kokkos_ENABLE_IMPL_VIEW_LEGACY

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Build kokkos
         working-directory: kokkos
         run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_ENABLE_${{ matrix.backend }}=ON  -DKokkos_ENABLE_DEPRECATED_CODE_3=OFF
+          cmake -B build \
+            -DCMAKE_INSTALL_PREFIX=$HOME/kokkos \
+            -DKokkos_ENABLE_${{ matrix.backend }}=ON \
+            -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+            -DKokkos_ENABLE_IMPL_VIEW_LEGACY=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout arborx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,12 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # find kokkos
 find_package(Kokkos 4.1 REQUIRED)
 
+# FIXME: remove when custom layout support with mdspan Views is added.
+if(Kokkos_VERSION VERSION_GREATER 4.6.99 AND Kokkos_ENABLE_IMPL_VIEW_LEGACY EQUAL OFF)
+  message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless"
+          "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
+endif()
+
 # set supported kokkos devices
 set(CABANA_SUPPORTED_DEVICES SERIAL THREADS OPENMP CUDA HIP SYCL OPENMPTARGET)
 


### PR DESCRIPTION
Cabana is incompatible with the Kokkos `develop` branch and potentially the soon to be 4.7 release. Add a notice on how to configure Kokkos for now