### PR TITLE
Fixes to use hypre 3.0 and hypre with ROCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #------------------------------------------------------------------------------#
 cmake_minimum_required(VERSION 3.16)
 
-project(Cabana LANGUAGES CXX)
+project(Cabana LANGUAGES C CXX)
 set(PROJECT_VERSION "0.8.0-dev")
 
 # If the user doesn't provide a build type default to release
@@ -99,7 +99,7 @@ set_package_properties(ALL PROPERTIES TYPE OPTIONAL PURPOSE "Used for load balan
 find_package( CLANG_FORMAT 14 )
 
 # find hypre
-Cabana_add_dependency( PACKAGE HYPRE VERSION 2.22.1 )
+Cabana_add_dependency( PACKAGE HYPRE VERSION 3.0.0 )
 set_package_properties(HYPRE PROPERTIES TYPE OPTIONAL PURPOSE "Used for structured solves")
 
 # find heffte

--- a/grid/src/Cabana_Grid_Hypre.hpp
+++ b/grid/src/Cabana_Grid_Hypre.hpp
@@ -67,8 +67,7 @@ struct HypreIsCompatibleWithMemorySpace<Kokkos::CudaUVMSpace> : std::true_type
 //! Hypre device compatibility check - HIP memory. FIXME - make this true when
 //! the HYPRE CMake includes HIP
 template <>
-struct HypreIsCompatibleWithMemorySpace<Kokkos::ExperimentalHIPSpace>
-    : std::false_type
+struct HypreIsCompatibleWithMemorySpace<Kokkos::HIPSpace> : std::true_type
 {
 };
 #endif // end KOKKOS_ENABLE_HIP


### PR DESCRIPTION
Changes CMakeLists.txt to require hypre 3.0.0 and the cabana hypre solver to work with ROCMSpace now that hypre 3.0 supports it.