### PR TITLE
Fix Cabana::Remove when nothing to remove

### DIFF
--- a/core/src/Cabana_Remove.hpp
+++ b/core/src/Cabana_Remove.hpp
@@ -46,6 +46,11 @@ void remove( const ExecutionSpace& exec_space, const int num_keep,
 
     // Determine the empty particle positions in the compaction zone.
     int num_particles = particles.size();
+
+    // Nothing to remove.
+    if ( num_particles == num_particles_ignore + num_keep )
+        return;
+
     // This View is either empty indices to be filled or the created particle
     // indices, depending on the ratio of allocated space to the number
     // created.

--- a/core/unit_test/tstRemove.hpp
+++ b/core/unit_test/tstRemove.hpp
@@ -25,17 +25,26 @@ void testRemove()
     int num_particle = 200;
     Cabana::AoSoA<Cabana::MemberTypes<int>, TEST_MEMSPACE> aosoa(
         "remove", num_particle );
-    // Purposely using zero-init here.
-    Kokkos::View<int*, TEST_MEMSPACE> keep_particle( "keep", num_particle );
-
     auto keep_slice = Cabana::slice<0>( aosoa, "slice" );
+
+    // Remove nothing
+    Kokkos::parallel_for(
+        "init", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_particle ),
+        KOKKOS_LAMBDA( const int p ) { keep_slice( p ) = 1; } );
+
+    Cabana::remove( TEST_EXECSPACE{}, num_particle, keep_slice, aosoa );
+    EXPECT_EQ( aosoa.size(), num_particle );
+
+    // Remove only odd particles.
+    aosoa.resize( num_particle );
+    keep_slice = Cabana::slice<0>( aosoa, "slice" );
+
     Kokkos::parallel_for(
         "init", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, num_particle ),
         KOKKOS_LAMBDA( const int p ) {
             if ( p % 2 )
             {
                 keep_slice( p ) = 1;
-                keep_particle( p ) = 1;
             }
             else
             {
@@ -43,22 +52,24 @@ void testRemove()
             }
         } );
 
-    // Remove only odd particles.
     int new_num_particle = num_particle / 2;
-    Cabana::remove( TEST_EXECSPACE{}, new_num_particle, keep_particle, aosoa );
+    Cabana::remove( TEST_EXECSPACE{}, new_num_particle, keep_slice, aosoa );
     EXPECT_EQ( aosoa.size(), new_num_particle );
 
+    auto aosoa_host =
+        Cabana::create_mirror_view_and_copy( Kokkos::HostSpace(), aosoa );
+    auto keep_slice_host = Cabana::slice<0>( aosoa_host, "host_slice" );
+    for ( int p = 0; p < new_num_particle; ++p )
+        EXPECT_EQ( keep_slice_host( p ), 1 );
+
     // Remove the rest.
-    Kokkos::resize( keep_particle, new_num_particle );
+    aosoa.resize( new_num_particle );
     keep_slice = Cabana::slice<0>( aosoa, "slice" );
     Kokkos::parallel_for(
         "init", Kokkos::RangePolicy<TEST_EXECSPACE>( 0, new_num_particle ),
-        KOKKOS_LAMBDA( const int p ) {
-            keep_particle( p ) = 1;
-            keep_slice( p ) = 0;
-        } );
+        KOKKOS_LAMBDA( const int p ) { keep_slice( p ) = 0; } );
 
-    Cabana::remove( TEST_EXECSPACE{}, 0, keep_particle, aosoa );
+    Cabana::remove( TEST_EXECSPACE{}, 0, keep_slice, aosoa );
     EXPECT_EQ( aosoa.size(), 0 );
 }
 


### PR DESCRIPTION
Fix Cabana_Remove to return without do anything when there is nothing to remove

Expand tests for:
- Slice vs View removal
- Number of particles removed