### PR TITLE
Drop CUDA_LAMBDA check on Kokkos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,6 @@ foreach(_device ${CABANA_SUPPORTED_DEVICES})
   endif()
 endforeach()
 
-# ensure that we can use lambdas
-if(Kokkos_ENABLE_CUDA)
-  kokkos_check(OPTIONS CUDA_LAMBDA)
-endif()
-
 # standard dependency macro
 macro(Cabana_add_dependency)
   cmake_parse_arguments(CABANA_DEPENDENCY "" "PACKAGE;VERSION" "COMPONENTS" ${ARGN})


### PR DESCRIPTION
With the current Kokkos 4.1 minimum requirement, that check is superfluous.  For compatibility with the (upcoming) Kokkos 5.2 it must be removed.

Fixes #866 

As documented in https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html#backend-specific-options, the CUDA_LAMBDA option is deprecated and always ON.
In the current develop, Kokkos stopped exporting the Kokkos_ENABLE_CUDA_LAMBDA variable so the check would fail.