### PR TITLE
Add support for large message sizes

### DIFF
--- a/core/src/impl/Cabana_CommunicationPlan_Mpi.hpp
+++ b/core/src/impl/Cabana_CommunicationPlan_Mpi.hpp
@@ -34,6 +34,99 @@
 namespace Cabana
 {
 
+/*!
+    \brief Helper to post non-blocking receive(s) for a single neighbor, handling
+    messages larger than INT_MAX when MPI version is less than 4 and
+    large-count messages are unavailable.
+
+    \param subview The receive buffer.
+
+    \param source Who to receive from.
+
+    \param tag The MPI message tag.
+
+    \param comm The MPI Communicator.
+
+    \param requests Requests vector to append this message to.
+*/
+template <class ViewType>
+inline void cabanaIrecv( const ViewType& subview, int source, int tag,
+                    MPI_Comm comm,
+                    std::vector<MPI_Request>& requests )
+{
+    using value_type = typename ViewType::value_type;
+    std::size_t total_bytes = subview.size() * sizeof( value_type );
+ 
+#if MPI_VERSION >= 4
+    // MPI 4.0 supports large counts natively via MPI_Irecv_c.
+    requests.push_back( MPI_Request() );
+    MPI_Irecv_c( subview.data(), static_cast<MPI_Count>( total_bytes ),
+                 MPI_BYTE, source, tag, comm, &( requests.back() ) );
+#else
+    // Chunk into INT_MAX-sized pieces.
+    std::size_t offset = 0;
+    while ( offset < total_bytes )
+    {
+        int chunk = static_cast<int>(
+            std::min( static_cast<std::size_t>( INT_MAX ),
+                      total_bytes - offset ) );
+ 
+        requests.push_back( MPI_Request() );
+        MPI_Irecv( reinterpret_cast<char*>( subview.data() ) + offset, chunk,
+                   MPI_BYTE, source, tag, comm, &( requests.back() ) );
+ 
+        offset += static_cast<std::size_t>( chunk );
+    }
+#endif
+}
+
+/*!
+    \brief Helper to post non-blocking sends(s) for a single neighbor, handling
+    messages larger than INT_MAX when MPI version is less than 4 and
+    large-count messages are unavailable.
+
+    \param subview The send buffer.
+
+    \param dest Who to send from.
+
+    \param tag The MPI message tag.
+
+    \param comm The MPI Communicator.
+
+    \param requests Requests vector to append this message to.
+*/
+template <class ViewType>
+inline void cabanaIsend( const ViewType& subview, int dest, int tag,
+                    MPI_Comm comm,
+                    std::vector<MPI_Request>& requests )
+{
+    using value_type = typename ViewType::value_type;
+    std::size_t total_bytes = subview.size() * sizeof( value_type );
+ 
+#if MPI_VERSION >= 4
+    // MPI 4.0 supports large counts natively via MPI_Isend_c.
+    requests.push_back( MPI_Request() );
+    MPI_Isend_c( subview.data(), static_cast<MPI_Count>( total_bytes ),
+                 MPI_BYTE, dest, tag, comm, &( requests.back() ) );
+#else
+    // Chunk into INT_MAX-sized pieces.
+    std::size_t offset = 0;
+    while ( offset < total_bytes )
+    {
+        int chunk = static_cast<int>(
+            std::min( static_cast<std::size_t>( INT_MAX ),
+                      total_bytes - offset ) );
+ 
+        requests.push_back( MPI_Request() );
+        MPI_Isend(
+            reinterpret_cast<const char*>( subview.data() ) + offset, chunk,
+            MPI_BYTE, dest, tag, comm, &( requests.back() ) );
+ 
+        offset += static_cast<std::size_t>( chunk );
+    }
+#endif
+}
+
 //---------------------------------------------------------------------------//
 /*!
   \brief Communication plan class. Uses vanilla MPI as the communication

--- a/core/src/impl/Cabana_CommunicationPlan_Mpi.hpp
+++ b/core/src/impl/Cabana_CommunicationPlan_Mpi.hpp
@@ -35,8 +35,8 @@ namespace Cabana
 {
 
 /*!
-    \brief Helper to post non-blocking receive(s) for a single neighbor, handling
-    messages larger than INT_MAX when MPI version is less than 4 and
+    \brief Helper to post non-blocking receive(s) for a single neighbor,
+   handling messages larger than INT_MAX when MPI version is less than 4 and
     large-count messages are unavailable.
 
     \param subview The receive buffer.
@@ -51,12 +51,11 @@ namespace Cabana
 */
 template <class ViewType>
 inline void cabanaIrecv( const ViewType& subview, int source, int tag,
-                    MPI_Comm comm,
-                    std::vector<MPI_Request>& requests )
+                         MPI_Comm comm, std::vector<MPI_Request>& requests )
 {
     using value_type = typename ViewType::value_type;
     std::size_t total_bytes = subview.size() * sizeof( value_type );
- 
+
 #if MPI_VERSION >= 4
     // MPI 4.0 supports large counts natively via MPI_Irecv_c.
     requests.push_back( MPI_Request() );
@@ -67,14 +66,13 @@ inline void cabanaIrecv( const ViewType& subview, int source, int tag,
     std::size_t offset = 0;
     while ( offset < total_bytes )
     {
-        int chunk = static_cast<int>(
-            std::min( static_cast<std::size_t>( INT_MAX ),
-                      total_bytes - offset ) );
- 
+        int chunk = static_cast<int>( std::min(
+            static_cast<std::size_t>( INT_MAX ), total_bytes - offset ) );
+
         requests.push_back( MPI_Request() );
         MPI_Irecv( reinterpret_cast<char*>( subview.data() ) + offset, chunk,
                    MPI_BYTE, source, tag, comm, &( requests.back() ) );
- 
+
         offset += static_cast<std::size_t>( chunk );
     }
 #endif
@@ -97,12 +95,11 @@ inline void cabanaIrecv( const ViewType& subview, int source, int tag,
 */
 template <class ViewType>
 inline void cabanaIsend( const ViewType& subview, int dest, int tag,
-                    MPI_Comm comm,
-                    std::vector<MPI_Request>& requests )
+                         MPI_Comm comm, std::vector<MPI_Request>& requests )
 {
     using value_type = typename ViewType::value_type;
     std::size_t total_bytes = subview.size() * sizeof( value_type );
- 
+
 #if MPI_VERSION >= 4
     // MPI 4.0 supports large counts natively via MPI_Isend_c.
     requests.push_back( MPI_Request() );
@@ -113,15 +110,13 @@ inline void cabanaIsend( const ViewType& subview, int dest, int tag,
     std::size_t offset = 0;
     while ( offset < total_bytes )
     {
-        int chunk = static_cast<int>(
-            std::min( static_cast<std::size_t>( INT_MAX ),
-                      total_bytes - offset ) );
- 
+        int chunk = static_cast<int>( std::min(
+            static_cast<std::size_t>( INT_MAX ), total_bytes - offset ) );
+
         requests.push_back( MPI_Request() );
-        MPI_Isend(
-            reinterpret_cast<const char*>( subview.data() ) + offset, chunk,
-            MPI_BYTE, dest, tag, comm, &( requests.back() ) );
- 
+        MPI_Isend( reinterpret_cast<const char*>( subview.data() ) + offset,
+                   chunk, MPI_BYTE, dest, tag, comm, &( requests.back() ) );
+
         offset += static_cast<std::size_t>( chunk );
     }
 #endif

--- a/core/src/impl/Cabana_Halo_Mpi.hpp
+++ b/core/src/impl/Cabana_Halo_Mpi.hpp
@@ -68,40 +68,45 @@ Gather<HaloType, AoSoAType,
     const int mpi_tag = 2345;
 
     // Post non-blocking receives.
-    int num_n = _comm_plan.numNeighbor();
-    std::vector<MPI_Request> requests( num_n );
+    std::vector<MPI_Request> requests;
+    requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        recv_range.second = recv_range.first + _comm_plan.numImport( n );
-
-        auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
-
-        MPI_Irecv( recv_subview.data(),
-                   recv_subview.size() * sizeof( data_type ), MPI_BYTE,
-                   _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm(),
-                   &( requests[n] ) );
-
+        recv_range.second = recv_range.first + distributor.numImport( n );
+ 
+        if ( ( distributor.numImport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
+ 
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+        }
+ 
         recv_range.first = recv_range.second;
     }
-
-    // Do blocking sends.
+ 
+    // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        send_range.second = send_range.first + _comm_plan.numExport( n );
-
-        auto send_subview = Kokkos::subview( send_buffer, send_range );
-
-        MPI_Send( send_subview.data(),
-                  send_subview.size() * sizeof( data_type ), MPI_BYTE,
-                  _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm() );
-
-        send_range.first = send_range.second;
+        if ( ( distributor.numExport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            send_range.second = send_range.first + distributor.numExport( n );
+ 
+            auto send_subview = Kokkos::subview( send_buffer, send_range );
+ 
+            cabanaIsend( send_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+ 
+            send_range.first = send_range.second;
+        }
     }
 
-    // Wait on non-blocking receives.
-    std::vector<MPI_Status> status( num_n );
+    // Wait on all non-blocking communication.
+    std::vector<MPI_Status> status( requests.size() );
     const int ec =
         MPI_Waitall( requests.size(), requests.data(), status.data() );
     if ( MPI_SUCCESS != ec )
@@ -171,42 +176,45 @@ Gather<HaloType, SliceType,
     const int mpi_tag = 2345;
 
     // Post non-blocking receives.
-    int num_n = _comm_plan.numNeighbor();
-    std::vector<MPI_Request> requests( num_n );
+    std::vector<MPI_Request> requests;
+    requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        recv_range.second = recv_range.first + _comm_plan.numImport( n );
-
-        auto recv_subview =
-            Kokkos::subview( recv_buffer, recv_range, Kokkos::ALL );
-
-        MPI_Irecv( recv_subview.data(),
-                   recv_subview.size() * sizeof( data_type ), MPI_BYTE,
-                   _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm(),
-                   &( requests[n] ) );
-
+        recv_range.second = recv_range.first + distributor.numImport( n );
+ 
+        if ( ( distributor.numImport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
+ 
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+        }
+ 
         recv_range.first = recv_range.second;
     }
-
-    // Do blocking sends.
+ 
+    // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        send_range.second = send_range.first + _comm_plan.numExport( n );
-
-        auto send_subview =
-            Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
-
-        MPI_Send( send_subview.data(),
-                  send_subview.size() * sizeof( data_type ), MPI_BYTE,
-                  _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm() );
-
-        send_range.first = send_range.second;
+        if ( ( distributor.numExport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            send_range.second = send_range.first + distributor.numExport( n );
+ 
+            auto send_subview = Kokkos::subview( send_buffer, send_range );
+ 
+            cabanaIsend( send_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+ 
+            send_range.first = send_range.second;
+        }
     }
 
-    // Wait on non-blocking receives.
-    std::vector<MPI_Status> status( num_n );
+    // Wait on all non-blocking communication.
+    std::vector<MPI_Status> status( requests.size() );
     const int ec =
         MPI_Waitall( requests.size(), requests.data(), status.data() );
     if ( MPI_SUCCESS != ec )
@@ -303,24 +311,46 @@ Scatter<HaloType, SliceType>::applyImpl( ExecutionSpace, CommSpaceType )
         recv_range.first = recv_range.second;
     }
 
-    // Do blocking sends.
+    // Post non-blocking receives.
+    std::vector<MPI_Request> requests;
+    requests.reserve( num_n * 2 );
+    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
+    for ( int n = 0; n < num_n; ++n )
+    {
+        recv_range.second = recv_range.first + distributor.numImport( n );
+ 
+        if ( ( distributor.numImport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
+ 
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+        }
+ 
+        recv_range.first = recv_range.second;
+    }
+ 
+    // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        send_range.second = send_range.first + _comm_plan.numImport( n );
-
-        auto send_subview =
-            Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
-
-        MPI_Send( send_subview.data(),
-                  send_subview.size() * sizeof( data_type ), MPI_BYTE,
-                  _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm() );
-
-        send_range.first = send_range.second;
+        if ( ( distributor.numExport( n ) > 0 ) &&
+             ( distributor.neighborRank( n ) != my_rank ) )
+        {
+            send_range.second = send_range.first + distributor.numExport( n );
+ 
+            auto send_subview = Kokkos::subview( send_buffer, send_range );
+ 
+            cabanaIsend( send_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+ 
+            send_range.first = send_range.second;
+        }
     }
 
-    // Wait on non-blocking receives.
-    std::vector<MPI_Status> status( num_n );
+    // Wait on all non-blocking communication.
+    std::vector<MPI_Status> status( requests.size() );
     const int ec =
         MPI_Waitall( requests.size(), requests.data(), status.data() );
     if ( MPI_SUCCESS != ec )

--- a/core/src/impl/Cabana_Halo_Mpi.hpp
+++ b/core/src/impl/Cabana_Halo_Mpi.hpp
@@ -68,41 +68,34 @@ Gather<HaloType, AoSoAType,
     const int mpi_tag = 2345;
 
     // Post non-blocking receives.
+    int num_n = _comm_plan.numNeighbor();
     std::vector<MPI_Request> requests;
     requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        recv_range.second = recv_range.first + distributor.numImport( n );
- 
-        if ( ( distributor.numImport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
- 
-            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
-        }
- 
+        recv_range.second = recv_range.first + _comm_plan.numImport( n );
+
+        auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
+
+        cabanaIrecv( recv_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
+
         recv_range.first = recv_range.second;
     }
- 
+
     // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        if ( ( distributor.numExport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            send_range.second = send_range.first + distributor.numExport( n );
- 
-            auto send_subview = Kokkos::subview( send_buffer, send_range );
- 
-            cabanaIsend( send_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
- 
-            send_range.first = send_range.second;
-        }
+        send_range.second = send_range.first + _comm_plan.numExport( n );
+
+        auto send_subview = Kokkos::subview( send_buffer, send_range );
+
+        cabanaIsend( send_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
+
+        send_range.first = send_range.second;
     }
 
     // Wait on all non-blocking communication.
@@ -176,41 +169,36 @@ Gather<HaloType, SliceType,
     const int mpi_tag = 2345;
 
     // Post non-blocking receives.
+    int num_n = _comm_plan.numNeighbor();
     std::vector<MPI_Request> requests;
     requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        recv_range.second = recv_range.first + distributor.numImport( n );
- 
-        if ( ( distributor.numImport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
- 
-            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
-        }
- 
+        recv_range.second = recv_range.first + _comm_plan.numImport( n );
+
+        auto recv_subview =
+            Kokkos::subview( recv_buffer, recv_range, Kokkos::ALL );
+
+        cabanaIrecv( recv_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
+
         recv_range.first = recv_range.second;
     }
- 
+
     // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        if ( ( distributor.numExport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            send_range.second = send_range.first + distributor.numExport( n );
- 
-            auto send_subview = Kokkos::subview( send_buffer, send_range );
- 
-            cabanaIsend( send_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
- 
-            send_range.first = send_range.second;
-        }
+        send_range.second = send_range.first + _comm_plan.numExport( n );
+
+        auto send_subview =
+            Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
+
+        cabanaIsend( send_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
+
+        send_range.first = send_range.second;
     }
 
     // Wait on all non-blocking communication.
@@ -294,7 +282,8 @@ Scatter<HaloType, SliceType>::applyImpl( ExecutionSpace, CommSpaceType )
 
     // Post non-blocking receives.
     int num_n = _comm_plan.numNeighbor();
-    std::vector<MPI_Request> requests( num_n );
+    std::vector<MPI_Request> requests;
+    requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
@@ -303,50 +292,25 @@ Scatter<HaloType, SliceType>::applyImpl( ExecutionSpace, CommSpaceType )
         auto recv_subview =
             Kokkos::subview( recv_buffer, recv_range, Kokkos::ALL );
 
-        MPI_Irecv( recv_subview.data(),
-                   recv_subview.size() * sizeof( data_type ), MPI_BYTE,
-                   _comm_plan.neighborRank( n ), mpi_tag, _comm_plan.comm(),
-                   &( requests[n] ) );
+        cabanaIrecv( recv_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
 
         recv_range.first = recv_range.second;
     }
 
-    // Post non-blocking receives.
-    std::vector<MPI_Request> requests;
-    requests.reserve( num_n * 2 );
-    std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
-    for ( int n = 0; n < num_n; ++n )
-    {
-        recv_range.second = recv_range.first + distributor.numImport( n );
- 
-        if ( ( distributor.numImport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
- 
-            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
-        }
- 
-        recv_range.first = recv_range.second;
-    }
- 
     // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
-        if ( ( distributor.numExport( n ) > 0 ) &&
-             ( distributor.neighborRank( n ) != my_rank ) )
-        {
-            send_range.second = send_range.first + distributor.numExport( n );
- 
-            auto send_subview = Kokkos::subview( send_buffer, send_range );
- 
-            cabanaIsend( send_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
- 
-            send_range.first = send_range.second;
-        }
+        send_range.second = send_range.first + _comm_plan.numImport( n );
+
+        auto send_subview =
+            Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
+
+        cabanaIsend( send_subview, _comm_plan.neighborRank( n ), mpi_tag,
+                     _comm_plan.comm(), requests );
+
+        send_range.first = send_range.second;
     }
 
     // Wait on all non-blocking communication.

--- a/core/src/impl/Cabana_Migrate_Mpi.hpp
+++ b/core/src/impl/Cabana_Migrate_Mpi.hpp
@@ -108,30 +108,25 @@ void migrateData(
 
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
-    requests.reserve( num_n );
+    requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
-
+ 
         if ( ( distributor.numImport( n ) > 0 ) &&
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
-
-            requests.push_back( MPI_Request() );
-
-            MPI_Irecv( recv_subview.data(),
-                       recv_subview.size() *
-                           sizeof( typename AoSoA_t::tuple_type ),
-                       MPI_BYTE, distributor.neighborRank( n ), mpi_tag,
-                       distributor.comm(), &( requests.back() ) );
+ 
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
         }
-
+ 
         recv_range.first = recv_range.second;
     }
-
-    // Do blocking sends.
+ 
+    // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
@@ -139,20 +134,17 @@ void migrateData(
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             send_range.second = send_range.first + distributor.numExport( n );
-
+ 
             auto send_subview = Kokkos::subview( send_buffer, send_range );
-
-            MPI_Send( send_subview.data(),
-                      send_subview.size() *
-                          sizeof( typename AoSoA_t::tuple_type ),
-                      MPI_BYTE, distributor.neighborRank( n ), mpi_tag,
-                      distributor.comm() );
-
+ 
+            cabanaIsend( send_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+ 
             send_range.first = send_range.second;
         }
     }
 
-    // Wait on non-blocking receives.
+    // Wait on all non-blocking communication.
     std::vector<MPI_Status> status( requests.size() );
     const int ec =
         MPI_Waitall( requests.size(), requests.data(), status.data() );
@@ -278,31 +270,25 @@ void migrateSlice(
 
     // Post non-blocking receives.
     std::vector<MPI_Request> requests;
-    requests.reserve( num_n );
+    requests.reserve( num_n * 2 );
     std::pair<std::size_t, std::size_t> recv_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
-
+ 
         if ( ( distributor.numImport( n ) > 0 ) &&
              ( distributor.neighborRank( n ) != my_rank ) )
         {
-            auto recv_subview =
-                Kokkos::subview( recv_buffer, recv_range, Kokkos::ALL );
-
-            requests.push_back( MPI_Request() );
-
-            MPI_Irecv( recv_subview.data(),
-                       recv_subview.size() *
-                           sizeof( typename Slice_t::value_type ),
-                       MPI_BYTE, distributor.neighborRank( n ), mpi_tag,
-                       distributor.comm(), &( requests.back() ) );
+            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
+ 
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
         }
-
+ 
         recv_range.first = recv_range.second;
     }
-
-    // Do blocking sends.
+ 
+    // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
     {
@@ -310,21 +296,17 @@ void migrateSlice(
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             send_range.second = send_range.first + distributor.numExport( n );
-
-            auto send_subview =
-                Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
-
-            MPI_Send( send_subview.data(),
-                      send_subview.size() *
-                          sizeof( typename Slice_t::value_type ),
-                      MPI_BYTE, distributor.neighborRank( n ), mpi_tag,
-                      distributor.comm() );
-
+ 
+            auto send_subview = Kokkos::subview( send_buffer, send_range );
+ 
+            cabanaIsend( send_subview, distributor.neighborRank( n ),
+                               mpi_tag, distributor.comm(), requests );
+ 
             send_range.first = send_range.second;
         }
     }
 
-    // Wait on non-blocking receives.
+    // Wait on all non-blocking communication.
     std::vector<MPI_Status> status( requests.size() );
     const int ec =
         MPI_Waitall( requests.size(), requests.data(), status.data() );

--- a/core/src/impl/Cabana_Migrate_Mpi.hpp
+++ b/core/src/impl/Cabana_Migrate_Mpi.hpp
@@ -113,19 +113,19 @@ void migrateData(
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
- 
+
         if ( ( distributor.numImport( n ) > 0 ) &&
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
- 
-            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
+
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ), mpi_tag,
+                         distributor.comm(), requests );
         }
- 
+
         recv_range.first = recv_range.second;
     }
- 
+
     // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
@@ -134,12 +134,12 @@ void migrateData(
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             send_range.second = send_range.first + distributor.numExport( n );
- 
+
             auto send_subview = Kokkos::subview( send_buffer, send_range );
- 
-            cabanaIsend( send_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
- 
+
+            cabanaIsend( send_subview, distributor.neighborRank( n ), mpi_tag,
+                         distributor.comm(), requests );
+
             send_range.first = send_range.second;
         }
     }
@@ -275,19 +275,20 @@ void migrateSlice(
     for ( int n = 0; n < num_n; ++n )
     {
         recv_range.second = recv_range.first + distributor.numImport( n );
- 
+
         if ( ( distributor.numImport( n ) > 0 ) &&
              ( distributor.neighborRank( n ) != my_rank ) )
         {
-            auto recv_subview = Kokkos::subview( recv_buffer, recv_range );
- 
-            cabanaIrecv( recv_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
+            auto recv_subview =
+                Kokkos::subview( recv_buffer, recv_range, Kokkos::ALL );
+
+            cabanaIrecv( recv_subview, distributor.neighborRank( n ), mpi_tag,
+                         distributor.comm(), requests );
         }
- 
+
         recv_range.first = recv_range.second;
     }
- 
+
     // Post non-blocking sends.
     std::pair<std::size_t, std::size_t> send_range = { 0, 0 };
     for ( int n = 0; n < num_n; ++n )
@@ -296,12 +297,13 @@ void migrateSlice(
              ( distributor.neighborRank( n ) != my_rank ) )
         {
             send_range.second = send_range.first + distributor.numExport( n );
- 
-            auto send_subview = Kokkos::subview( send_buffer, send_range );
- 
-            cabanaIsend( send_subview, distributor.neighborRank( n ),
-                               mpi_tag, distributor.comm(), requests );
- 
+
+            auto send_subview =
+                Kokkos::subview( send_buffer, send_range, Kokkos::ALL );
+
+            cabanaIsend( send_subview, distributor.neighborRank( n ), mpi_tag,
+                         distributor.comm(), requests );
+
             send_range.first = send_range.second;
         }
     }


### PR DESCRIPTION
Added Cabana wrappers for `MPI_Isend` and `MPI_Irecv` that support message sizes larger than INT_MAX. If `MPI_VERSION >= 4.0` use `MPI_Isend_c` and `MPI_Irecv_c` versions, otherwise truncate messages to INT_MAX.

I am open to moving these functions to a different file, renaming them, or placing them in a new namespace.