### PR TITLE
Use Kokkos::HIP outside of Kokkos::Experimental namespace

### DIFF
--- a/cmake/test_harness/TestHIP_Category.hpp
+++ b/cmake/test_harness/TestHIP_Category.hpp
@@ -13,9 +13,8 @@
 #define CABANA_TEST_HIP_CATEGORY_HPP
 
 #define TEST_CATEGORY hip
-#define TEST_EXECSPACE Kokkos::Experimental::HIP
-#define TEST_MEMSPACE Kokkos::Experimental::HIPSpace
-#define TEST_DEVICE                                                            \
-    Kokkos::Device<Kokkos::Experimental::HIP, Kokkos::Experimental::HIPSpace>
+#define TEST_EXECSPACE Kokkos::HIP
+#define TEST_MEMSPACE Kokkos::HIPSpace
+#define TEST_DEVICE Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace>
 
 #endif

--- a/core/src/Cabana_CommunicationPlan.hpp
+++ b/core/src/Cabana_CommunicationPlan.hpp
@@ -77,7 +77,7 @@ struct CountSendsAndCreateSteeringAlgorithm<Kokkos::Cuda>
 #endif // end KOKKOS_ENABLE_CUDA
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-struct CountSendsAndCreateSteeringAlgorithm<Kokkos::Experimental::HIP>
+struct CountSendsAndCreateSteeringAlgorithm<Kokkos::HIP>
 {
     using type = CountSendsAndCreateSteeringAtomic;
 };

--- a/core/src/impl/Cabana_PerformanceTraits.hpp
+++ b/core/src/impl/Cabana_PerformanceTraits.hpp
@@ -78,7 +78,7 @@ class PerformanceTraits<Kokkos::Cuda>
 //---------------------------------------------------------------------------//
 #if defined( KOKKOS_ENABLE_HIP )
 template <>
-class PerformanceTraits<Kokkos::Experimental::HIP>
+class PerformanceTraits<Kokkos::HIP>
 {
   public:
     static constexpr int vector_length = 64; // wavefront size

--- a/grid/src/Cabana_Grid_FastFourierTransform.hpp
+++ b/grid/src/Cabana_Grid_FastFourierTransform.hpp
@@ -415,7 +415,7 @@ struct HeffteBackendTraits<Kokkos::Cuda, Impl::FFTBackendDefault>
 #ifdef Heffte_ENABLE_ROCM
 #ifdef KOKKOS_ENABLE_HIP
 template <>
-struct HeffteBackendTraits<Kokkos::Experimental::HIP, Impl::FFTBackendDefault>
+struct HeffteBackendTraits<Kokkos::HIP, Impl::FFTBackendDefault>
 {
     using backend_type = heffte::backend::rocfft;
 };


### PR DESCRIPTION
Promoted in Kokkos 4.0