### PR TITLE
Fix race condition when constructing CommunicationPlan from imports

### DIFF
--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1063,6 +1063,12 @@ class CommunicationPlan
         if ( MPI_SUCCESS != ec )
             throw std::logic_error( "Failed MPI Communication" );
 
+        // This barrier is needed to ensure all the above Isends and IRecvs
+        // complete before the next echange starts. If there is no barrier
+        // sometimes the send_to data will be populated incorrectly and cause
+        // the code to hang.
+        MPI_Barrier( comm() );
+
         // Get the total number of imports/exports.
         _total_num_export =
             std::accumulate( _num_export.begin(), _num_export.end(), 0 );
@@ -1306,6 +1312,13 @@ class CommunicationPlan
             MPI_Waitall( num_recvs, mpi_requests.data(), mpi_statuses.data() );
         if ( MPI_SUCCESS != ec0 )
             throw std::logic_error( "Failed MPI Communication" );
+
+        // This barrier is needed to ensure all the above Isends and IRecvs
+        // complete before the next echange starts. If there is no barrier
+        // sometimes the send_to data will be populated incorrectly and cause
+        // the code to hang.
+        MPI_Barrier( comm() );
+
         // Save ranks we got messages from and track total messages to size
         // buffers
         _total_num_export = 0;

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1079,8 +1079,10 @@ class CommunicationPlan
         int num_messages = _total_num_export + element_import_ranks.extent( 0 );
         std::vector<MPI_Request> mpi_requests( num_messages );
         std::vector<MPI_Status> mpi_statuses( num_messages );
-        // Increment the mpi_tag to ensure messages are processed in the correct
-        // order from the previous round of Isends and Irecvs.
+
+        // Increment the mpi_tag for this round of messages to ensure messages
+        // are processed in the correct order from the previous round of Isends
+        // and Irecvs.
         for ( std::size_t i = 0; i < num_n; i++ )
         {
             for ( std::size_t j = 0; j < _num_export[i]; j++ )
@@ -1093,8 +1095,6 @@ class CommunicationPlan
         }
 
         // Send the indices we need
