### PR TITLE
Slice rewrite for compatibility with Kokkos mdspan Views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # find kokkos
 find_package(Kokkos 4.1 REQUIRED)
 
-# FIXME: remove when custom layout support with mdspan Views is added.
-if(Kokkos_VERSION VERSION_GREATER_EQUAL 4.6.99 AND NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY)
-  message(FATAL_ERROR "Current Kokkos does not support custom View layouts needed for AoSoA unless "
-          "Kokkos is built with Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON.")
-endif()
-
 # set supported kokkos devices
 set(CABANA_SUPPORTED_DEVICES SERIAL THREADS OPENMP CUDA HIP SYCL OPENMPTARGET)
 

--- a/benchmark/core/CMakeLists.txt
+++ b/benchmark/core/CMakeLists.txt
@@ -9,6 +9,9 @@
 # SPDX-License-Identifier: BSD-3-Clause                                    #
 ############################################################################
 
+add_executable(AoSoAPerformance Cabana_AoSoAPerformance.cpp)
+target_link_libraries(AoSoAPerformance Cabana::Core)
+
 add_executable(BinSortPerformance Cabana_BinSortPerformance.cpp)
 target_link_libraries(BinSortPerformance Cabana::Core)
 
@@ -29,6 +32,8 @@ target_link_libraries(CommPerformance Cabana::Core)
 endif()
 
 if(Cabana_ENABLE_TESTING)
+  add_test(NAME Cabana_Core_Performance_AoSoA COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:AoSoAPerformance> aosoa_output.txt)
+
   add_test(NAME Cabana_Core_Performance_BinSort COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:BinSortPerformance> sort_output.txt)
 
   add_test(NAME Cabana_Core_Performance_NeighborVerlet COMMAND ${NONMPI_PRECOMMAND} $<TARGET_FILE:NeighborVerletPerformance> verlet_output.txt)

