### PR TITLE
Fix MySoA struct breaking CI tests

### DIFF
--- a/core/unit_test/tstAoSoA.hpp
+++ b/core/unit_test/tstAoSoA.hpp
@@ -531,8 +531,8 @@ struct MySoA
     double m2[D1][VLEN];
     double m3[D1][D2][VLEN];
 
-    KOKKOS_DEFAULTED_FUNCTION
-    MySoA() = default;
+    KOKKOS_INLINE_FUNCTION
+    MySoA(){};
 };
 
 // Test an unmanaged AoSoA.


### PR DESCRIPTION
 The CI errors have been fixed by editing the struct `MySoA` in `core/src/unit_test/tstAoSoA.hpp`:
```c++
template <int VLEN, int D1, int D2, int D3>
struct MySoA
{
    float m0[D1][D2][D3][VLEN];
    int m1[VLEN];
    double m2[D1][VLEN];
    double m3[D1][D2][VLEN];
    
    KOKKOS_INLINE_FUNCTION
    MySoA(){};
};
```
Adding the constructor fixes the Ubuntu/OpenSUSE warnings and adding `KOKKOS_INLINE_FUNCTION` fixes a "calling a host function on the device" error when building with HIP.