-        // Increment the mpi_tag to ensure messages are processed in the correct
-        // order from the previous round of Isends and Irecvs.
         for ( std::size_t i = 0; i < element_import_ranks.extent( 0 ); i++ )
         {
             MPI_Isend( element_import_ids.data() + i, 1, MPI_INT,
@@ -1391,8 +1391,10 @@ class CommunicationPlan
         int num_messages = _total_num_export + element_import_ranks.extent( 0 );
         mpi_requests.resize( num_messages );
         mpi_statuses.resize( num_messages );
-        // Increment the mpi_tag to ensure messages are processed in the correct
-        // order from the previous round of Isends and Irecvs.
+
+        // Increment the mpi_tag for this round of messages to ensure messages
+        // are processed in the correct order from the previous round of Isends
+        // and Irecvs.
         for ( int i = 0; i < num_recvs; i++ )
         {
             for ( int j = 0; j < send_counts( i ); j++ )
@@ -1405,8 +1407,6 @@ class CommunicationPlan
         }
 
         // Send the indices we need
-        // Increment the mpi_tag to ensure messages are processed in the correct
-        // order from the previous round of Isends and Irecvs.
         for ( std::size_t i = 0; i < element_import_ranks.extent( 0 ); i++ )
         {
             MPI_Isend( element_import_ids.data() + i, 1, MPI_INT,

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1064,12 +1064,6 @@ class CommunicationPlan
         if ( MPI_SUCCESS != ec )
             throw std::logic_error( "Failed MPI Communication" );
 
-        // This barrier is needed to ensure all the above Isends and Irecvs
-        // complete before the next exchange starts. If there is no barrier
-        // sometimes the send_to data will be populated incorrectly and cause
-        // the code to hang.
-        MPI_Barrier( comm() );
-
         // Get the total number of imports/exports.
         _total_num_export =
             std::accumulate( _num_export.begin(), _num_export.end(), 0 );
@@ -1128,7 +1122,7 @@ class CommunicationPlan
                 ExecutionSpace>::type() );
 
         // No barrier is needed because all ranks know who they are receiving
-        // and sending to.
+        // from and sending to.
 
         // Return the neighbor ids, export ranks, and export indices
         return std::tuple{ counts_and_ids2.second, element_export_ranks,
@@ -1317,12 +1311,6 @@ class CommunicationPlan
             MPI_Waitall( num_recvs, mpi_requests.data(), mpi_statuses.data() );
         if ( MPI_SUCCESS != ec0 )
             throw std::logic_error( "Failed MPI Communication" );
-
-        // This barrier is needed to ensure all the above Isends and Irecvs
-        // complete before the next exchange starts. If there is no barrier
-        // sometimes the send_to data will be populated incorrectly and cause
-        // the code to hang.
-        MPI_Barrier( comm() );
 
         // Save ranks we got messages from and track total messages to size
         // buffers

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1124,7 +1124,7 @@ class CommunicationPlan
             exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
                 ExecutionSpace>::type() );
-            
+
         // Barrier before continuing to ensure synchronization.
         MPI_Barrier( comm() );
 
@@ -1437,7 +1437,7 @@ class CommunicationPlan
             exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
                 ExecutionSpace>::type() );
-        
+
         // Barrier before continuing to ensure synchronization.
         MPI_Barrier( comm() );
 

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1063,8 +1063,8 @@ class CommunicationPlan
         if ( MPI_SUCCESS != ec )
             throw std::logic_error( "Failed MPI Communication" );
 
-        // This barrier is needed to ensure all the above Isends and IRecvs
-        // complete before the next echange starts. If there is no barrier
+        // This barrier is needed to ensure all the above Isends and Irecvs
+        // complete before the next exchange starts. If there is no barrier
         // sometimes the send_to data will be populated incorrectly and cause
         // the code to hang.
         MPI_Barrier( comm() );
@@ -1313,8 +1313,8 @@ class CommunicationPlan
         if ( MPI_SUCCESS != ec0 )
             throw std::logic_error( "Failed MPI Communication" );
 
-        // This barrier is needed to ensure all the above Isends and IRecvs
-        // complete before the next echange starts. If there is no barrier
+        // This barrier is needed to ensure all the above Isends and Irecvs
+        // complete before the next exchange starts. If there is no barrier
         // sometimes the send_to data will be populated incorrectly and cause
         // the code to hang.
         MPI_Barrier( comm() );

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1079,6 +1079,8 @@ class CommunicationPlan
         int num_messages = _total_num_export + element_import_ranks.extent( 0 );
         std::vector<MPI_Request> mpi_requests( num_messages );
         std::vector<MPI_Status> mpi_statuses( num_messages );
+        // Increment the mpi_tag to ensure messages are processed in the correct
+        // order from the previous round of Isends and Irecvs.
         for ( std::size_t i = 0; i < num_n; i++ )
         {
             for ( std::size_t j = 0; j < _num_export[i]; j++ )
@@ -1091,6 +1093,8 @@ class CommunicationPlan
         }
 
         // Send the indices we need
+        // Increment the mpi_tag to ensure messages are processed in the correct
+        // order from the previous round of Isends and Irecvs.
         for ( std::size_t i = 0; i < element_import_ranks.extent( 0 ); i++ )
         {
             MPI_Isend( element_import_ids.data() + i, 1, MPI_INT,
@@ -1387,6 +1391,8 @@ class CommunicationPlan
         int num_messages = _total_num_export + element_import_ranks.extent( 0 );
         mpi_requests.resize( num_messages );
         mpi_statuses.resize( num_messages );
+        // Increment the mpi_tag to ensure messages are processed in the correct
+        // order from the previous round of Isends and Irecvs.
         for ( int i = 0; i < num_recvs; i++ )
         {
             for ( int j = 0; j < send_counts( i ); j++ )
@@ -1399,6 +1405,8 @@ class CommunicationPlan
         }
 
         // Send the indices we need
+        // Increment the mpi_tag to ensure messages are processed in the correct
+        // order from the previous round of Isends and Irecvs.
         for ( std::size_t i = 0; i < element_import_ranks.extent( 0 ); i++ )
         {
             MPI_Isend( element_import_ids.data() + i, 1, MPI_INT,

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -1124,6 +1124,9 @@ class CommunicationPlan
             exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
                 ExecutionSpace>::type() );
+            
+        // Barrier before continuing to ensure synchronization.
+        MPI_Barrier( comm() );
 
         // Return the neighbor ids, export ranks, and export indices
         return std::tuple{ counts_and_ids2.second, element_export_ranks,
@@ -1434,6 +1437,9 @@ class CommunicationPlan
             exec_space, element_export_ranks, comm_size,
             typename Impl::CountSendsAndCreateSteeringAlgorithm<
                 ExecutionSpace>::type() );
+        
+        // Barrier before continuing to ensure synchronization.
+        MPI_Barrier( comm() );
 
         return std::tuple{ counts_and_ids2.second, element_export_ranks,
                            export_indices };


### PR DESCRIPTION
Sometimes `CommunicationPlan` test 10 hangs. I believe there is a race condition between the two rounds of `Isends` and `Irecvs` when constructing a `CommunicationPlan` from imports only. The test does not hang after adding an `MPI_Barrier` after the first `MPI_Waitall`.

This pull request adds the barriers to fix the bug.