### PR TITLE
fail when legacy kokkos views are off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(Kokkos 4.1 REQUIRED)
 
 # FIXME: remove when custom layout support with mdspan Views is added.
-if(Kokkos_VERSION VERSION_GREATER 4.6.99 AND Kokkos_ENABLE_IMPL_VIEW_LEGACY EQUAL OFF)
-  message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless"
-          "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
+if(Kokkos_VERSION VERSION_GREATER 4.6.99)
+    if (NOT DEFINED Kokkos_ENABLE_IMPL_VIEW_LEGACY OR Kokkos_ENABLE_IMPL_VIEW_LEGACY EQUAL OFF)
+       message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless "
+                           "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
+    endif()
 endif()
 
 # set supported kokkos devices

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(Kokkos 4.1 REQUIRED)
 
 # FIXME: remove when custom layout support with mdspan Views is added.
-if(Kokkos_VERSION VERSION_GREATER 4.6.99)
-    if (NOT DEFINED Kokkos_ENABLE_IMPL_VIEW_LEGACY OR Kokkos_ENABLE_IMPL_VIEW_LEGACY EQUAL OFF)
-       message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless "
-                           "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
-    endif()
+if(Kokkos_VERSION VERSION_GREATER_EQUAL 4.6.99 AND NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY)
+  message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless "
+          "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
 endif()
 
 # set supported kokkos devices


### PR DESCRIPTION
If kokkos was built with non-legacy views then the cmake var Kokkos_ENABLE_IMPL_VIEW_LEGACY is not defined.  This was tested with kokkos @ develop b06886a37.