--- a/benchmark/core/Cabana_AoSoAPerformance.cpp
+++ b/benchmark/core/Cabana_AoSoAPerformance.cpp
@@ -1,0 +1,342 @@
+/****************************************************************************
+ * Copyright (c) 2018-2023 by the Cabana authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cabana library. Cabana is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include "../Cabana_BenchmarkUtils.hpp"
+
+#include <Cabana_Core.hpp>
+#include <Kokkos_Core.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+//---------------------------------------------------------------------------//
+// Mixed-member AoSoA benchmark.
+template <class Device>
+void performanceTestMixed( std::ostream& stream, const std::string& test_prefix,
+                           const std::vector<int>& problem_sizes )
+{
+    using exec_space = typename Device::execution_space;
+    using memory_space = typename Device::memory_space;
+
+    constexpr int num_run = 20;
+
+    using member_types =
+        Cabana::MemberTypes<double[3][3], double[3], double, int>;
+    using aosoa_type = Cabana::AoSoA<member_types, memory_space>;
+
+    int num_problem_size = problem_sizes.size();
+    std::vector<aosoa_type> aosoas( num_problem_size );
+    std::vector<int> psizes;
+
+    // Create and initialize.
+    for ( int p = 0; p < num_problem_size; ++p )
+    {
+        int num_p = problem_sizes[p];
+        psizes.push_back( num_p );
+        aosoas[p].resize( num_p );
+
+        auto m33 = Cabana::slice<0>( aosoas[p], "mat33" );
+        auto v3 = Cabana::slice<1>( aosoas[p], "vec3" );
+        auto s0 = Cabana::slice<2>( aosoas[p], "scalar" );
+        auto i0 = Cabana::slice<3>( aosoas[p], "int_scalar" );
+
+        Kokkos::parallel_for(
+            "init_mixed", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+            KOKKOS_LAMBDA( const int i ) {
+                for ( int d0 = 0; d0 < 3; ++d0 )
+                    for ( int d1 = 0; d1 < 3; ++d1 )
+                        m33( i, d0, d1 ) = 1.0 + d0 + d1;
+
+                for ( int d = 0; d < 3; ++d )
+                    v3( i, d ) = 2.0 + d;
+
+                s0( i ) = 3.0;
+                i0( i ) = 4;
+            } );
+        Kokkos::fence();
+    }
+
+    Cabana::Benchmark::Timer mixed_mat33_timer( test_prefix + "mixed_mat33",
+                                                num_problem_size );
+    Cabana::Benchmark::Timer mixed_vec3_timer( test_prefix + "mixed_vec3",
+                                               num_problem_size );
+    Cabana::Benchmark::Timer mixed_scalar_timer( test_prefix + "mixed_scalar",
+                                                 num_problem_size );
+    Cabana::Benchmark::Timer mixed_int_timer( test_prefix + "mixed_int",
+                                              num_problem_size );
+    Cabana::Benchmark::Timer mixed_all_timer( test_prefix + "mixed_all",
+                                              num_problem_size );
+
+    for ( int p = 0; p < num_problem_size; ++p )
+    {
+        int num_p = problem_sizes[p];
+
+        std::cout << "Running mixed AoSoA slice benchmark for " << num_p
+                  << " tuples on " << test_prefix << std::endl;
+
+        auto m33 = Cabana::slice<0>( aosoas[p], "mat33" );
+        auto v3 = Cabana::slice<1>( aosoas[p], "vec3" );
+        auto s0 = Cabana::slice<2>( aosoas[p], "scalar" );
+        auto i0 = Cabana::slice<3>( aosoas[p], "int_scalar" );
+
+        for ( int t = 0; t < num_run; ++t )
+        {
+            mixed_mat33_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_mixed_mat33",
+                Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) {
+                    for ( int d0 = 0; d0 < 3; ++d0 )
+                        for ( int d1 = 0; d1 < 3; ++d1 )
+                            m33( i, d0, d1 ) += 1.0;
+                } );
+            Kokkos::fence();
+            mixed_mat33_timer.stop( p );
+
+            mixed_vec3_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_mixed_vec3", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) {
+                    for ( int d = 0; d < 3; ++d )
+                        v3( i, d ) += 1.0;
+                } );
+            Kokkos::fence();
+            mixed_vec3_timer.stop( p );
+
+            mixed_scalar_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_mixed_scalar",
+                Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) { s0( i ) += 1.0; } );
+            Kokkos::fence();
+            mixed_scalar_timer.stop( p );
+
+            mixed_int_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_mixed_int", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) { i0( i ) += 1; } );
+            Kokkos::fence();
+            mixed_int_timer.stop( p );
+
+            mixed_all_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_mixed_all", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) {
+                    s0( i ) += 0.5;
+                    for ( int d = 0; d < 3; ++d )
+                        v3( i, d ) += s0( i );
+                    for ( int d0 = 0; d0 < 3; ++d0 )
+                        for ( int d1 = 0; d1 < 3; ++d1 )
+                            m33( i, d0, d1 ) += v3( i, d0 ) + d1;
+                    i0( i ) += static_cast<int>( m33( i, 0, 0 ) );
+                } );
+            Kokkos::fence();
+            mixed_all_timer.stop( p );
+        }
+    }
+
+    outputResults( stream, "problem_size", psizes, mixed_mat33_timer );
+    outputResults( stream, "problem_size", psizes, mixed_vec3_timer );
+    outputResults( stream, "problem_size", psizes, mixed_scalar_timer );
+    outputResults( stream, "problem_size", psizes, mixed_int_timer );
+    outputResults( stream, "problem_size", psizes, mixed_all_timer );
+}
+
+//---------------------------------------------------------------------------//
+// Single-component AoSoA benchmark.
+template <class Device>
+void performanceTestSingle( std::ostream& stream,
+                            const std::string& test_prefix,
+                            const std::vector<int>& problem_sizes )
+{
+    using exec_space = typename Device::execution_space;
+    using memory_space = typename Device::memory_space;
+
+    constexpr int num_run = 20;
+
+    using mat_member_types = Cabana::MemberTypes<double[3][3]>;
+    using vec_member_types = Cabana::MemberTypes<double[3]>;
+    using scalar_member_types = Cabana::MemberTypes<double>;
+    using int_member_types = Cabana::MemberTypes<int>;
+
+    using mat_aosoa_type = Cabana::AoSoA<mat_member_types, memory_space>;
+    using vec_aosoa_type = Cabana::AoSoA<vec_member_types, memory_space>;
+    using scalar_aosoa_type = Cabana::AoSoA<scalar_member_types, memory_space>;
+    using int_aosoa_type = Cabana::AoSoA<int_member_types, memory_space>;
+
+    int num_problem_size = problem_sizes.size();
+
+    std::vector<mat_aosoa_type> mat_aosoas( num_problem_size );
+    std::vector<vec_aosoa_type> vec_aosoas( num_problem_size );
+    std::vector<scalar_aosoa_type> scalar_aosoas( num_problem_size );
+    std::vector<int_aosoa_type> int_aosoas( num_problem_size );
+
+    std::vector<int> psizes;
+
+    // Create and initialize.
+    for ( int p = 0; p < num_problem_size; ++p )
+    {
+        int num_p = problem_sizes[p];
+        psizes.push_back( num_p );
+
+        mat_aosoas[p].resize( num_p );
+        vec_aosoas[p].resize( num_p );
+        scalar_aosoas[p].resize( num_p );
+        int_aosoas[p].resize( num_p );
+
+        auto m33 = Cabana::slice<0>( mat_aosoas[p], "mat33" );
+        auto v3 = Cabana::slice<0>( vec_aosoas[p], "vec3" );
+        auto s0 = Cabana::slice<0>( scalar_aosoas[p], "scalar" );
+        auto i0 = Cabana::slice<0>( int_aosoas[p], "int_scalar" );
+
+        Kokkos::parallel_for(
+            "init_single", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+            KOKKOS_LAMBDA( const int i ) {
+                for ( int d0 = 0; d0 < 3; ++d0 )
+                    for ( int d1 = 0; d1 < 3; ++d1 )
+                        m33( i, d0, d1 ) = 1.0 + d0 + d1;
+
+                for ( int d = 0; d < 3; ++d )
+                    v3( i, d ) = 2.0 + d;
+
+                s0( i ) = 3.0;
+                i0( i ) = 4;
+            } );
+        Kokkos::fence();
+    }
+
+    Cabana::Benchmark::Timer single_mat33_timer( test_prefix + "single_mat33",
+                                                 num_problem_size );
+    Cabana::Benchmark::Timer single_vec3_timer( test_prefix + "single_vec3",
+                                                num_problem_size );
+    Cabana::Benchmark::Timer single_scalar_timer( test_prefix + "single_scalar",
+                                                  num_problem_size );
+    Cabana::Benchmark::Timer single_int_timer( test_prefix + "single_int",
+                                               num_problem_size );
+
+    for ( int p = 0; p < num_problem_size; ++p )
+    {
+        int num_p = problem_sizes[p];
+
+        std::cout << "Running single-component AoSoA benchmark for " << num_p
+                  << " tuples on " << test_prefix << std::endl;
+
+        auto m33 = Cabana::slice<0>( mat_aosoas[p], "mat33" );
+        auto v3 = Cabana::slice<0>( vec_aosoas[p], "vec3" );
+        auto s0 = Cabana::slice<0>( scalar_aosoas[p], "scalar" );
+        auto i0 = Cabana::slice<0>( int_aosoas[p], "int_scalar" );
+
+        for ( int t = 0; t < num_run; ++t )
+        {
+            single_mat33_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_single_mat33",
+                Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) {
+                    for ( int d0 = 0; d0 < 3; ++d0 )
+                        for ( int d1 = 0; d1 < 3; ++d1 )
+                            m33( i, d0, d1 ) += 1.0;
+                } );
+            Kokkos::fence();
+            single_mat33_timer.stop( p );
+
+            single_vec3_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_single_vec3",
+                Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) {
+                    for ( int d = 0; d < 3; ++d )
+                        v3( i, d ) += 1.0;
+                } );
+            Kokkos::fence();
+            single_vec3_timer.stop( p );
+
+            single_scalar_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_single_scalar",
+                Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) { s0( i ) += 1.0; } );
+            Kokkos::fence();
+            single_scalar_timer.stop( p );
+
+            single_int_timer.start( p );
+            Kokkos::parallel_for(
+                "bench_single_int", Kokkos::RangePolicy<exec_space>( 0, num_p ),
+                KOKKOS_LAMBDA( const int i ) { i0( i ) += 1; } );
+            Kokkos::fence();
+            single_int_timer.stop( p );
+        }
+    }
+
+    outputResults( stream, "problem_size", psizes, single_mat33_timer );
+    outputResults( stream, "problem_size", psizes, single_vec3_timer );
+    outputResults( stream, "problem_size", psizes, single_scalar_timer );
+    outputResults( stream, "problem_size", psizes, single_int_timer );
+}
+
+//---------------------------------------------------------------------------//
+// main
+int main( int argc, char* argv[] )
+{
+    Kokkos::initialize( argc, argv );
+    {
+        if ( argc < 2 )
+            throw std::runtime_error(
+                "Incorrect number of arguments.\n"
+                "First argument - file name for output\n"
+                "Optional second argument - run size (small or large)\n"
+                "\n"
+                "Example:\n"
+                "./SlicePerformance test_results.txt\n" );
+
+        std::string filename = argv[1];
+
+        std::string run_type = "";
+        if ( argc > 2 )
+            run_type = argv[2];
+
+        std::vector<int> problem_sizes = { 1000, 10000, 100000, 1000000 };
+        std::vector<int> host_problem_sizes = problem_sizes;
+
+        if ( run_type == "large" )
+        {
+            problem_sizes = { 10000, 100000, 1000000, 5000000, 10000000 };
+            host_problem_sizes = { 10000, 100000, 1000000 };
+        }
+
+        std::fstream file;
+        file.open( filename, std::fstream::out );
+
+        using host_exec_space = Kokkos::DefaultHostExecutionSpace;
+        using host_device_type = host_exec_space::device_type;
+        using exec_space = Kokkos::DefaultExecutionSpace;
+        using device_type = exec_space::device_type;
+
+        if ( !std::is_same<device_type, host_device_type>{} )
+        {
+            performanceTestMixed<device_type>( file, "device_", problem_sizes );
+            performanceTestSingle<device_type>( file, "device_",
+                                                problem_sizes );
+        }
+
+        performanceTestMixed<host_device_type>( file, "host_",
+                                                host_problem_sizes );
+        performanceTestSingle<host_device_type>( file, "host_",
+                                                 host_problem_sizes );
+
+        file.close();
+    }
+    Kokkos::finalize();
+    return 0;
+}

--- a/core/src/Cabana_DeepCopy.hpp
+++ b/core/src/Cabana_DeepCopy.hpp
@@ -300,20 +300,6 @@ deep_copy( DstSlice& dst, const SrcSlice& src,
                    "Cabana::deep_copy: Attempted to deep copy Slice objects of "
                    "different value types" );
 
-    // Check that the element dimensions are the same.
-    static_assert( SrcSlice::view_layout::D0 == SrcSlice::view_layout::D0,
-                   "Cabana::deep_copy: Slice dimension 0 is different" );
-    static_assert( SrcSlice::view_layout::D1 == SrcSlice::view_layout::D1,
-                   "Cabana::deep_copy: Slice dimension 1 is different" );
-    static_assert( SrcSlice::view_layout::D2 == SrcSlice::view_layout::D2,
-                   "Cabana::deep_copy: Slice dimension 2 is different" );
-    static_assert( SrcSlice::view_layout::D3 == SrcSlice::view_layout::D3,
-                   "Cabana::deep_copy: Slice dimension 3 is different" );
-    static_assert( SrcSlice::view_layout::D4 == SrcSlice::view_layout::D4,
-                   "Cabana::deep_copy: Slice dimension 4 is different" );
-    static_assert( SrcSlice::view_layout::D5 == SrcSlice::view_layout::D5,
-                   "Cabana::deep_copy: Slice dimension 5 is different" );
-
     // Check for the same number of elements.
     if ( dst.size() != src.size() )
     {

--- a/core/src/Cabana_Slice.hpp
+++ b/core/src/Cabana_Slice.hpp
@@ -23,354 +23,11 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <cassert>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <type_traits>
-
-//---------------------------------------------------------------------------//
-namespace Kokkos
-{
-//---------------------------------------------------------------------------//
-//! Cabana Slice layout.
-template <int SOASTRIDE, int VLEN, int DIM0 = 0, int DIM1 = 0, int DIM2 = 0,
-          int DIM3 = 0, int DIM4 = 0, int DIM5 = 0>
-struct LayoutCabanaSlice
-{
-    //! Slice array layout.
-    typedef LayoutCabanaSlice array_layout;
-    //! Slice is extent constructible.
-    enum
-    {
-        is_extent_constructible = true
-    };
-
-    //! Slice SoA stride.
-    static constexpr int Stride = SOASTRIDE;
-    //! Slice vectorlength.
-    static constexpr int VectorLength = VLEN;
-    //! Slice zeroth dimension size.
-    static constexpr int D0 = DIM0;
-    //! Slice first dimension size.
-    static constexpr int D1 = DIM1;
-    //! Slice second dimension size.
-    static constexpr int D2 = DIM2;
-    //! Slice third dimension size.
-    static constexpr int D3 = DIM3;
-    //! Slice fourth dimension size.
-    static constexpr int D4 = DIM4;
-    //! Slice fifth dimension size.
-    static constexpr int D5 = DIM5;
-
-    //! Slice dimension.
-    size_t dimension[ARRAY_LAYOUT_MAX_RANK];
-
-    //! Const copy constructor.
-    LayoutCabanaSlice( LayoutCabanaSlice const& ) = default;
-    //! Copy constructor.
-    LayoutCabanaSlice( LayoutCabanaSlice&& ) = default;
-    //! Const assignment operator.
-    LayoutCabanaSlice& operator=( LayoutCabanaSlice const& ) = default;
-    //! Assignment operator.
-    LayoutCabanaSlice& operator=( LayoutCabanaSlice&& ) = default;
-
-    //! Constructor.
-    KOKKOS_INLINE_FUNCTION
-    explicit constexpr LayoutCabanaSlice( size_t num_soa = 0,
-                                          size_t vector_length = VectorLength,
-                                          size_t d0 = D0, size_t d1 = D1,
-                                          size_t d2 = D2, size_t d3 = D3,
-                                          size_t d4 = D4, size_t d5 = D5 )
-        : dimension{ num_soa, vector_length, d0, d1, d2, d3, d4, d5 }
-    {
-    }
-};
-
-//---------------------------------------------------------------------------//
-namespace Impl
-{
-//! \cond Impl
-
-//---------------------------------------------------------------------------//
-// View offset of LayoutCabanaSlice.
-template <class Dimension, int... LayoutDims>
-struct ViewOffset<Dimension, Kokkos::LayoutCabanaSlice<LayoutDims...>, void>
-{
-  public:
-    using is_mapping_plugin = std::true_type;
-    using is_regular = std::true_type;
-
-    typedef size_t size_type;
-    typedef Dimension dimension_type;
-    typedef Kokkos::LayoutCabanaSlice<LayoutDims...> array_layout;
-
-    static constexpr int Stride = array_layout::Stride;
-    static constexpr int VectorLength = array_layout::VectorLength;
-    static constexpr int D0 = array_layout::D0;
-    static constexpr int D1 = array_layout::D1;
-    static constexpr int D2 = array_layout::D2;
-    static constexpr int D3 = array_layout::D3;
-    static constexpr int D4 = array_layout::D4;
-    static constexpr int D5 = array_layout::D5;
-
-    dimension_type m_dim;
-
-    //----------------------------------------
-
-    // rank 1
-    template <typename S>
-    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const& s ) const
-    {
-        return Stride * s;
-    }
-
-    // rank 2
-    template <typename S, typename A>
-    KOKKOS_INLINE_FUNCTION constexpr size_type operator()( S const& s,
-                                                           A const& a ) const
-    {
-        return Stride * s + a;
-    }
-
-    // rank 3
-    template <typename S, typename A, typename I0>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0 ) const
-    {
-        return Stride * s + a + VectorLength * i0;
-    }
-
-    // rank 4
-    template <typename S, typename A, typename I0, typename I1>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1 ) const
-    {
-        return Stride * s + a + VectorLength * ( i1 + D1 * i0 );
-    }
-
-    // rank 5
-    template <typename S, typename A, typename I0, typename I1, typename I2>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
-                I2 const& i2 ) const
-    {
-        return Stride * s + a + VectorLength * ( i2 + D2 * ( i1 + D1 * i0 ) );
-    }
-
-    // rank 6
-    template <typename S, typename A, typename I0, typename I1, typename I2,
-              typename I3>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
-                I2 const& i2, I3 const& i3 ) const
-    {
-        return Stride * s + a +
-               VectorLength * ( i3 + D3 * i2 + D2 * ( i1 + D1 * i0 ) );
-    }
-
-    // rank 7
-    template <typename S, typename A, typename I0, typename I1, typename I2,
-              typename I3, typename I4>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
-                I2 const& i2, I3 const& i3, I4 const& i4 ) const
-    {
-        return Stride * s + a +
-               VectorLength *
-                   ( i4 + D4 * ( i3 + D3 * i2 + D2 * ( i1 + D1 * i0 ) ) );
-    }
-
-    // rank 8
-    template <typename S, typename A, typename I0, typename I1, typename I2,
-              typename I3, typename I4, typename I5>
-    KOKKOS_INLINE_FUNCTION constexpr size_type
-    operator()( S const& s, A const& a, I0 const& i0, I1 const& i1,
-                I2 const& i2, I3 const& i3, I4 const& i4, I5 const& i5 ) const
-    {
-        return Stride * s + a +
-               VectorLength *
-                   ( i5 + D5 * ( i4 + D4 * ( i3 + D3 * i2 +
-                                             D2 * ( i1 + D1 * i0 ) ) ) );
-    }
-
-    //----------------------------------------
-
-    KOKKOS_INLINE_FUNCTION
-    constexpr array_layout layout() const { return array_layout( m_dim.N0 ); }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_0() const
-    {
-        return m_dim.N0;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_1() const
-    {
-        return m_dim.N1;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_2() const
-    {
-        return m_dim.N2;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_3() const
-    {
-        return m_dim.N3;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_4() const
-    {
-        return m_dim.N4;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_5() const
-    {
-        return m_dim.N5;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_6() const
-    {
-        return m_dim.N6;
-    }
-    KOKKOS_INLINE_FUNCTION constexpr size_type dimension_7() const
-    {
-        return m_dim.N7;
-    }
-
-    /* Cardinality of the domain index space */
-    KOKKOS_INLINE_FUNCTION
-    constexpr size_type size() const
-    {
-        return m_dim.N0 * m_dim.N1 * m_dim.N2 * m_dim.N3 * m_dim.N4 * m_dim.N5 *
-               m_dim.N6 * m_dim.N7;
-    }
-
-    /* Span of the range space, largest stride * dimension */
-    KOKKOS_INLINE_FUNCTION
-    constexpr size_type span() const { return m_dim.N0 * Stride; }
-
-    KOKKOS_INLINE_FUNCTION constexpr bool span_is_contiguous() const
-    {
-        return span() == size();
-    }
-
-    /* Strides of dimensions */
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_0() const
-    {
-        return Stride;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_1() const { return 1; }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_2() const
-    {
-        return m_dim.N7 * m_dim.N6 * m_dim.N5 * m_dim.N4 * m_dim.N3 *
-               VectorLength;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_3() const
-    {
-        return m_dim.N7 * m_dim.N6 * m_dim.N5 * m_dim.N4 * VectorLength;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_4() const
-    {
-        return m_dim.N7 * m_dim.N6 * m_dim.N5 * VectorLength;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_5() const
-    {
-        return m_dim.N7 * m_dim.N6 * VectorLength;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_6() const
-    {
-        return m_dim.N7 * VectorLength;
-    }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_type stride_7() const
-    {
-        return VectorLength;
-    }
-
-    // Stride with [ rank ] value is the total length
-    template <typename iType>
-    KOKKOS_INLINE_FUNCTION void stride( iType* const s ) const
-    {
-        if ( 0 < dimension_type::rank )
-        {
-            s[0] = stride_0();
-        }
-        if ( 1 < dimension_type::rank )
-        {
-            s[1] = stride_1();
-        }
-        if ( 2 < dimension_type::rank )
-        {
-            s[2] = stride_2();
-        }
-        if ( 3 < dimension_type::rank )
-        {
-            s[3] = stride_3();
-        }
-        if ( 4 < dimension_type::rank )
-        {
-            s[4] = stride_4();
-        }
-        if ( 5 < dimension_type::rank )
-        {
-            s[5] = stride_5();
-        }
-        if ( 6 < dimension_type::rank )
-        {
-            s[6] = stride_6();
-        }
-        if ( 7 < dimension_type::rank )
-        {
-            s[7] = stride_7();
-        }
-        s[dimension_type::rank] = span();
-    }
-
-    //----------------------------------------
-
-    ViewOffset() = default;
-    ViewOffset( const ViewOffset& ) = default;
-    ViewOffset& operator=( const ViewOffset& ) = default;
-
-    KOKKOS_INLINE_FUNCTION
-    constexpr ViewOffset( std::integral_constant<unsigned, 0> const&,
-                          Kokkos::LayoutCabanaSlice<LayoutDims...> const& rhs )
-        : m_dim( rhs.dimension[0], rhs.dimension[1], rhs.dimension[2],
-                 rhs.dimension[3], rhs.dimension[4], rhs.dimension[5],
-                 rhs.dimension[6], rhs.dimension[7] )
-    {
-    }
-
-    template <class DimRHS, class LayoutRHS>
-    KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
-        const ViewOffset<DimRHS, LayoutRHS, void>& rhs )
-        : m_dim( rhs.m_dim.N0, rhs.m_dim.N1, rhs.m_dim.N2, rhs.m_dim.N3,
-                 rhs.m_dim.N4, rhs.m_dim.N5, rhs.m_dim.N6, rhs.m_dim.N7 )
-    {
-        static_assert( int( DimRHS::rank ) == int( dimension_type::rank ),
-                       "ViewOffset assignment requires equal rank" );
-    }
-
-    //----------------------------------------
-    // Subview construction
-
-    template <class DimRHS, class LayoutRHS>
-    KOKKOS_INLINE_FUNCTION constexpr ViewOffset(
-        const ViewOffset<DimRHS, LayoutRHS, void>&,
-        const SubviewExtents<DimRHS::rank, dimension_type::rank>& sub )
-        : m_dim( sub.range_extent( 0 ), sub.range_extent( 1 ),
-                 sub.range_extent( 2 ), sub.range_extent( 3 ),
-                 sub.range_extent( 4 ), sub.range_extent( 5 ),
-                 sub.range_extent( 6 ), sub.range_extent( 7 ) )
-    {
-    }
-};
-
-//---------------------------------------------------------------------------//
-
-//! \endcond
-} // namespace Impl
-
-} // end namespace Kokkos
 
 //---------------------------------------------------------------------------//
 namespace Cabana
@@ -393,11 +50,11 @@ struct KokkosDataTypeImpl<T, 0, VectorLength, Stride>
 {
     using value_type = typename std::remove_all_extents<T>::type;
     using data_type = value_type* [VectorLength];
-    using cabana_layout = Kokkos::LayoutCabanaSlice<Stride, VectorLength>;
+    using array_layout = Kokkos::LayoutStride;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
-        return cabana_layout( num_soa );
+        return array_layout( num_soa, Stride, VectorLength, 1 );
     }
 };
 
@@ -408,11 +65,12 @@ struct KokkosDataTypeImpl<T, 1, VectorLength, Stride>
     using value_type = typename std::remove_all_extents<T>::type;
     static constexpr std::size_t D0 = std::extent<T, 0>::value;
     using data_type = value_type* [VectorLength][D0];
-    using cabana_layout = Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0>;
+    using array_layout = Kokkos::LayoutStride;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
-        return cabana_layout( num_soa );
+        return array_layout( num_soa, Stride, VectorLength, 1, D0,
+                             VectorLength );
     }
 };
 
@@ -424,12 +82,12 @@ struct KokkosDataTypeImpl<T, 2, VectorLength, Stride>
     static constexpr std::size_t D0 = std::extent<T, 0>::value;
     static constexpr std::size_t D1 = std::extent<T, 1>::value;
     using data_type = value_type* [VectorLength][D0][D1];
-    using cabana_layout =
-        Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0, D1>;
+    using array_layout = Kokkos::LayoutStride;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
-        return cabana_layout( num_soa );
+        return array_layout( num_soa, Stride, VectorLength, 1, D0,
+                             VectorLength * D1, D1, VectorLength );
     }
 };
 
@@ -442,12 +100,13 @@ struct KokkosDataTypeImpl<T, 3, VectorLength, Stride>
     static constexpr std::size_t D1 = std::extent<T, 1>::value;
     static constexpr std::size_t D2 = std::extent<T, 2>::value;
     using data_type = value_type* [VectorLength][D0][D1][D2];
-    using cabana_layout =
-        Kokkos::LayoutCabanaSlice<Stride, VectorLength, D0, D1, D2>;
+    using array_layout = Kokkos::LayoutStride;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
-        return cabana_layout( num_soa );
+        return array_layout( num_soa, Stride, VectorLength, 1, D0,
+                             VectorLength * D1 * D2, D1, VectorLength * D2, D2,
+                             VectorLength );
     }
 };
 
@@ -458,9 +117,9 @@ struct KokkosDataType
     using kokkos_data_type =
         KokkosDataTypeImpl<T, std::rank<T>::value, VectorLength, Stride>;
     using data_type = typename kokkos_data_type::data_type;
-    using cabana_layout = typename kokkos_data_type::cabana_layout;
+    using array_layout = typename kokkos_data_type::array_layout;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
         return kokkos_data_type::createLayout( num_soa );
     }
@@ -476,10 +135,10 @@ struct KokkosViewWrapper
     using data_type =
         typename KokkosDataType<T, VectorLength, Stride>::data_type;
 
-    using cabana_layout =
-        typename KokkosDataType<T, VectorLength, Stride>::cabana_layout;
+    using array_layout =
+        typename KokkosDataType<T, VectorLength, Stride>::array_layout;
 
-    inline static cabana_layout createLayout( const std::size_t num_soa )
+    inline static array_layout createLayout( const std::size_t num_soa )
     {
         return KokkosDataType<T, VectorLength, Stride>::createLayout( num_soa );
     }
@@ -527,9 +186,6 @@ class Slice
     //! SoA stride.
     static constexpr int soa_stride = Stride;
 
-    //! Memory space size type.
-    using size_type = typename memory_space::size_type;
-
     //! Index type.
     using index_type = Impl::Index<vector_length>;
 
@@ -546,8 +202,11 @@ class Slice
     //! Kokkos view type.
     using kokkos_view =
         Kokkos::View<typename view_wrapper::data_type,
-                     typename view_wrapper::cabana_layout, MemorySpace,
+                     typename view_wrapper::array_layout, MemorySpace,
                      typename MemoryAccessType::kokkos_memory_traits>;
+
+    //! Size type.
+    using size_type = typename kokkos_view::size_type;
 
     //! View reference type alias.
     using reference_type = typename kokkos_view::reference_type;
@@ -557,6 +216,11 @@ class Slice
     using pointer_type = typename kokkos_view::pointer_type;
     //! View array layout type alias.
     using view_layout = typename kokkos_view::array_layout;
+
+    //! Rank of the data without struct/array indexing.
+    static constexpr std::size_t data_rank = std::rank<DataType>::value;
+    //! Actual rank of the data, including struct/array indexing.
+    static constexpr std::size_t view_rank = data_rank + 2;
 
     //! Default memory access slice type.
     using default_access_slice =
@@ -583,7 +247,7 @@ class Slice
     // compatibility with Kokkos views.
     enum
     {
-        rank = std::rank<DataType>::value + 1
+        rank = data_rank + 1
     };
 
   public:
@@ -877,8 +541,7 @@ template <class ExecutionSpace, class ViewType, class SliceType>
 void copySliceToView(
     ExecutionSpace exec_space, ViewType& view, const SliceType& slice,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        2 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 2 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copySliceToView::Rank0",
@@ -891,8 +554,7 @@ template <class ExecutionSpace, class ViewType, class SliceType>
 void copySliceToView(
     ExecutionSpace exec_space, ViewType& view, const SliceType& slice,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        3 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 3 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copySliceToView::Rank1",
@@ -908,8 +570,7 @@ template <class ExecutionSpace, class ViewType, class SliceType>
 void copySliceToView(
     ExecutionSpace exec_space, ViewType& view, const SliceType& slice,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        4 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 4 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copySliceToView::Rank2",
@@ -939,8 +600,7 @@ template <class ExecutionSpace, class SliceType, class ViewType>
 void copyViewToSlice(
     ExecutionSpace exec_space, SliceType& slice, const ViewType& view,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        2 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 2 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copyViewToSlice::Rank0",
@@ -953,8 +613,7 @@ template <class ExecutionSpace, class SliceType, class ViewType>
 void copyViewToSlice(
     ExecutionSpace exec_space, SliceType& slice, const ViewType& view,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        3 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 3 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copyViewToSlice::Rank1",
@@ -970,8 +629,7 @@ template <class ExecutionSpace, class SliceType, class ViewType>
 void copyViewToSlice(
     ExecutionSpace exec_space, SliceType& slice, const ViewType& view,
     const std::size_t begin, const std::size_t end,
-    typename std::enable_if<
-        4 == SliceType::kokkos_view::traits::dimension::rank, int*>::type = 0 )
+    typename std::enable_if<( SliceType::view_rank == 4 ), int*>::type = 0 )
 {
     Kokkos::parallel_for(
         "Cabana::copyViewToSlice::Rank2",


### PR DESCRIPTION
This removes the incompatibility with Kokkos mdspan-based Views by removing custom `LayoutCabanaSlice` and directly using the `Kokkos::LayoutStride`. The intent is to later replace this with a fully customized Kokkos layout 

Performance details will be posted prior to merging, but initial testing shows performance degradation on the order of 10%  as compared to the previous implementation (with some cases showing small speedup) depending on AoSoA member data types